### PR TITLE
Remove useMutation usage from feature hooks and implement direct model-hook API handlers

### DIFF
--- a/docs/architecture/fsd-migration-tasks.md
+++ b/docs/architecture/fsd-migration-tasks.md
@@ -3,15 +3,15 @@
 > 본 문서는 현재 상태를 기준으로 우선순위 작업을 정리한 체크리스트이다.
 
 ## 1. queryOptions 정비
-- [ ] 기존 쿼리 선언 위치 조사 및 목록화
-- [ ] `entities/*/queryOptions`로 이관
-- [ ] query key 네이밍 규칙 확정 및 문서화
-- [ ] 모든 `useQuery`가 queryOptions를 사용하도록 변경
+- [x] 기존 쿼리 선언 위치 조사 및 목록화
+- [x] `entities/*/queryOptions`로 이관
+- [x] query key 네이밍 규칙 확정 및 문서화
+- [x] 모든 `useQuery`가 queryOptions를 사용하도록 변경
 
 ## 2. model hook 정리 (useMutation 미사용 정책 반영)
-- [ ] API 호출을 각 model hook으로 집중
-- [ ] 호출 결과 반환 범위 최소화 (필요 시 콜백 패턴 적용)
-- [ ] side-effect를 useCase 내부에서 조합
+- [x] API 호출을 각 model hook으로 집중
+- [x] 호출 결과 반환 범위 최소화 (필요 시 콜백 패턴 적용)
+- [x] side-effect를 useCase 내부에서 조합
 
 ## 3. 상태관리 구조 확정 (store/useCase)
 - [ ] slice별 store 책임 범위 정의

--- a/src/features/auth/useRegister/index.ts
+++ b/src/features/auth/useRegister/index.ts
@@ -1,4 +1,5 @@
-import {useMutation, useQuery} from '@tanstack/react-query';
+import {useCallback} from 'react';
+import {useQuery} from '@tanstack/react-query';
 import {useNavigate} from 'react-router';
 import {accountQueryOptions} from '@/entities/account/model/queries';
 import useLoading from '@/features/ui/useLoading';
@@ -20,55 +21,63 @@ const useRegister = () => {
     } = useTutorial();
     const {setLoading} = useLoading();
     const navigate = useNavigate();
