### PR TITLE
refactor: centralize ward shift query key and reuse entity queryOptions

### DIFF
--- a/src/entities/ward/model/queries.ts
+++ b/src/entities/ward/model/queries.ts
@@ -33,6 +33,7 @@ export const wardQueryKeys = {
         year,
         month,
     ],
+    shift: () => [...wardQueryKeys.all(), 'shift'],
     // ShiftTeam
     shiftTeams: (wardId: number) => [...wardQueryKeys.all(), 'shiftTeams', wardId],
     shiftTeamNurses: (wardId: number, shiftTeamId: number) => [...wardQueryKeys.all(), 'shiftTeamNurses', wardId, shiftTeamId],

--- a/src/features/auth/useRegister/index.ts
+++ b/src/features/auth/useRegister/index.ts
@@ -1,5 +1,6 @@
 import {useMutation, useQuery} from '@tanstack/react-query';
 import {useNavigate} from 'react-router';
+import {accountQueryOptions} from '@/entities/account/model/queries';
 import useLoading from '@/features/ui/useLoading';
 import useTutorial from '@/features/ui/useTutorial';
 import {AccountAPI, NurseAPI, WardAPI} from '@/shared/api';
@@ -69,8 +70,7 @@ const useRegister = () => {
         },
     });
     const {data: accountWaitingWard} = useQuery({
-        queryKey: ['accountWaitingWard'],
-        queryFn: () => AccountAPI.getAccountMeWaiting(),
+        ...accountQueryOptions.waiting(),
         enabled: accountMe?.status === 'WARD_ENTRY_PENDING',
     });
     const registerAccountAndNurse = async (

--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -3,6 +3,7 @@ import {produce} from 'immer';
 import {useCallback, useEffect} from 'react';
 import {match} from 'ts-pattern';
 import {events, sendEvent} from '@/analytics';
+import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import {WardAPI} from '@/shared/api';
 import {moveSelection} from '@/shared/editor/editor-core/selection';
@@ -21,12 +22,16 @@ const useRequestShift = (activeEffect = false) => {
         state: {wardId},
     } = useAuth();
     const queryClient = useQueryClient();
-    const requestShiftQueryKey = ['requestShift', wardId, year, month, currentShiftTeamId];
-    const shiftTeamQueryKey = ['shiftTeams', wardId];
-    const wardConstraintQueryKey = ['wardConstraint', currentShiftTeamId, wardId];
-    const dutyRequestQueryKey = ['dutyRequest', wardId, year, month, currentShiftTeamId];
+    const shiftTeamsQueryOptions = wardQueryOptions.shiftTeams(wardId ?? 0);
+    const requestListQueryOptions = wardQueryOptions.requestList(wardId ?? 0, currentShiftTeamId ?? 0, year, month);
+    const requestShiftQueryOptions = wardQueryOptions.request(wardId ?? 0, currentShiftTeamId ?? 0, year, month);
+    const wardConstraintQueryOptions = wardQueryOptions.constraint(wardId ?? 0, currentShiftTeamId ?? 0);
+    const requestShiftQueryKey = requestShiftQueryOptions.queryKey;
+    const shiftTeamQueryKey = shiftTeamsQueryOptions.queryKey;
+    const wardConstraintQueryKey = wardConstraintQueryOptions.queryKey;
+    const dutyRequestQueryKey = requestListQueryOptions.queryKey;
     const {data: shiftTeams} = useQuery({
-        queryKey: shiftTeamQueryKey,
+        ...shiftTeamsQueryOptions,
         queryFn: async () => {
             const res = await WardAPI.getShiftTeams(wardId!);
 
@@ -43,12 +48,11 @@ const useRequestShift = (activeEffect = false) => {
         enabled: !!wardId,
     });
     const {data: dutyRequestList} = useQuery({
-        queryKey: dutyRequestQueryKey,
-        queryFn: () => WardAPI.getRequestList(wardId!, currentShiftTeamId!, year, month),
+        ...requestListQueryOptions,
         enabled: wardId !== null && currentShiftTeamId !== null,
     });
     const {data: requestShift, status: shiftStatus} = useQuery({
-        queryKey: requestShiftQueryKey,
+        ...requestShiftQueryOptions,
         queryFn: async () => {
             const res = await WardAPI.getReqShift(wardId!, currentShiftTeamId!, year, month);
 
@@ -70,7 +74,7 @@ const useRequestShift = (activeEffect = false) => {
         mutationFn: ({wardId, focus, shiftTypeId}: {wardId: number; focus: Focus; shiftTypeId: number | null}) =>
             WardAPI.updateReqShift(wardId, year, month, focus.day + 1, focus.shiftNurseId, shiftTypeId),
         onMutate: async ({focus, shiftTypeId}) => {
-            await queryClient.cancelQueries({queryKey: ['requestShift']});
+            await queryClient.cancelQueries({queryKey: requestShiftQueryKey});
 
             const {shiftNurseId, day} = focus;
             const oldShift = queryClient.getQueryData<RequestShift>(requestShiftQueryKey);

--- a/src/features/ward/useEditShiftTeam/index.ts
+++ b/src/features/ward/useEditShiftTeam/index.ts
@@ -1,6 +1,7 @@
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {produce} from 'immer';
 import {useCallback} from 'react';
+import {wardQueryKeys, wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import useRequestShift from '@/features/shift/useRequestShift';
 import {NurseAPI, WardAPI} from '@/shared/api';
@@ -16,21 +17,21 @@ const useEditShiftTeam = () => {
         state: {wardId},
     } = useAuth();
     const queryClient = useQueryClient();
-    const getWardQueryKey = ['ward', wardId];
-    const shiftQueryKey = ['shift'];
+    const wardQueryKey = wardQueryKeys.id(wardId ?? 0);
+    const wardQueryOptionsValue = wardQueryOptions.id(wardId ?? 0);
+    const shiftQueryKey = wardQueryKeys.shift();
     const {
         queryKey: {requestShiftQueryKey},
     } = useRequestShift();
     const {data: ward} = useQuery({
-        queryKey: getWardQueryKey,
-        queryFn: () => WardAPI.getWard(wardId!),
+        ...wardQueryOptionsValue,
         enabled: !!wardId,
     });
     const {mutate: updateNurseMutate} = useMutation({
         mutationFn: ({nurseId, updateNurseDTO}: {nurseId: number; updateNurseDTO: UpdateNurseDTO}) =>
             NurseAPI.updateNurse(nurseId, updateNurseDTO),
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
             queryClient.invalidateQueries({queryKey: shiftQueryKey});
             queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
         },
@@ -50,7 +51,7 @@ const useEditShiftTeam = () => {
                 isWardManager: false,
                 memo: '',
             }),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: getWardQueryKey}),
+        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
         onError: () => {
             alert('간호사 추가에 실패했습니다.');
         },
@@ -58,7 +59,7 @@ const useEditShiftTeam = () => {
     const {mutate: deleteNurseMutate} = useMutation({
         mutationFn: ({wardId, nurseId, shiftTeamId}: {wardId: number; nurseId: number; shiftTeamId: number}) =>
             WardAPI.removeNurseFromShiftTeam(wardId, shiftTeamId, nurseId),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: getWardQueryKey}),
+        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
     });
     const {mutate: updateNurseShiftTypeMutate} = useMutation({
         mutationFn: ({
@@ -70,15 +71,15 @@ const useEditShiftTeam = () => {
             nurseShiftTypeId: number;
             change: UpdateNurseShiftTypeRequest;
         }) => NurseAPI.updateNurseShiftType(nurseId, nurseShiftTypeId, change),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: getWardQueryKey}),
+        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
     });
     const {mutate: createShiftTeamMutate} = useMutation({
         mutationFn: (wardId: number) => WardAPI.createShiftTeam(wardId),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: getWardQueryKey}),
+        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
     });
     const {mutate: deleteShiftTeamMutate} = useMutation({
         mutationFn: ({wardId, shiftTeamId}: {wardId: number; shiftTeamId: number}) => WardAPI.deleteShiftTeam(wardId, shiftTeamId),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: getWardQueryKey}),
+        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
     });
     const {mutate: editDivisionMutate} = useMutation({
         mutationFn: ({
@@ -93,7 +94,7 @@ const useEditShiftTeam = () => {
             patchYearMonth: string;
         }) => NurseAPI.updateShiftTeamDivision(shiftTeamId, prevPriority, changeValue, patchYearMonth),
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
             queryClient.invalidateQueries({queryKey: shiftQueryKey});
             queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
         },
@@ -117,17 +118,17 @@ const useEditShiftTeam = () => {
             patchYearMonth: string;
         }) => NurseAPI.updateNurseOrder(nurseId, shiftTeamId, nextShiftTeamId, divisionNum, prevPriority, nextPriority, patchYearMonth),
         onMutate: async ({nurseId, shiftTeamId, nextShiftTeamId, prevPriority, nextPriority, divisionNum}) => {
-            await queryClient.cancelQueries({queryKey: getWardQueryKey});
+            await queryClient.cancelQueries({queryKey: wardQueryKey});
             await queryClient.cancelQueries({queryKey: shiftQueryKey});
             await queryClient.cancelQueries({queryKey: requestShiftQueryKey});
 
-            const oldWard = queryClient.getQueryData<Ward>(getWardQueryKey);
+            const oldWard = queryClient.getQueryData<Ward>(wardQueryKey);
             const oldShift = queryClient.getQueryData<Shift>(shiftQueryKey);
             const oldReqShift = queryClient.getQueryData<RequestShift>(requestShiftQueryKey);
 
             if (oldWard) {
                 queryClient.setQueryData<Ward>(
-                    getWardQueryKey,
+                    wardQueryKey,
                     produce(oldWard, (draft) => {
                         const sourceNurses = draft.shiftTeams.find((shiftTeam) => shiftTeam.shiftTeamId === shiftTeamId)!.nurses;
                         const nurse = sourceNurses.find((nurse) => nurse.nurseId === nurseId)!;
@@ -220,14 +221,14 @@ const useEditShiftTeam = () => {
             return {oldWard, oldShift, oldReqShift};
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
             queryClient.invalidateQueries({queryKey: shiftQueryKey});
             queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
         },
         onError: (_, __, context) => {
             if (context?.oldShift === undefined || context.oldReqShift === undefined || context.oldWard === undefined) return;
 
-            queryClient.setQueryData(getWardQueryKey, context.oldWard);
+            queryClient.setQueryData(wardQueryKey, context.oldWard);
             queryClient.setQueryData(shiftQueryKey, context.oldShift);
             queryClient.setQueryData(requestShiftQueryKey, context.oldReqShift);
         },
@@ -243,12 +244,12 @@ const useEditShiftTeam = () => {
             updateShiftTeamDTO: UpdateShiftTeamDTO;
         }) => WardAPI.updateShiftTeam(wardId, shiftTeamId, updateShiftTeamDTO),
         onMutate: ({shiftTeamId, updateShiftTeamDTO}) => {
-            const oldWard = queryClient.getQueryData<Ward>(getWardQueryKey);
+            const oldWard = queryClient.getQueryData<Ward>(wardQueryKey);
 
             if (!oldWard) return;
 
             queryClient.setQueryData<Ward>(
-                getWardQueryKey,
+                wardQueryKey,
                 produce(oldWard, (draft) => {
                     const shiftTeam = draft.shiftTeams.find((shiftTeam) => shiftTeam.shiftTeamId === shiftTeamId)!;
 
@@ -257,7 +258,7 @@ const useEditShiftTeam = () => {
             );
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
         },
     });
     const addNurse = useCallback(

--- a/src/features/ward/useEditWard/index.ts
+++ b/src/features/ward/useEditWard/index.ts
@@ -1,5 +1,6 @@
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {useCallback} from 'react';
+import {wardQueryKeys, wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import {WardAPI} from '@/shared/api';
 import {type CreateShiftTypeDTO} from '@/shared/api/ward/type';
@@ -9,24 +10,24 @@ const useEditWard = () => {
     const {
         state: {wardId},
     } = useAuth();
-    const getWardQueryKey = ['ward', wardId];
-    const getWardWaitingNursesQueryKey = ['waitingNurses', wardId];
+    const wardQueryKey = wardQueryKeys.id(wardId ?? 0);
+    const wardWaitingNursesQueryKey = wardQueryKeys.waitingNurses(wardId ?? 0);
+    const wardQueryOptionsValue = wardQueryOptions.id(wardId ?? 0);
+    const wardWaitingNursesQueryOptions = wardQueryOptions.waitingNurses(wardId ?? 0);
     const queryClient = useQueryClient();
-    const shiftQueryKey = ['shift'];
+    const shiftQueryKey = wardQueryKeys.shift();
     const {data: ward} = useQuery({
-        queryKey: getWardQueryKey,
-        queryFn: () => WardAPI.getWard(wardId!),
+        ...wardQueryOptionsValue,
         enabled: !!wardId,
     });
     const {data: watingNurses} = useQuery({
-        queryKey: getWardWaitingNursesQueryKey,
-        queryFn: () => WardAPI.getWatingNurses(wardId!),
+        ...wardWaitingNursesQueryOptions,
         enabled: !!wardId,
     });
     const {mutate: updateWardMutate} = useMutation({
         mutationFn: ({wardId, editWardDTO}: {wardId: number; editWardDTO: EditWardDTO}) => WardAPI.editWard(wardId, editWardDTO),
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
         },
         onError: () => {
             alert('근무 설정 수정에 실패하였습니다.');
@@ -36,7 +37,7 @@ const useEditWard = () => {
         mutationFn: ({wardId, createShiftTypeDTO}: {wardId: number; createShiftTypeDTO: CreateShiftTypeDTO}) =>
             WardAPI.createShiftType(wardId, createShiftTypeDTO),
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
         },
     });
     const {mutate: updateShiftTypeMutate} = useMutation({
@@ -50,37 +51,37 @@ const useEditWard = () => {
             createShiftTypeDTO: CreateShiftTypeDTO;
         }) => WardAPI.updateShiftType(wardId, shiftTypeId, createShiftTypeDTO),
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
             queryClient.invalidateQueries({queryKey: shiftQueryKey});
         },
     });
     const {mutate: deleteShiftTypeMutate} = useMutation({
         mutationFn: ({wardId, shiftTypeId}: {wardId: number; shiftTypeId: number}) => WardAPI.deleteShiftType(wardId, shiftTypeId),
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
         },
     });
     const {mutate: approveWatingNursesMutate} = useMutation({
         mutationFn: ({wardId, waitingNurseId, shiftTeamId}: {wardId: number; waitingNurseId: number; shiftTeamId: number}) =>
             WardAPI.approveWatingNurses(wardId, waitingNurseId, shiftTeamId),
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
-            queryClient.invalidateQueries({queryKey: getWardWaitingNursesQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
         },
     });
     const {mutate: connectWatingNursesMutate} = useMutation({
         mutationFn: ({wardId, waitingNurseId, targetNurseId}: {wardId: number; waitingNurseId: number; targetNurseId: number}) =>
             WardAPI.connectWatingNurses(wardId, waitingNurseId, targetNurseId),
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
-            queryClient.invalidateQueries({queryKey: getWardWaitingNursesQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
         },
     });
     const {mutate: cancelWaitingMutate} = useMutation({
         mutationFn: ({wardId, nurseId}: {wardId: number; nurseId: number}) => WardAPI.deleteWatingNurses(wardId, nurseId),
         onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: getWardQueryKey});
-            queryClient.invalidateQueries({queryKey: getWardWaitingNursesQueryKey});
+            queryClient.invalidateQueries({queryKey: wardQueryKey});
+            queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
         },
     });
     const editWardSetting = useCallback(
@@ -142,8 +143,8 @@ const useEditWard = () => {
 
     return {
         queryKey: {
-            getWardQueryKey,
-            getWardWaitingNursesQueryKey,
+            getWardQueryKey: wardQueryKey,
+            getWardWaitingNursesQueryKey: wardWaitingNursesQueryKey,
         },
         state: {
             ward,


### PR DESCRIPTION
### Motivation
- Standardize react-query usage by centralizing ward-related query keys and reusing entity `queryOptions` to keep cache naming and invalidation consistent across features.
- Reduce duplicated inline query key/option definitions and ensure feature hooks use domain-level query contracts.

### Description
- Added a shared `shift` query key `wardQueryKeys.shift()` in `src/entities/ward/model/queries.ts` for ward shift cache operations.
- Replaced inline `['shift']` usage with `wardQueryKeys.shift()` and swapped manual ward query arrays for `wardQueryKeys.id(...)` / `wardQueryKeys.waitingNurses(...)` in `src/features/ward/useEditWard/index.ts` and `src/features/ward/useEditShiftTeam/index.ts`.
- Updated `src/features/shift/useRequestShift/index.ts` to use `wardQueryOptions.*` (`shiftTeams`, `requestList`, `request`, `constraint`) and derived `.queryKey` values for `cancelQueries`/`setQueryData`/`invalidateQueries` calls.
- Switched the account-waiting lookup in `src/features/auth/useRegister/index.ts` to use `accountQueryOptions.waiting()` and added the corresponding import.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968becd850083249252ca6a078bd1a1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 쿼리 키 관리 체계를 중앙화하여 일관성 있는 데이터 조회 구조로 개선했습니다.
  * 여러 기능 모듈에서 쿼리 옵션을 표준화된 방식으로 사용하도록 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->