### PR TITLE
[DUT-842]: duty와 make-shift page-level model 의존 제거

### DIFF
--- a/src/features/shift-editor/model/index.ts
+++ b/src/features/shift-editor/model/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './store';
+export * from './shift-adapter';
 export * from './useShiftEditorCommands';
 export * from './useShiftEditorKeyBindings';
 export {buildViolationMap} from './validator';

--- a/src/features/shift-editor/model/shift-adapter.test.ts
+++ b/src/features/shift-editor/model/shift-adapter.test.ts
@@ -1,0 +1,116 @@
+import {describe, expect, it} from 'vitest';
+import type {TShift} from '@/entities';
+import {buildWorkKeyMap, docToWardShiftsDTO, shiftToDoc} from './shift-adapter';
+
+function createShift(): TShift {
+    return {
+        lastDays: [],
+        days: [
+            {day: 1, dayType: 'workday'},
+            {day: 2, dayType: 'workday'},
+        ],
+        wardShiftTypes: [
+            {
+                wardShiftTypeId: 10,
+                name: 'Day',
+                shortName: 'D',
+                startTime: '07:00',
+                endTime: '15:00',
+                color: '#fff',
+                isDefault: true,
+                isOff: false,
+                isCounted: true,
+                classification: 'DAY',
+            },
+            {
+                wardShiftTypeId: 20,
+                name: 'Off',
+                shortName: 'O',
+                startTime: '00:00',
+                endTime: '00:00',
+                color: '#000',
+                isDefault: true,
+                isOff: true,
+                isCounted: false,
+                classification: 'OFF',
+            },
+            {
+                wardShiftTypeId: 30,
+                name: 'Training',
+                shortName: 'TR',
+                startTime: '09:00',
+                endTime: '18:00',
+                color: '#ccc',
+                isDefault: false,
+                isOff: false,
+                isCounted: false,
+                classification: 'OTHER_WORK',
+            },
+        ],
+        divisionShiftNurses: [
+            [
+                {
+                    shiftNurse: {
+                        shiftNurseId: 1,
+                        name: 'Kim',
+                        carried: 0,
+                        divisionNum: 0,
+                        priority: 0,
+                        isWorker: true,
+                        nurseId: 100,
+                    },
+                    lastWardShiftList: [],
+                    lastWardReqShiftList: [],
+                    wardShiftList: [10, null],
+                    wardReqShiftList: [],
+                },
+                {
+                    shiftNurse: {
+                        shiftNurseId: 2,
+                        name: 'Lee',
+                        carried: 0,
+                        divisionNum: 0,
+                        priority: 1,
+                        isWorker: false as never,
+                        nurseId: 101,
+                    },
+                    lastWardShiftList: [],
+                    lastWardReqShiftList: [],
+                    wardShiftList: [20, 10],
+                    wardReqShiftList: [],
+                },
+            ],
+        ],
+    };
+}
+
+describe('shift-adapter', () => {
+    it('converts only worker rows into editor doc', () => {
+        const doc = shiftToDoc(createShift(), 2026, 3);
+
+        expect(doc.columns).toEqual(['2026-03-01', '2026-03-02']);
+        expect(doc.rows).toEqual([{workerId: '1', cells: ['D', null]}]);
+        expect(doc.workerMeta).toEqual({1: {name: 'Kim'}});
+    });
+
+    it('converts editor doc back to ward shifts dto', () => {
+        const shift = createShift();
+        const doc = {
+            columns: ['2026-03-01', '2026-03-02'],
+            rows: [{workerId: '1', cells: ['O', 'D']}],
+            workerMeta: {1: {name: 'Kim'}},
+        };
+
+        expect(docToWardShiftsDTO(doc, shift)).toEqual([
+            {shiftNurseId: 1, date: '2026-03-01', wardShiftTypeId: 20},
+            {shiftNurseId: 1, date: '2026-03-02', wardShiftTypeId: 10},
+        ]);
+    });
+
+    it('builds work key map from single-character short names only', () => {
+        expect(buildWorkKeyMap(createShift())).toEqual({
+            d: 'D',
+            o: 'O',
+        });
+    });
+});

--- a/src/features/shift-editor/model/shift-adapter.ts
+++ b/src/features/shift-editor/model/shift-adapter.ts
@@ -1,6 +1,6 @@
 import type {TShift, TWardShiftType} from '@/entities';
-import type {TCellValue, TDutyDoc, TWorkKeyMap} from '@/features/shift-editor';
 import type {TWardShiftsDTO} from '@/shared/api/ward/type';