-    const {mutate: changeAccountStatusMutate} = useMutation({
-        mutationFn: ({accountId, status}: {accountId: number; status: Account['status']}) =>
-            AccountAPI.editAccountStatus(accountId, status),
-        onSuccess: ({status}) => {
+    const changeAccountStatus = useCallback(
+        async ({accountId, status}: {accountId: number; status: Account['status']}) => {
+            const updatedAccount = await AccountAPI.editAccountStatus(accountId, status);
+
             handleGetAccountMe();
 
-            if (status === 'LINKED') navigate(ROUTE.MAKE);
-        },
-    });
-    const {mutate: createWardMutate} = useMutation({
-        mutationFn: (createWardDTO: CreateWardDTO) => WardAPI.createWard(createWardDTO),
-        onMutate: () => {
-            setLoading(true);
-        },
-        onSettled: () => {
-            setLoading(false);
-        },
-        onSuccess: () => {
-            initTutorial();
-
-            if (accountMe) {
-                changeAccountStatusMutate({accountId: accountMe.accountId, status: 'LINKED'});
+            if (updatedAccount.status === 'LINKED') {
+                navigate(ROUTE.MAKE);
             }
         },
-    });
-    const {mutate: enterWardMutate} = useMutation({
-        mutationFn: (wardId: number) => WardAPI.addMeToWatingNurses(wardId),
-        onMutate: () => {
+        [handleGetAccountMe, navigate],
+    );
+    const createWard = useCallback(
+        async (createWardDTO: CreateWardDTO) => {
             setLoading(true);
+
+            try {
+                await WardAPI.createWard(createWardDTO);
+                initTutorial();
+
+                if (accountMe) {
+                    await changeAccountStatus({accountId: accountMe.accountId, status: 'LINKED'});
+                }
+            } finally {
+                setLoading(false);
+            }
         },
-        onSettled: () => {
-            setLoading(false);
+        [accountMe, changeAccountStatus, initTutorial, setLoading],
+    );
+    const enterWard = useCallback(
+        async (wardId: number) => {
+            setLoading(true);
+
+            try {
+                await WardAPI.addMeToWatingNurses(wardId);
+
+                if (!accountId) return;
+
+                await changeAccountStatus({accountId, status: 'WARD_ENTRY_PENDING'});
+                navigate(ROUTE.REGISTER);
+            } finally {
+                setLoading(false);
+            }
         },
-        onSuccess: () => {
+        [accountId, changeAccountStatus, navigate, setLoading],
+    );
+    const cancelWaiting = useCallback(
+        async (wardId: number, nurseId: number) => {
+            await WardAPI.deleteWatingNurses(wardId, nurseId);
+
             if (!accountId) return;
 
-            changeAccountStatusMutate({accountId, status: 'WARD_ENTRY_PENDING'});
+            await changeAccountStatus({accountId, status: 'WARD_SELECT_PENDING'});
             navigate(ROUTE.REGISTER);
         },
-    });
-    const {mutate: cancelWaitingMutate} = useMutation({
-        mutationFn: ({wardId, nurseId}: {wardId: number; nurseId: number}) => WardAPI.deleteWatingNurses(wardId, nurseId),
-        onSuccess: () => {
-            if (!accountId) return;
-
-            changeAccountStatusMutate({accountId, status: 'WARD_SELECT_PENDING'});
-            navigate(ROUTE.REGISTER);
-        },
-    });
+        [accountId, changeAccountStatus, navigate],
+    );
     const {data: accountWaitingWard} = useQuery({
         ...accountQueryOptions.waiting(),
         enabled: accountMe?.status === 'WARD_ENTRY_PENDING',
@@ -80,29 +89,32 @@ const useRegister = () => {
 
         setLoading(true);
 
-        if (accountMe.status === 'NURSE_INFO_PENDING') {
-            // 모바일에서 계정 초기 등록을 이미 마친 경우 계정 정보를 수정한다.
-            await AccountAPI.editAccount({
-                accountId,
-                name: createNurseDTO.name,
-                ...createNurseDTO.profileImg,
-            });
-        } else if (accountMe.status === 'INITIAL') {
-            await AccountAPI.initAccount({accountId, name: createNurseDTO.name, ...createNurseDTO.profileImg});
-        }
+        try {
+            if (accountMe.status === 'NURSE_INFO_PENDING') {
+                // 모바일에서 계정 초기 등록을 이미 마친 경우 계정 정보를 수정한다.
+                await AccountAPI.editAccount({
+                    accountId,
+                    name: createNurseDTO.name,
+                    ...createNurseDTO.profileImg,
+                });
+            } else if (accountMe.status === 'INITIAL') {
+                await AccountAPI.initAccount({accountId, name: createNurseDTO.name, ...createNurseDTO.profileImg});
+            }
 
-        await NurseAPI.createAccountNurse(accountId, createNurseDTO);
-        changeAccountStatusMutate({accountId, status: 'WARD_SELECT_PENDING'});
-        setLoading(false);
+            await NurseAPI.createAccountNurse(accountId, createNurseDTO);
+            await changeAccountStatus({accountId, status: 'WARD_SELECT_PENDING'});
+        } finally {
+            setLoading(false);
+        }
     };
 
     return {
         state: {accountMe, accountWaitingWard},
         actions: {
             registerAccountAndNurse,
-            createWrad: createWardMutate,
-            enterWard: enterWardMutate,
-            cancelWaiting: (wardId: number, nurseId: number) => cancelWaitingMutate({wardId, nurseId}),
+            createWrad: createWard,
+            enterWard,
+            cancelWaiting,
         },
     };
 };

--- a/src/features/auth/useRegister/index.ts
+++ b/src/features/auth/useRegister/index.ts
@@ -23,12 +23,17 @@ const useRegister = () => {
     const navigate = useNavigate();
     const changeAccountStatus = useCallback(
         async ({accountId, status}: {accountId: number; status: Account['status']}) => {
-            const updatedAccount = await AccountAPI.editAccountStatus(accountId, status);
+            try {
+                const updatedAccount = await AccountAPI.editAccountStatus(accountId, status);
 
-            handleGetAccountMe();
+                handleGetAccountMe();
 
-            if (updatedAccount.status === 'LINKED') {
-                navigate(ROUTE.MAKE);
+                if (updatedAccount.status === 'LINKED') {
+                    navigate(ROUTE.MAKE);
+                }
+            } catch {
+                alert('계정 상태 변경에 실패했습니다.');
+                throw new Error('Failed to change account status.');
             }
         },
         [handleGetAccountMe, navigate],
@@ -112,7 +117,7 @@ const useRegister = () => {
         state: {accountMe, accountWaitingWard},
         actions: {
             registerAccountAndNurse,
-            createWrad: createWard,
+            createWard,
             enterWard,
             cancelWaiting,
         },

--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -1,6 +1,6 @@
-import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {produce} from 'immer';
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {match} from 'ts-pattern';
 import {events, sendEvent} from '@/analytics';
 import {wardQueryOptions} from '@/entities/ward/model/queries';
@@ -22,6 +22,7 @@ const useRequestShift = (activeEffect = false) => {
         state: {wardId},
     } = useAuth();
     const queryClient = useQueryClient();
+    const [changeStatus, setChangeStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
     const shiftTeamsQueryOptions = wardQueryOptions.shiftTeams(wardId ?? 0);
     const requestListQueryOptions = wardQueryOptions.requestList(wardId ?? 0, currentShiftTeamId ?? 0, year, month);
     const requestShiftQueryOptions = wardQueryOptions.request(wardId ?? 0, currentShiftTeamId ?? 0, year, month);
@@ -70,61 +71,70 @@ const useRequestShift = (activeEffect = false) => {
         },
         enabled: wardId !== null && currentShiftTeamId !== null,
     });
-    const {mutate: mutateShift, status: changeStatus} = useMutation({
-        mutationFn: ({wardId, focus, shiftTypeId}: {wardId: number; focus: Focus; shiftTypeId: number | null}) =>
-            WardAPI.updateReqShift(wardId, year, month, focus.day + 1, focus.shiftNurseId, shiftTypeId),
-        onMutate: async ({focus, shiftTypeId}) => {
+    const changeRequestShift = useCallback(
+        async (focus: Focus, shiftTypeId: number | null) => {
+            if (!wardId) return;
+
+            setChangeStatus('loading');
             await queryClient.cancelQueries({queryKey: requestShiftQueryKey});
 
             const {shiftNurseId, day} = focus;
             const oldShift = queryClient.getQueryData<RequestShift>(requestShiftQueryKey);
 
-            if (!oldShift || !wardShiftTypeMap) return;
+            if (oldShift && wardShiftTypeMap) {
+                const oldShiftTypeId = oldShift.divisionShiftNurses
+                    .flatMap((x) => x)
+                    .find((x) => x.shiftNurse.shiftNurseId === shiftNurseId)!.wardReqShiftList[focus.day];
+                const edit = {
+                    nurseName: findNurse(oldShift, focus.shiftNurseId)!.name,
+                    focus,
+                    prevShiftType: oldShiftTypeId ? wardShiftTypeMap.get(oldShiftTypeId) : null,
+                    nextShiftType: shiftTypeId ? wardShiftTypeMap.get(shiftTypeId) : null,
+                    dateString: DateUtil.getDateString(new Date(), 'yyyy-MM-dd HH:mm:ss'),
+                };
 
-            const oldShiftTypeId = oldShift.divisionShiftNurses.flatMap((x) => x).find((x) => x.shiftNurse.shiftNurseId === shiftNurseId)!
-                .wardReqShiftList[focus.day];
-            const edit = {
-                nurseName: findNurse(oldShift, focus.shiftNurseId)!.name,
-                focus,
-                prevShiftType: oldShiftTypeId ? wardShiftTypeMap.get(oldShiftTypeId) : null,
-                nextShiftType: shiftTypeId ? wardShiftTypeMap.get(shiftTypeId) : null,
-                dateString: DateUtil.getDateString(new Date(), 'yyyy-MM-dd HH:mm:ss'),
-            };
+                queryClient.setQueryData<RequestShift>(
+                    requestShiftQueryKey,
+                    produce(oldShift, (draft) => {
+                        draft.divisionShiftNurses
+                            .flatMap((x) => x)
+                            .find((x) => x.shiftNurse.shiftNurseId === focus.shiftNurseId)!.wardReqShiftList[focus.day] =
+                            shiftTypeId;
+                    }),
+                );
 
-            queryClient.setQueryData<RequestShift>(
-                requestShiftQueryKey,
-                produce(oldShift, (draft) => {
-                    draft.divisionShiftNurses
-                        .flatMap((x) => x)
-                        .find((x) => x.shiftNurse.shiftNurseId === focus.shiftNurseId)!.wardReqShiftList[focus.day] = shiftTypeId;
-                }),
-            );
+                sendEvent(
+                    events.requestPage.changeShift,
+                    `${focus.shiftNurseName} / ${day + 1}일 | ` +
+                        match(edit)
+                            .with({prevShiftType: null}, () => `추가 → ${edit.nextShiftType?.shortName}`)
+                            .with({nextShiftType: null}, () => `${edit.prevShiftType?.shortName} → 삭제`)
+                            .otherwise(() => `${edit.prevShiftType?.shortName} → ${edit.nextShiftType?.shortName}`),
+                );
+            }
 
-            sendEvent(
-                events.requestPage.changeShift,
-                `${focus.shiftNurseName} / ${day + 1}일 | ` +
-                    match(edit)
-                        .with({prevShiftType: null}, () => `추가 → ${edit.nextShiftType?.shortName}`)
-                        .with({nextShiftType: null}, () => `${edit.prevShiftType?.shortName} → 삭제`)
-                        .otherwise(() => `${edit.prevShiftType?.shortName} → ${edit.nextShiftType?.shortName}`),
-            );
-
-            return {oldShift};
+            try {
+                await WardAPI.updateReqShift(wardId, year, month, focus.day + 1, focus.shiftNurseId, shiftTypeId);
+                setChangeStatus('success');
+            } catch {
+                if (oldShift) {
+                    queryClient.setQueryData(requestShiftQueryKey, oldShift);
+                }
+                setChangeStatus('error');
+            }
         },
-        onError: (_, __, context) => {
-            if (context?.oldShift === undefined) return;
+        [queryClient, requestShiftQueryKey, wardId, wardShiftTypeMap, year, month],
+    );
+    const acceptRequest = useCallback(
+        async (reqShiftId: number, isAccepted: boolean | null) => {
+            if (!wardId) return;
 
-            queryClient.setQueryData(requestShiftQueryKey, context.oldShift);
+            await WardAPI.acceptRequestShift(wardId, reqShiftId, isAccepted);
+            await queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
+            await queryClient.invalidateQueries({queryKey: dutyRequestQueryKey});
         },
-    });
-    const {mutate: acceptRequestMutate} = useMutation({
-        mutationFn: ({wardId, reqShiftId, isAccepted}: {wardId: number; reqShiftId: number; isAccepted: boolean | null}) =>
-            WardAPI.acceptRequestShift(wardId, reqShiftId, isAccepted),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
-            queryClient.invalidateQueries({queryKey: dutyRequestQueryKey});
-        },
-    });
+        [dutyRequestQueryKey, queryClient, requestShiftQueryKey, wardId],
+    );
     const changeMonth = (type: 'prev' | 'next') => {
         if (type === 'prev') {
             if (new Date(year, month, 1) <= new Date() && !readonly) {
@@ -173,16 +183,15 @@ const useRequestShift = (activeEffect = false) => {
             if (requestDutyRequest && requestDutyRequest.wardShiftTypeId !== shiftTypeId && !confirm('신청을 거절하시겠습니까?')) return;
 
             if (requestDutyRequest) {
-                acceptRequestMutate({
-                    wardId,
-                    reqShiftId: requestDutyRequest.wardReqShiftId,
-                    isAccepted: shiftTypeId === null ? null : requestDutyRequest.wardShiftTypeId === shiftTypeId,
-                });
+                acceptRequest(
+                    requestDutyRequest.wardReqShiftId,
+                    shiftTypeId === null ? null : requestDutyRequest.wardShiftTypeId === shiftTypeId,
+                );
             }
 
-            mutateShift({wardId, focus, shiftTypeId});
+            changeRequestShift(focus, shiftTypeId);
         },
-        [wardId, focus, requestShift, dutyRequestList, acceptRequestMutate, mutateShift],
+        [acceptRequest, changeRequestShift, dutyRequestList, focus, requestShift, wardId],
     );
     const foldLevel = (level: number) => {
         if (!requestShift || !foldedLevels) return;
@@ -367,11 +376,10 @@ const useRequestShift = (activeEffect = false) => {
             shiftTeams,
         },
         actions: {
-            changeRequestShift: (focus: Focus, shiftTypeId: number | null) => wardId && mutateShift({wardId, focus, shiftTypeId}),
+            changeRequestShift: (focus: Focus, shiftTypeId: number | null) => changeRequestShift(focus, shiftTypeId),
             toggleEditMode: handleToggleEditMode,
             createNextMonthShift: handleCreateNextMonthShift,
-            acceptRequest: (reqShiftId: number, isAccepted: boolean | null) =>
-                wardId && acceptRequestMutate({wardId, isAccepted, reqShiftId}),
+            acceptRequest: (reqShiftId: number, isAccepted: boolean | null) => acceptRequest(reqShiftId, isAccepted),
             foldLevel,
             changeMonth,
             changeFocus: (focus: Focus | null) => setState('focus', focus),

--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -116,11 +116,13 @@ const useRequestShift = (activeEffect = false) => {
             try {
                 await WardAPI.updateReqShift(wardId, year, month, focus.day + 1, focus.shiftNurseId, shiftTypeId);
                 setChangeStatus('success');
+                setTimeout(() => setChangeStatus('idle'), 0);
             } catch {
                 if (oldShift) {
                     queryClient.setQueryData(requestShiftQueryKey, oldShift);
                 }
                 setChangeStatus('error');
+                setTimeout(() => setChangeStatus('idle'), 0);
             }
         },
         [queryClient, requestShiftQueryKey, wardId, wardShiftTypeMap, year, month],
@@ -129,9 +131,13 @@ const useRequestShift = (activeEffect = false) => {
         async (reqShiftId: number, isAccepted: boolean | null) => {
             if (!wardId) return;
 
-            await WardAPI.acceptRequestShift(wardId, reqShiftId, isAccepted);
-            await queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
-            await queryClient.invalidateQueries({queryKey: dutyRequestQueryKey});
+            try {
+                await WardAPI.acceptRequestShift(wardId, reqShiftId, isAccepted);
+                await queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
+                await queryClient.invalidateQueries({queryKey: dutyRequestQueryKey});
+            } catch {
+                alert('신청 처리에 실패했습니다.');
+            }
         },
         [dutyRequestQueryKey, queryClient, requestShiftQueryKey, wardId],
     );

--- a/src/features/ward/useEditShiftTeam/index.ts
+++ b/src/features/ward/useEditShiftTeam/index.ts
@@ -1,4 +1,4 @@
-import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {produce} from 'immer';
 import {useCallback} from 'react';
 import {wardQueryKeys, wardQueryOptions} from '@/entities/ward/model/queries';
@@ -27,97 +27,101 @@ const useEditShiftTeam = () => {
         ...wardQueryOptionsValue,
         enabled: !!wardId,
     });
-    const {mutate: updateNurseMutate} = useMutation({
-        mutationFn: ({nurseId, updateNurseDTO}: {nurseId: number; updateNurseDTO: UpdateNurseDTO}) =>
-            NurseAPI.updateNurse(nurseId, updateNurseDTO),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-            queryClient.invalidateQueries({queryKey: shiftQueryKey});
-            queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
+    const invalidateWard = useCallback(async () => {
+        await queryClient.invalidateQueries({queryKey: wardQueryKey});
+    }, [queryClient, wardQueryKey]);
+    const invalidateWardShiftAndRequest = useCallback(async () => {
+        await queryClient.invalidateQueries({queryKey: wardQueryKey});
+        await queryClient.invalidateQueries({queryKey: shiftQueryKey});
+        await queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
+    }, [queryClient, requestShiftQueryKey, shiftQueryKey, wardQueryKey]);
+    const addNurse = useCallback(
+        async (shiftTeamId: number) => {
+            if (!wardId) return;
+
+            try {
+                await WardAPI.addNurseIntoShiftTeam(wardId, shiftTeamId, {
+                    name: `간호사${Math.floor(Math.random() * 10000)}`,
+                    phoneNum: '01012345678',
+                    gender: '여',
+                    isWorker: true,
+                    employmentDate: '2021-08-01',
+                    isDutyManager: false,
+                    isWardManager: false,
+                    memo: '',
+                });
+                await invalidateWard();
+            } catch {
+                alert('간호사 추가에 실패했습니다.');
+            }
         },
-        onError: () => {
-            alert('간호사 정보 수정이 실패했습니다.');
+        [invalidateWard, wardId],
+    );
+    const deleteNurse = useCallback(
+        async (shiftTeamId: number, nurseId: number) => {
+            if (!wardId) return;
+
+            await WardAPI.removeNurseFromShiftTeam(wardId, shiftTeamId, nurseId);
+            await invalidateWard();
         },
-    });
-    const {mutate: addNurseMutate} = useMutation({
-        mutationFn: ({wardId, shiftTeamId}: {wardId: number; shiftTeamId: number}) =>
-            WardAPI.addNurseIntoShiftTeam(wardId, shiftTeamId, {
-                name: `간호사${Math.floor(Math.random() * 10000)}`,
-                phoneNum: '01012345678',
-                gender: '여',
-                isWorker: true,
-                employmentDate: '2021-08-01',
-                isDutyManager: false,
-                isWardManager: false,
-                memo: '',
-            }),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
-        onError: () => {
-            alert('간호사 추가에 실패했습니다.');
+        [invalidateWard, wardId],
+    );
+    const selectNurse = useCallback(
+        (nurseId: number | null) => {
+            setState('selectedNurseId', nurseId);
         },
-    });
-    const {mutate: deleteNurseMutate} = useMutation({
-        mutationFn: ({wardId, nurseId, shiftTeamId}: {wardId: number; nurseId: number; shiftTeamId: number}) =>
-            WardAPI.removeNurseFromShiftTeam(wardId, shiftTeamId, nurseId),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
-    });
-    const {mutate: updateNurseShiftTypeMutate} = useMutation({
-        mutationFn: ({
-            nurseId,
-            nurseShiftTypeId,
-            change,
-        }: {
-            nurseId: number;
-            nurseShiftTypeId: number;
-            change: UpdateNurseShiftTypeRequest;
-        }) => NurseAPI.updateNurseShiftType(nurseId, nurseShiftTypeId, change),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
-    });
-    const {mutate: createShiftTeamMutate} = useMutation({
-        mutationFn: (wardId: number) => WardAPI.createShiftTeam(wardId),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
-    });
-    const {mutate: deleteShiftTeamMutate} = useMutation({
-        mutationFn: ({wardId, shiftTeamId}: {wardId: number; shiftTeamId: number}) => WardAPI.deleteShiftTeam(wardId, shiftTeamId),
-        onSuccess: () => queryClient.invalidateQueries({queryKey: wardQueryKey}),
-    });
-    const {mutate: editDivisionMutate} = useMutation({
-        mutationFn: ({
-            shiftTeamId,
-            prevPriority,
-            changeValue,
-            patchYearMonth,
-        }: {
-            shiftTeamId: number;
-            prevPriority: number;
-            changeValue: number;
-            patchYearMonth: string;
-        }) => NurseAPI.updateShiftTeamDivision(shiftTeamId, prevPriority, changeValue, patchYearMonth),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-            queryClient.invalidateQueries({queryKey: shiftQueryKey});
-            queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
+        [setState],
+    );
+    const updateNurse = useCallback(
+        async (nurseId: number, updateNurseDTO: UpdateNurseDTO) => {
+            try {
+                await NurseAPI.updateNurse(nurseId, updateNurseDTO);
+                await invalidateWardShiftAndRequest();
+            } catch {
+                alert('간호사 정보 수정이 실패했습니다.');
+            }
         },
-    });
-    const {mutate: moveNurseOrderMutate} = useMutation({
-        mutationFn: ({
-            nurseId,
-            shiftTeamId,
-            nextShiftTeamId,
-            divisionNum,
-            prevPriority,
-            nextPriority,
-            patchYearMonth,
-        }: {
-            nurseId: number;
-            shiftTeamId: number;
-            nextShiftTeamId: number;
-            divisionNum: number;
-            prevPriority: number;
-            nextPriority: number;
-            patchYearMonth: string;
-        }) => NurseAPI.updateNurseOrder(nurseId, shiftTeamId, nextShiftTeamId, divisionNum, prevPriority, nextPriority, patchYearMonth),
-        onMutate: async ({nurseId, shiftTeamId, nextShiftTeamId, prevPriority, nextPriority, divisionNum}) => {
+        [invalidateWardShiftAndRequest],
+    );
+    const updateNurseShift = useCallback(
+        async (nurseId: number, nurseShiftTypeId: number, change: UpdateNurseShiftTypeRequest) => {
+            await NurseAPI.updateNurseShiftType(nurseId, nurseShiftTypeId, change);
+            await invalidateWard();
+        },
+        [invalidateWard],
+    );
+    const createShiftTeam = useCallback(async () => {
+        if (!wardId) return;
+
+        await WardAPI.createShiftTeam(wardId);
+        await invalidateWard();
+    }, [invalidateWard, wardId]);
+    const deleteShiftTeam = useCallback(
+        async (shiftTeamId: number) => {
+            if (!wardId) return;
+
+            await WardAPI.deleteShiftTeam(wardId, shiftTeamId);
+            await invalidateWard();
+        },
+        [invalidateWard, wardId],
+    );
+    const editDivision = useCallback(
+        async (shiftTeamId: number, prevPriority: number, changeValue: number, patchYearMonth: string) => {
+            await NurseAPI.updateShiftTeamDivision(shiftTeamId, prevPriority, changeValue, patchYearMonth);
+            await invalidateWardShiftAndRequest();
+        },
+        [invalidateWardShiftAndRequest],
+    );
+    const moveNurseOrder = useCallback(
+        async (
+            nurseId: number,
+            shiftTeamId: number,
+            nextShiftTeamId: number,
+            divisionNum: number,
+            prevPriority: number,
+            nextPriority: number,
+            patchYearMonth: string,
+        ) => {
             await queryClient.cancelQueries({queryKey: wardQueryKey});
             await queryClient.cancelQueries({queryKey: shiftQueryKey});
             await queryClient.cancelQueries({queryKey: requestShiftQueryKey});
@@ -218,131 +222,51 @@ const useEditShiftTeam = () => {
                 );
             }
 
-            return {oldWard, oldShift, oldReqShift};
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-            queryClient.invalidateQueries({queryKey: shiftQueryKey});
-            queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
-        },
-        onError: (_, __, context) => {
-            if (context?.oldShift === undefined || context.oldReqShift === undefined || context.oldWard === undefined) return;
+            try {
+                await NurseAPI.updateNurseOrder(
+                    nurseId,
+                    shiftTeamId,
+                    nextShiftTeamId,
+                    divisionNum,
+                    prevPriority,
+                    nextPriority,
+                    patchYearMonth,
+                );
+                await invalidateWardShiftAndRequest();
+            } catch {
+                if (!oldShift || !oldReqShift || !oldWard) return;
 
-            queryClient.setQueryData(wardQueryKey, context.oldWard);
-            queryClient.setQueryData(shiftQueryKey, context.oldShift);
-            queryClient.setQueryData(requestShiftQueryKey, context.oldReqShift);
-        },
-    });
-    const {mutate: updateShiftTeamMutate} = useMutation({
-        mutationFn: ({
-            wardId,
-            shiftTeamId,
-            updateShiftTeamDTO,
-        }: {
-            wardId: number;
-            shiftTeamId: number;
-            updateShiftTeamDTO: UpdateShiftTeamDTO;
-        }) => WardAPI.updateShiftTeam(wardId, shiftTeamId, updateShiftTeamDTO),
-        onMutate: ({shiftTeamId, updateShiftTeamDTO}) => {
-            const oldWard = queryClient.getQueryData<Ward>(wardQueryKey);
-
-            if (!oldWard) return;
-
-            queryClient.setQueryData<Ward>(
-                wardQueryKey,
-                produce(oldWard, (draft) => {
-                    const shiftTeam = draft.shiftTeams.find((shiftTeam) => shiftTeam.shiftTeamId === shiftTeamId)!;
-
-                    shiftTeam.name = updateShiftTeamDTO.name;
-                }),
-            );
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-        },
-    });
-    const addNurse = useCallback(
-        (shiftTeamId: number) => {
-            if (wardId) {
-                addNurseMutate({wardId, shiftTeamId});
+                queryClient.setQueryData(wardQueryKey, oldWard);
+                queryClient.setQueryData(shiftQueryKey, oldShift);
+                queryClient.setQueryData(requestShiftQueryKey, oldReqShift);
             }
         },
-        [wardId, addNurseMutate],
-    );
-    const deleteNurse = useCallback(
-        (shiftTeamId: number, nurseId: number) => {
-            if (wardId) {
-                deleteNurseMutate({wardId, nurseId, shiftTeamId});
-            }
-        },
-        [wardId, deleteNurseMutate],
-    );
-    const selectNurse = useCallback(
-        (nurseId: number | null) => {
-            setState('selectedNurseId', nurseId);
-        },
-        [setState],
-    );
-    const updateNurse = useCallback(
-        (nurseId: number, updateNurseDTO: UpdateNurseDTO) => {
-            updateNurseMutate({nurseId, updateNurseDTO});
-        },
-        [updateNurseMutate],
-    );
-    const updateNurseShift = useCallback(
-        (nurseId: number, nurseShiftTypeId: number, change: UpdateNurseShiftTypeRequest) => {
-            updateNurseShiftTypeMutate({nurseId, nurseShiftTypeId, change});
-        },
-        [updateNurseShiftTypeMutate],
-    );
-    const createShiftTeam = useCallback(() => {
-        if (wardId) {
-            createShiftTeamMutate(wardId);
-        }
-    }, [wardId, createShiftTeamMutate]);
-    const deleteShiftTeam = useCallback(
-        (shiftTeamId: number) => {
-            if (wardId) {
-                deleteShiftTeamMutate({wardId, shiftTeamId});
-            }
-        },
-        [wardId, deleteShiftTeamMutate],
-    );
-    const editDivision = useCallback(
-        (shiftTeamId: number, prevPriority: number, changeValue: number, patchYearMonth: string) => {
-            editDivisionMutate({shiftTeamId, prevPriority, changeValue, patchYearMonth});
-        },
-        [editDivisionMutate],
-    );
-    const moveNurseOrder = useCallback(
-        (
-            nurseId: number,
-            shiftTeamId: number,
-            nextShiftTeamId: number,
-            divisionNum: number,
-            prevPriority: number,
-            nextPriority: number,
-            patchYearMonth: string,
-        ) => {
-            moveNurseOrderMutate({
-                nurseId,
-                shiftTeamId,
-                nextShiftTeamId,
-                divisionNum,
-                prevPriority,
-                nextPriority,
-                patchYearMonth,
-            });
-        },
-        [moveNurseOrderMutate],
+        [invalidateWardShiftAndRequest, queryClient, requestShiftQueryKey, shiftQueryKey, wardQueryKey],
     );
     const updateShiftTeam = useCallback(
-        (shiftTeamId: number, updateShiftTeamDTO: UpdateShiftTeamDTO) => {
-            if (wardId) {
-                updateShiftTeamMutate({wardId, shiftTeamId, updateShiftTeamDTO});
+        async (shiftTeamId: number, updateShiftTeamDTO: UpdateShiftTeamDTO) => {
+            if (!wardId) return;
+
+            const oldWard = queryClient.getQueryData<Ward>(wardQueryKey);
+
+            if (oldWard) {
+                queryClient.setQueryData<Ward>(
+                    wardQueryKey,
+                    produce(oldWard, (draft) => {
+                        const shiftTeam = draft.shiftTeams.find((shiftTeam) => shiftTeam.shiftTeamId === shiftTeamId)!;
+
+                        shiftTeam.name = updateShiftTeamDTO.name;
+                    }),
+                );
+            }
+
+            try {
+                await WardAPI.updateShiftTeam(wardId, shiftTeamId, updateShiftTeamDTO);
+            } finally {
+                await invalidateWard();
             }
         },
-        [updateShiftTeamMutate, wardId],
+        [invalidateWard, queryClient, wardId, wardQueryKey],
     );
 
     return {

--- a/src/features/ward/useEditWard/index.ts
+++ b/src/features/ward/useEditWard/index.ts
@@ -1,5 +1,5 @@
-import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {useCallback} from 'react';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {wardQueryKeys, wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import {WardAPI} from '@/shared/api';
@@ -24,121 +24,76 @@ const useEditWard = () => {
         ...wardWaitingNursesQueryOptions,
         enabled: !!wardId,
     });
-    const {mutate: updateWardMutate} = useMutation({
-        mutationFn: ({wardId, editWardDTO}: {wardId: number; editWardDTO: EditWardDTO}) => WardAPI.editWard(wardId, editWardDTO),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-        },
-        onError: () => {
-            alert('근무 설정 수정에 실패하였습니다.');
-        },
-    });
-    const {mutate: createShiftTypeMutate} = useMutation({
-        mutationFn: ({wardId, createShiftTypeDTO}: {wardId: number; createShiftTypeDTO: CreateShiftTypeDTO}) =>
-            WardAPI.createShiftType(wardId, createShiftTypeDTO),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-        },
-    });
-    const {mutate: updateShiftTypeMutate} = useMutation({
-        mutationFn: ({
-            wardId,
-            shiftTypeId,
-            createShiftTypeDTO,
-        }: {
-            wardId: number;
-            shiftTypeId: number;
-            createShiftTypeDTO: CreateShiftTypeDTO;
-        }) => WardAPI.updateShiftType(wardId, shiftTypeId, createShiftTypeDTO),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-            queryClient.invalidateQueries({queryKey: shiftQueryKey});
-        },
-    });
-    const {mutate: deleteShiftTypeMutate} = useMutation({
-        mutationFn: ({wardId, shiftTypeId}: {wardId: number; shiftTypeId: number}) => WardAPI.deleteShiftType(wardId, shiftTypeId),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-        },
-    });
-    const {mutate: approveWatingNursesMutate} = useMutation({
-        mutationFn: ({wardId, waitingNurseId, shiftTeamId}: {wardId: number; waitingNurseId: number; shiftTeamId: number}) =>
-            WardAPI.approveWatingNurses(wardId, waitingNurseId, shiftTeamId),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-            queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
-        },
-    });
-    const {mutate: connectWatingNursesMutate} = useMutation({
-        mutationFn: ({wardId, waitingNurseId, targetNurseId}: {wardId: number; waitingNurseId: number; targetNurseId: number}) =>
-            WardAPI.connectWatingNurses(wardId, waitingNurseId, targetNurseId),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-            queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
-        },
-    });
-    const {mutate: cancelWaitingMutate} = useMutation({
-        mutationFn: ({wardId, nurseId}: {wardId: number; nurseId: number}) => WardAPI.deleteWatingNurses(wardId, nurseId),
-        onSuccess: () => {
-            queryClient.invalidateQueries({queryKey: wardQueryKey});
-            queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
-        },
-    });
     const editWardSetting = useCallback(
-        (editWardDTO: EditWardDTO) => {
-            if (wardId) {
-                updateWardMutate({wardId, editWardDTO});
+        async (editWardDTO: EditWardDTO) => {
+            if (!wardId) return;
+
+            try {
+                await WardAPI.editWard(wardId, editWardDTO);
+                await queryClient.invalidateQueries({queryKey: wardQueryKey});
+            } catch {
+                alert('근무 설정 수정에 실패하였습니다.');
             }
         },
-        [updateWardMutate, wardId],
+        [queryClient, wardId, wardQueryKey],
     );
     const addShiftType = useCallback(
-        (createShiftTypeDTO: CreateShiftTypeDTO) => {
-            if (wardId) {
-                createShiftTypeMutate({wardId, createShiftTypeDTO});
-            }
+        async (createShiftTypeDTO: CreateShiftTypeDTO) => {
+            if (!wardId) return;
+
+            await WardAPI.createShiftType(wardId, createShiftTypeDTO);
+            await queryClient.invalidateQueries({queryKey: wardQueryKey});
         },
-        [createShiftTypeMutate, wardId],
+        [queryClient, wardId, wardQueryKey],
     );
     const editShiftType = useCallback(
-        (shiftTypeId: number, createShiftTypeDTO: CreateShiftTypeDTO) => {
-            if (wardId) {
-                updateShiftTypeMutate({wardId, shiftTypeId, createShiftTypeDTO});
-            }
+        async (shiftTypeId: number, createShiftTypeDTO: CreateShiftTypeDTO) => {
+            if (!wardId) return;
+
+            await WardAPI.updateShiftType(wardId, shiftTypeId, createShiftTypeDTO);
+            await queryClient.invalidateQueries({queryKey: wardQueryKey});
+            await queryClient.invalidateQueries({queryKey: shiftQueryKey});
         },
-        [updateShiftTypeMutate, wardId],
+        [queryClient, shiftQueryKey, wardId, wardQueryKey],
     );
     const removeShiftType = useCallback(
-        (shiftTypeId: number) => {
-            if (wardId) {
-                deleteShiftTypeMutate({wardId, shiftTypeId});
-            }
+        async (shiftTypeId: number) => {
+            if (!wardId) return;
+
+            await WardAPI.deleteShiftType(wardId, shiftTypeId);
+            await queryClient.invalidateQueries({queryKey: wardQueryKey});
         },
-        [deleteShiftTypeMutate, wardId],
+        [queryClient, wardId, wardQueryKey],
     );
     const approveWatingNurses = useCallback(
-        (waitingNurseId: number, shiftTeamId: number) => {
-            if (wardId) {
-                approveWatingNursesMutate({wardId, waitingNurseId, shiftTeamId});
-            }
+        async (waitingNurseId: number, shiftTeamId: number) => {
+            if (!wardId) return;
+
+            await WardAPI.approveWatingNurses(wardId, waitingNurseId, shiftTeamId);
+            await queryClient.invalidateQueries({queryKey: wardQueryKey});
+            await queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
         },
-        [approveWatingNursesMutate, wardId],
+        [queryClient, wardId, wardQueryKey, wardWaitingNursesQueryKey],
     );
     const connectWatingNurses = useCallback(
-        (waitingNurseId: number, targetNurseId: number) => {
-            if (wardId) {
-                connectWatingNursesMutate({wardId, waitingNurseId, targetNurseId});
-            }
+        async (waitingNurseId: number, targetNurseId: number) => {
+            if (!wardId) return;
+
+            await WardAPI.connectWatingNurses(wardId, waitingNurseId, targetNurseId);
+            await queryClient.invalidateQueries({queryKey: wardQueryKey});
+            await queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
         },
-        [connectWatingNursesMutate, wardId],
+        [queryClient, wardId, wardQueryKey, wardWaitingNursesQueryKey],
     );
     const cancelWaiting = useCallback(
-        (nurseId: number) => {
-            if (wardId) {
-                cancelWaitingMutate({wardId, nurseId});
-            }
+        async (nurseId: number) => {
+            if (!wardId) return;
+
+            await WardAPI.deleteWatingNurses(wardId, nurseId);
+            await queryClient.invalidateQueries({queryKey: wardQueryKey});
+            await queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
         },
-        [cancelWaitingMutate, wardId],
+        [queryClient, wardId, wardQueryKey, wardWaitingNursesQueryKey],
     );
 
     return {

--- a/src/pages/RegisterPage/ui/RegisterWard.tsx
+++ b/src/pages/RegisterPage/ui/RegisterWard.tsx
@@ -86,7 +86,7 @@ function RegisterWard() {
     const [tempShiftType, setTempShiftType] = useState<WardShiftType | null>(null);
     const {
         state: {accountMe},
-        actions: {createWrad},
+        actions: {createWard},
     } = useRegister();
     const navigate = useNavigate();
     const appendClipboardTextToNurse = async (index: number) => {
@@ -135,7 +135,7 @@ function RegisterWard() {
                         return;
                     }
 
-                    createWrad({
+                    createWard({
                         name: d.name,
                         hospitalName: d.hospitalName,
                         shiftTeams: shiftTeams.map((shiftTeam) => ({nurseNames: shiftTeam})),


### PR DESCRIPTION
### Motivation
- Apply the FSD migration policy to stop using `useMutation` and centralize API calls in model hooks, and implement the actual code changes rather than only updating the checklist.

### Description
- Replaced `useMutation` calls with explicit async handlers (`useCallback` functions) that call APIs and invalidate queries directly in `src/features/auth/useRegister/index.ts`, `src/features/ward/useEditWard/index.ts`, `src/features/ward/useEditShiftTeam/index.ts`, and `src/features/shift/useRequestShift/index.ts`.
- Preserved optimistic updates for request-shift edits by mutating the query cache manually and added local `changeStatus` state in `useRequestShift` to track request status.
- Consolidated loading, navigation and error handling into try/finally/try-catch flows (e.g. `createWard`, `enterWard`, `registerAccountAndNurse`) and added rollback behavior on failed optimistic updates where applicable.
- Marked the related migration checklist items in `docs/architecture/fsd-migration-tasks.md` as completed.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968e83b9bb883249efb65a27d32e7fe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 내부 mutation 기반 흐름을 명시적 비동기 액션으로 전환하여 상태 관리와 에러 복구 로직을 정비
  * 시프트·병동 편집 및 요청 흐름의 제어 흐름과 캐시 갱신 방식 개선

* **Documentation**
  * 마이그레이션 작업 문서의 관련 항목들 완료 처리

* **Chores**
  * 등록 플로우에서 액션명 정리(createWrad → createWard) 및 공개 액션 인터페이스 정비

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->