### PR TITLE
[DUT-839]: 자동완성 provider/contract 분리

### DIFF
--- a/src/pages/make-shift/model/ai-schedule-api-provider.ts
+++ b/src/pages/make-shift/model/ai-schedule-api-provider.ts
@@ -1,0 +1,23 @@
+import axiosInstance from '@/shared/api/client';
+import type {TAiScheduleResponse} from '@/shared/types/ai-schedule';
+import type {TAiScheduleProvider} from './ai-schedule-contract';
+
+type TAiScheduleApiPayload = {
+    year: number;
+    month: number;
+    schedule: Record<string, string[]>;
+};
+
+export const apiAiScheduleProvider: TAiScheduleProvider = {
+    generate: async ({wardId, shiftTeamId, year, month, doc}) => {
+        const schedule = Object.fromEntries(doc.rows.map((row) => [row.workerId, row.cells.map((cell) => cell ?? '')]));
+        const payload: TAiScheduleApiPayload = {
+            year,
+            month,
+            schedule,
+        };
+
+        return (await axiosInstance.post<TAiScheduleResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}/duty/ai-autofill`, payload))
+            .data;
+    },
+};

--- a/src/pages/make-shift/model/ai-schedule-contract.ts
+++ b/src/pages/make-shift/model/ai-schedule-contract.ts
@@ -1,0 +1,24 @@
+import type {TDutyDoc} from '@/features/shift-editor';
+import type {TAiScheduleResponse} from '@/shared/types/ai-schedule';
+
+export type TAiScheduleRequest = {
+    wardId: number;
+    shiftTeamId: number;
+    year: number;
+    month: number;
+    doc: TDutyDoc;
+};
+
+export type TAiScheduleProvider = {
+    generate: (request: TAiScheduleRequest) => Promise<TAiScheduleResponse>;
+};
+
+export type TAiScheduleResult =
+    | {
+          ok: true;
+          response: TAiScheduleResponse;
+      }
+    | {
+          ok: false;
+          message: string;
+      };

--- a/src/pages/make-shift/model/ai-schedule-mock.ts
+++ b/src/pages/make-shift/model/ai-schedule-mock.ts
@@ -1,5 +1,6 @@
 import type {TDutyDoc} from '@/features/shift-editor';
 import type {TAiScheduleResponse} from '@/shared/types/ai-schedule';
+import type {TAiScheduleProvider} from './ai-schedule-contract';
 
 export function generateMockAiSchedule(doc: TDutyDoc): TAiScheduleResponse {
     const patterns = ['D', 'D', 'E', 'E', 'N', 'N', 'O', 'O'];
@@ -33,3 +34,7 @@ export function generateMockAiSchedule(doc: TDutyDoc): TAiScheduleResponse {
         created_at: new Date().toISOString(),
     };
 }
+
+export const mockAiScheduleProvider: TAiScheduleProvider = {
+    generate: async ({doc}) => generateMockAiSchedule(doc),
+};

--- a/src/pages/make-shift/model/ai-schedule-provider.ts
+++ b/src/pages/make-shift/model/ai-schedule-provider.ts
@@ -1,0 +1,33 @@
+import {apiAiScheduleProvider} from './ai-schedule-api-provider';
+import {type TAiScheduleProvider, type TAiScheduleRequest, type TAiScheduleResult} from './ai-schedule-contract';
+import {mockAiScheduleProvider} from './ai-schedule-mock';
+
+type TProviderName = 'mock' | 'api';
+
+function getProviderName(): TProviderName {
+    const mode = (import.meta.env.VITE_AI_SCHEDULE_PROVIDER ?? 'mock').toLowerCase();
+
+    if (mode === 'api') return 'api';
+
+    return 'mock';
+}
+
+function getAiScheduleProvider(): TAiScheduleProvider {
+    return getProviderName() === 'api' ? apiAiScheduleProvider : mockAiScheduleProvider;
+}
+
+function toErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) return error.message;
+
+    return 'AI 자동 채우기에 실패했습니다.';
+}
+
+export async function requestAiSchedule(request: TAiScheduleRequest): Promise<TAiScheduleResult> {
+    try {
+        const response = await getAiScheduleProvider().generate(request);
+
+        return {ok: true, response};
+    } catch (error) {
+        return {ok: false, message: toErrorMessage(error)};
+    }
+}

--- a/src/pages/make-shift/view/steps/ai-auto-fill.tsx
+++ b/src/pages/make-shift/view/steps/ai-auto-fill.tsx
@@ -13,7 +13,7 @@ import CountDutyByDay from '@/features/shift-editor/ui/complex-view/count-duty-b
 import ShiftCalendar from '@/features/shift-editor/ui/complex-view/shift-calendar';
 import WardAPI from '@/shared/api/ward';
 import {HistoryBackIcon, HistoryNextIcon, InfoIcon, PlusIcon, SaveCompleteIcon, SavingIcon} from '@/shared/assets/svg';
-import {generateMockAiSchedule} from '../../model/ai-schedule-mock';
+import {requestAiSchedule} from '../../model/ai-schedule-provider';
 import {useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
 import {buildWorkKeyMap, docToWardShiftsDTO, shiftToDoc} from '../../model/shift-editor-adapter';
@@ -55,6 +55,7 @@ export function AiAutofill() {
     const [showFaults, setShowFaults] = useState(true);
     const violationMap = useMemo(() => buildViolationMap(violations, editorDoc), [violations, editorDoc]);
     const [isWorking, setIsWorking] = useState(false);
+    const [isAiGenerating, setIsAiGenerating] = useState(false);
     const savingLabel = isWorking ? '저장 중' : '저장 완료';
     const SavingStatusIcon = isWorking ? SavingIcon : SaveCompleteIcon;
     const handleConfirm = async () => {
@@ -73,10 +74,30 @@ export function AiAutofill() {
             setIsWorking(false);
         }
     };
-    const handleAiFill = () => {
-        const response = generateMockAiSchedule(editorDoc);
+    const handleAiFill = async () => {
+        if (!wardId || !currentShiftTeamId || isAiGenerating) return;
 
-        commands.applySchedule(response.schedule, 'ai');
+        setIsAiGenerating(true);
+
+        try {
+            const result = await requestAiSchedule({
+                wardId,
+                shiftTeamId: currentShiftTeamId,
+                year,
+                month,
+                doc: editorDoc,
+            });
+
+            if (!result.ok) {
+                alert(result.message);
+
+                return;
+            }
+
+            commands.applySchedule(result.response.schedule, 'ai');
+        } finally {
+            setIsAiGenerating(false);
+        }
     };
 
     useEffect(() => {
@@ -139,12 +160,13 @@ export function AiAutofill() {
                     </div>
                     <button
                         className="ml-2 flex h-[42px] w-[208px] items-center justify-center gap-[6px] rounded-[10px] font-apple text-[24px] font-semibold text-white"
+                        disabled={isAiGenerating}
                         style={{backgroundImage: 'linear-gradient(105deg, #B53DFA 0%, #663DFA 100%)'}}
                         onClick={handleAiFill}
                         type="button"
                     >
                         <PlusIcon className="h-6 w-6 stroke-white" />
-                        AI 다시 채우기
+                        {isAiGenerating ? 'AI 채우는 중...' : 'AI 다시 채우기'}
                     </button>
                     <button
                         className="flex h-[42px] items-center rounded-[10px] bg-[#0A0F15] px-[20px] py-[8px] font-apple text-[24px] font-semibold text-white"

--- a/src/pages/make-shift/view/steps/ai-auto-fill.tsx
+++ b/src/pages/make-shift/view/steps/ai-auto-fill.tsx
@@ -13,6 +13,7 @@ import CountDutyByDay from '@/features/shift-editor/ui/complex-view/count-duty-b
 import ShiftCalendar from '@/features/shift-editor/ui/complex-view/shift-calendar';
 import WardAPI from '@/shared/api/ward';
 import {HistoryBackIcon, HistoryNextIcon, InfoIcon, PlusIcon, SaveCompleteIcon, SavingIcon} from '@/shared/assets/svg';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import {requestAiSchedule} from '../../model/ai-schedule-provider';
 import {useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
@@ -33,6 +34,7 @@ function isSameDocShape(a: TDutyDoc, b: TDutyDoc): boolean {
 }
 
 export function AiAutofill() {
+    const {t} = useTypedTranslation();
     const {
         state: {wardId},
     } = useAuth();
@@ -56,6 +58,11 @@ export function AiAutofill() {
     const violationMap = useMemo(() => buildViolationMap(violations, editorDoc), [violations, editorDoc]);
     const [isWorking, setIsWorking] = useState(false);
     const [isAiGenerating, setIsAiGenerating] = useState(false);
+    const aiRequestSeqRef = useRef(0);
+    const currentAiContextRef = useRef({wardId, shiftTeamId: currentShiftTeamId, year, month});
+
+    currentAiContextRef.current = {wardId, shiftTeamId: currentShiftTeamId, year, month};
+
     const savingLabel = isWorking ? '저장 중' : '저장 완료';
     const SavingStatusIcon = isWorking ? SavingIcon : SaveCompleteIcon;
     const handleConfirm = async () => {
@@ -75,18 +82,35 @@ export function AiAutofill() {
         }
     };
     const handleAiFill = async () => {
-        if (!wardId || !currentShiftTeamId || isAiGenerating) return;
+        if (wardId == null || currentShiftTeamId == null || isAiGenerating) return;
 
+        const requestSeq = aiRequestSeqRef.current + 1;
+        const requestContext = {wardId, shiftTeamId: currentShiftTeamId, year, month};
+
+        aiRequestSeqRef.current = requestSeq;
         setIsAiGenerating(true);
 
         try {
             const result = await requestAiSchedule({
-                wardId,
-                shiftTeamId: currentShiftTeamId,
-                year,
-                month,
+                wardId: requestContext.wardId,
+                shiftTeamId: requestContext.shiftTeamId,
+                year: requestContext.year,
+                month: requestContext.month,
                 doc: editorDoc,
             });
+
+            if (aiRequestSeqRef.current !== requestSeq) return;
+
+            const currentContext = currentAiContextRef.current;
+
+            if (
+                currentContext.wardId !== requestContext.wardId ||
+                currentContext.shiftTeamId !== requestContext.shiftTeamId ||
+                currentContext.year !== requestContext.year ||
+                currentContext.month !== requestContext.month
+            ) {
+                return;
+            }
 
             if (!result.ok) {
                 alert(result.message);
@@ -96,7 +120,9 @@ export function AiAutofill() {
 
             commands.applySchedule(result.response.schedule, 'ai');
         } finally {
-            setIsAiGenerating(false);
+            if (aiRequestSeqRef.current === requestSeq) {
+                setIsAiGenerating(false);
+            }
         }
     };
 
@@ -166,7 +192,7 @@ export function AiAutofill() {
                         type="button"
                     >
                         <PlusIcon className="h-6 w-6 stroke-white" />
-                        {isAiGenerating ? 'AI 채우는 중...' : 'AI 다시 채우기'}
+                        {isAiGenerating ? t('page.makeShift.aiRefill.generating') : t('page.makeShift.aiRefill.action')}
                     </button>
                     <button
                         className="flex h-[42px] items-center rounded-[10px] bg-[#0A0F15] px-[20px] py-[8px] font-apple text-[24px] font-semibold text-white"

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -53,6 +53,10 @@ export const en: TLocale = {
                 },
                 dragHandleAria: 'Drag to reorder',
             },
+            aiRefill: {
+                action: 'Refill with AI',
+                generating: 'Filling with AI...',
+            },
         },
         duty: {
             prevMonth: 'Previous month',

--- a/src/shared/locales/ko.ts
+++ b/src/shared/locales/ko.ts
@@ -51,6 +51,10 @@ export const ko = {
                 },
                 dragHandleAria: '드래그하여 순서 변경',
             },
+            aiRefill: {
+                action: 'AI 다시 채우기',
+                generating: 'AI 채우는 중...',
+            },
         },
         duty: {
             prevMonth: '이전 달',


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-839](https://gom3.atlassian.net/browse/DUT-839)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- TAiScheduleRequest/Provider/Result 계약 타입을 추가해 자동완성 요청/응답 경계를 명시했습니다.
- mock 구현(mockAiScheduleProvider)과 API 구현(apiAiScheduleProvider)을 분리하고, VITE_AI_SCHEDULE_PROVIDER 기반 선택 지점을 ai-schedule-provider.ts로 통합했습니다.
- AiAutofill 화면은 provider 구현을 직접 참조하지 않고 requestAiSchedule의 결과 상태(ok, message, response)만 소비하도록 리팩터링했습니다.
- AI 실행 중 중복 요청 방지를 위해 버튼 disabled 및 진행 상태 라벨(AI 채우는 중...)을 추가했습니다.

<br>

## To Reviewers

- API provider 엔드포인트(/wards/{wardId}/shift-teams/{shiftTeamId}/duty/ai-autofill)가 백엔드 스펙과 다르면 ai-schedule-api-provider.ts의 경로/페이로드만 교체하면 됩니다.
- 검증: pnpm type-check, pnpm eslint src/pages/make-shift/model/ai-schedule-contract.ts src/pages/make-shift/model/ai-schedule-mock.ts src/pages/make-shift/model/ai-schedule-api-provider.ts src/pages/make-shift/model/ai-schedule-provider.ts src/pages/make-shift/view/steps/ai-auto-fill.tsx

[DUT-839]: https://gom3.atlassian.net/browse/DUT-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * AI 자동 채우기 중 로딩 인디케이터 표시
  * 생성 중 버튼 비활성화로 중복 요청 방지
  * 향상된 오류 처리 및 사용자 친화적 오류 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->