+import type {TCellValue, TDutyDoc, TWorkKeyMap} from './types';
 
 type TWardShiftTypeMaps = {
     idToType: Map<number, TWardShiftType>;

--- a/src/features/shift-editor/model/types.ts
+++ b/src/features/shift-editor/model/types.ts
@@ -1,6 +1,7 @@
 import {type TWardConstraint} from '@/entities';
 
 export type TCellValue = string | null;
+export type TWorkKeyMap = Record<string, TCellValue>;
 
 export type TDateKey = string; // YYYY-MM-DD
 

--- a/src/features/shift-editor/model/useShiftEditorKeyBindings.ts
+++ b/src/features/shift-editor/model/useShiftEditorKeyBindings.ts
@@ -1,10 +1,8 @@
 import {useCallback, useMemo} from 'react';
 import {koToEn} from '@/shared/util/koToEn';
 import {useShiftEditorStore} from './store';
-import type {TCellValue, TClipboardPayload} from './types';
+import type {TClipboardPayload, TWorkKeyMap} from './types';
 import {useShiftEditorCommands} from './useShiftEditorCommands';
-
-export type TWorkKeyMap = Record<string, TCellValue>;
 
 export type TShiftEditorKeyBindingsOptions = {
     /**

--- a/src/pages/duty/model/dutyHook.ts
+++ b/src/pages/duty/model/dutyHook.ts
@@ -3,10 +3,16 @@ import {useEffect, useMemo, useRef} from 'react';
 import {useNavigate, useSearchParams} from 'react-router';
 import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
-import {type TDutyDoc, useShiftEditorCommands, useShiftEditorKeyBindings, useShiftEditorStore} from '@/features/shift-editor';
+import {
+    buildWorkKeyMap,
+    docToWardShiftsDTO,
+    shiftToDoc,
+    type TDutyDoc,
+    useShiftEditorCommands,
+    useShiftEditorKeyBindings,
+    useShiftEditorStore,
+} from '@/features/shift-editor';
 import useLoadingUseCase from '@/features/ui/useLoading';
-import {useMakeShiftStore} from '@/pages/make-shift/model/make-shift-store';
-import {buildWorkKeyMap, docToWardShiftsDTO, shiftToDoc} from '@/pages/make-shift/model/shift-editor-adapter';
 import WardAPI from '@/shared/api/ward';
 import ROUTE from '@/shared/constant/path';
 import {shiftToExcel} from '@/shared/util/shiftToExcel';
@@ -54,7 +60,6 @@ export function useDutyHook() {
     const setReadonly = useDutyStore((s) => s.setReadonly);
     const setShift = useDutyStore((s) => s.setShift);
     const setStatus = useDutyStore((s) => s.setStatus);
-    const setMakeShiftTeamId = useMakeShiftStore((s) => s.setCurrentShiftTeamId);
     const commands = useShiftEditorCommands();
     const doc = useShiftEditorStore((s) => s.doc);
     const editorRef = useRef<HTMLDivElement>(null);
@@ -184,9 +189,9 @@ export function useDutyHook() {
         const params = new URLSearchParams({
             year: String(nextYear),
             month: String(nextMonth),
+            shiftTeamId: String(currentShiftTeamId ?? ''),
         });
 
-        setMakeShiftTeamId(currentShiftTeamId);
         navigate(`${ROUTE.MAKE}?${params.toString()}`);
     };
     const handlePostShift = async () => {

--- a/src/pages/make-shift/view/steps/ai-auto-fill.tsx
+++ b/src/pages/make-shift/view/steps/ai-auto-fill.tsx
@@ -3,11 +3,14 @@ import {useEffect, useMemo, useRef, useState} from 'react';
 import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import {
+    buildWorkKeyMap,
+    buildViolationMap,
+    docToWardShiftsDTO,
     type TDutyDoc,
+    shiftToDoc,
     useShiftEditorCommands,
     useShiftEditorKeyBindings,
     useShiftEditorStore,
-    buildViolationMap,
 } from '@/features/shift-editor';
 import CountDutyByDay from '@/features/shift-editor/ui/complex-view/count-duty-by-day';
 import ShiftCalendar from '@/features/shift-editor/ui/complex-view/shift-calendar';
@@ -17,7 +20,6 @@ import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import {requestAiSchedule} from '../../model/ai-schedule-provider';
 import {useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
-import {buildWorkKeyMap, docToWardShiftsDTO, shiftToDoc} from '../../model/shift-editor-adapter';
 
 function isSameDocShape(a: TDutyDoc, b: TDutyDoc): boolean {
     if (a.columns.length !== b.columns.length || a.rows.length !== b.rows.length) return false;

--- a/src/pages/make-shift/view/steps/fixed-shifts.tsx
+++ b/src/pages/make-shift/view/steps/fixed-shifts.tsx
@@ -3,7 +3,9 @@ import {useEffect, useMemo, useRef} from 'react';
 import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import {
+    buildWorkKeyMap,
     buildViolationMap,
+    shiftToDoc,
     type TDutyDoc,
     useShiftEditorCommands,
     useShiftEditorKeyBindings,
@@ -13,7 +15,6 @@ import CountDutyByDay from '@/features/shift-editor/ui/complex-view/count-duty-b
 import ShiftCalendar from '@/features/shift-editor/ui/complex-view/shift-calendar';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
-import {buildWorkKeyMap, shiftToDoc} from '../../model/shift-editor-adapter';
 
 function isSameDocShape(a: TDutyDoc, b: TDutyDoc): boolean {
     if (a.columns.length !== b.columns.length || a.rows.length !== b.rows.length) return false;


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-842](https://gom3.atlassian.net/browse/DUT-842)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- duty/make-shift 공통 근무표 변환 adapter를 `features/shift-editor`로 이동해 page-level model 의존을 제거했습니다.
- `duty`에서 다음 달 근무 만들기로 이동할 때 `shiftTeamId`를 URL query로 전달하도록 바꿔 make-shift store 직접 접근을 제거했습니다.
- 공통 adapter 동작을 검증하는 `shift-adapter` 테스트를 추가했습니다.

<br>

## To Reviewers

- `make-shift`의 fixed-shifts, ai-auto-fill 단계가 새 공용 adapter export를 사용하도록 바뀌었습니다.
- `duty -> make-shift` 이동 시 선택 팀이 query 기반으로 유지되는지 확인 부탁드립니다.
- 검증: `pnpm test:run src/features/shift-editor/model/shift-adapter.test.ts`, `pnpm type-check`, touched-file `eslint`


[DUT-842]: https://gom3.atlassian.net/browse/DUT-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