### PR TITLE
[DUT-834]: 온보딩 draft/validation 분리

### DIFF
--- a/src/pages/OnboardingWardCreatePage/components/OnboardingStepLayout.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/OnboardingStepLayout.tsx
@@ -7,10 +7,11 @@ interface IOnboardingStepLayoutProps {
     onSkip: () => void;
     onPrev: () => void;
     onNext: () => void;
+    nextDisabled?: boolean;
     children: ReactNode;
 }
 
-function OnboardingStepLayout({step, onSkip, onPrev, onNext, children}: IOnboardingStepLayoutProps) {
+function OnboardingStepLayout({step, onSkip, onPrev, onNext, nextDisabled = false, children}: IOnboardingStepLayoutProps) {
     return (
         <>
             {children}
@@ -24,7 +25,9 @@ function OnboardingStepLayout({step, onSkip, onPrev, onNext, children}: IOnboard
                             이전
                         </WizardButton>
                     ) : null}
-                    <WizardButton onClick={onNext}>{step < 4 ? '다음' : '완료'}</WizardButton>
+                    <WizardButton onClick={onNext} disabled={nextDisabled}>
+                        {step < 4 ? '다음' : '완료'}
+                    </WizardButton>
                 </div>
             </div>
         </>

--- a/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
+++ b/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
@@ -3,29 +3,28 @@ import {useEffect, useState} from 'react';
 import toast from 'react-hot-toast';
 import {
     applyMockUpload,
-    applySkillLevels,
-    createEmptyNurse,
-    createEmptyShiftType,
+    addNurseDraft,
+    addShiftTypeDraft,
+    addTeamDraft,
+    canComplete,
+    canGoNext,
+    canGoPrev,
     createInitialDraft,
+    deleteShiftTypeDraft,
+    getStepValidation,
+    goNextStep as goNextStepDraft,
+    goPreviousStep as goPreviousStepDraft,
     serializeDraft,
-    type TOnboardingNurseDraft,
-    type TOnboardingStep,
+    reorderNursesWithinTeam,
+    saveSkillLevelConfig,
     type TOnboardingWardDraft,
-    type TOnboardingWardShiftType,
     type TSkillLevelConfig,
+    updateNurseDraft,
+    updateShiftTypeDraft,
 } from '../model';
 import type {TSortMode} from '../types';
 
-const MIN_STEP = 1;
 const MAX_STEP = 4;
-
-function getNextStep(step: TOnboardingStep): TOnboardingStep {
-    return Math.min(MAX_STEP, step + 1) as TOnboardingStep;
-}
-
-function getPreviousStep(step: TOnboardingStep): TOnboardingStep {
-    return Math.max(MIN_STEP, step - 1) as TOnboardingStep;
-}
 
 function useOnboardingWardWizard() {
     const [draft, setDraft] = useState<TOnboardingWardDraft>(() => createInitialDraft());
@@ -42,96 +41,51 @@ function useOnboardingWardWizard() {
 
     const selectedTeamExists = draft.teams.some((team) => team.id === selectedTeamId);
     const activeTeamId = selectedTeamExists ? selectedTeamId : (draft.teams[0]?.id ?? '');
-    const goToStep = (step: TOnboardingStep) => {
-        setDraft((prev) => ({...prev, currentStep: step}));
-    };
     const goNextStep = () => {
-        setDraft((prev) => ({...prev, currentStep: getNextStep(prev.currentStep)}));
+        setDraft((prev) => goNextStepDraft(prev));
     };
     const goPreviousStep = () => {
-        setDraft((prev) => ({...prev, currentStep: getPreviousStep(prev.currentStep)}));
+        setDraft((prev) => goPreviousStepDraft(prev));
     };
-    const updateShiftType = (shiftTypeId: string, updater: Partial<TOnboardingWardShiftType>) => {
-        setDraft((prev) => ({
-            ...prev,
-            shiftTypes: prev.shiftTypes.map((shiftType) => (shiftType.id === shiftTypeId ? {...shiftType, ...updater} : shiftType)),
-        }));
+    const updateShiftType = (shiftTypeId: string, updater: Parameters<typeof updateShiftTypeDraft>[2]) => {
+        setDraft((prev) => updateShiftTypeDraft(prev, shiftTypeId, updater));
     };
     const addShiftType = () => {
-        setDraft((prev) => ({
-            ...prev,
-            shiftTypes: [...prev.shiftTypes, createEmptyShiftType()],
-        }));
+        setDraft((prev) => addShiftTypeDraft(prev));
     };
     const deleteShiftType = (shiftTypeId: string) => {
-        setDraft((prev) => ({
-            ...prev,
-            shiftTypes: prev.shiftTypes.filter((shiftType) => shiftType.id !== shiftTypeId),
-            nurses: prev.nurses.map((nurse) => ({
-                ...nurse,
-                possibleShiftTypeIds: nurse.possibleShiftTypeIds.filter((value) => value !== shiftTypeId),
-            })),
-        }));
+        setDraft((prev) => deleteShiftTypeDraft(prev, shiftTypeId));
     };
-    const updateNurse = (nurseId: string, updater: Partial<TOnboardingNurseDraft>) => {
-        setDraft((prev) => ({
-            ...prev,
-            nurses: prev.nurses.map((nurse) => (nurse.id === nurseId ? {...nurse, ...updater} : nurse)),
-        }));
+    const updateNurse = (nurseId: string, updater: Parameters<typeof updateNurseDraft>[2]) => {
+        setDraft((prev) => updateNurseDraft(prev, nurseId, updater));
     };
     const addTeam = () => {
-        const team = {
-            id: `team-new-${draft.teams.length + 1}`,
-            name: `간호사 ${draft.teams.length + 1}팀`,
-        };
+        const {draft: nextDraft, addedTeamId} = addTeamDraft(draft);
 
-        setDraft((prev) => ({...prev, teams: [...prev.teams, team]}));
-        setSelectedTeamId(team.id);
+        setDraft(nextDraft);
+        setSelectedTeamId(addedTeamId);
     };
     const addNurse = () => {
-        if (!activeTeamId) {
-            return;
-        }
-
-        setDraft((prev) => ({
-            ...prev,
-            nurses: [...prev.nurses, createEmptyNurse(activeTeamId, prev.shiftTypes)],
-        }));
+        setDraft((prev) => addNurseDraft(prev, activeTeamId));
     };
     const handleNurseDragEnd = ({destination, source}: DropResult) => {
         if (!destination || !activeTeamId || destination.index === source.index || sortMode !== 'manual') {
             return;
         }
 
-        setDraft((prev) => {
-            const teamNurses = prev.nurses.filter((nurse) => nurse.teamId === activeTeamId);
-            const otherNurses = prev.nurses.filter((nurse) => nurse.teamId !== activeTeamId);
-            const nextNurses = [...teamNurses];
-            const [moved] = nextNurses.splice(source.index, 1);
-
-            if (!moved) {
-                return prev;
-            }
-
-            nextNurses.splice(destination.index, 0, moved);
-
-            return {
-                ...prev,
-                nurses: [...otherNurses, ...nextNurses],
-            };
-        });
+        setDraft((prev) => reorderNursesWithinTeam(prev, activeTeamId, {destination, source}));
     };
     const uploadMockFile = (fileName: string) => {
         setDraft((prev) => applyMockUpload(prev, fileName));
     };
     const saveSkillConfig = (config: TSkillLevelConfig) => {
-        setDraft((prev) => ({
-            ...prev,
-            skillLevelConfig: config,
-            nurses: applySkillLevels(prev.nurses, config),
-        }));
+        setDraft((prev) => saveSkillLevelConfig(prev, config));
     };
     const complete = () => {
+        if (!canComplete(draft)) {
+            return;
+        }
+
         const payload = serializeDraft(draft);
         const stringified = JSON.stringify(payload, null, 2);
 
@@ -152,14 +106,12 @@ function useOnboardingWardWizard() {
     return {
         draft,
         activeTeamId,
-        selectedTeamId,
         setSelectedTeamId,
         sortMode,
         setSortMode,
         showSkillModal,
         setShowSkillModal,
         completedPayload,
-        goToStep,
         goNextStep,
         goPreviousStep,
         skipOrComplete,
@@ -173,6 +125,10 @@ function useOnboardingWardWizard() {
         uploadMockFile,
         saveSkillConfig,
         complete,
+        currentStepValidation: getStepValidation(draft),
+        canGoPrev: canGoPrev(draft),
+        canGoNext: canGoNext(draft),
+        canComplete: canComplete(draft),
     };
 }
 

--- a/src/pages/OnboardingWardCreatePage/index.test.tsx
+++ b/src/pages/OnboardingWardCreatePage/index.test.tsx
@@ -30,6 +30,61 @@ describe('OnboardingWardCreatePage', () => {
         expect(screen.getAllByText('간호사 추가하기')[0]).toBeInTheDocument();
     });
 
+    it('disables next in step 2 when a shift type is invalid', async () => {
+        const user = userEvent.setup();
+
+        render(<OnboardingWardCreatePage />);
+
+        await user.click(screen.getByRole('button', {name: '다음'}));
+        await user.click(screen.getByRole('button', {name: '근무 추가하기'}));
+
+        const nextButton = screen.getByRole('button', {name: '다음'});
+
+        expect(nextButton).toBeDisabled();
+    });
+
+    it('disables next in step 3 when any team has no nurses', async () => {
+        const user = userEvent.setup();
+
+        render(<OnboardingWardCreatePage />);
+
+        await user.click(screen.getByRole('button', {name: '다음'}));
+        await user.click(screen.getByRole('button', {name: '다음'}));
+        await user.click(screen.getByRole('button', {name: /팀 추가하기/ }));
+
+        expect(screen.getByRole('button', {name: '다음'})).toBeDisabled();
+    });
+
+    it('disables next in step 3 when a nurse name is empty', async () => {
+        const user = userEvent.setup();
+
+        render(<OnboardingWardCreatePage />);
+
+        await user.click(screen.getByRole('button', {name: '다음'}));
+        await user.click(screen.getByRole('button', {name: '다음'}));
+
+        const nurseInputs = screen.getAllByDisplayValue(/홍길동|김하늘|박연우|이서윤/);
+
+        await user.clear(nurseInputs[0] as HTMLInputElement);
+
+        expect(screen.getByRole('button', {name: '다음'})).toBeDisabled();
+    });
+
+    it('allows skip to bypass validation and move to the next step', async () => {
+        const user = userEvent.setup();
+
+        render(<OnboardingWardCreatePage />);
+
+        await user.click(screen.getByRole('button', {name: '다음'}));
+        await user.click(screen.getByRole('button', {name: '근무 추가하기'}));
+
+        expect(screen.getByRole('button', {name: '다음'})).toBeDisabled();
+
+        await user.click(screen.getByRole('button', {name: '건너뛰기'}));
+
+        expect(screen.getAllByText('간호사 추가하기')[0]).toBeInTheDocument();
+    });
+
     it('updates skill level config and creates a mock payload on completion', async () => {
         const user = userEvent.setup();
 
@@ -37,7 +92,13 @@ describe('OnboardingWardCreatePage', () => {
 
         await user.click(screen.getByRole('button', {name: '건너뛰기'}));
         await user.click(screen.getByRole('button', {name: '다음'}));
-        await user.click(screen.getByRole('button', {name: '다음'}));
+
+        await user.click(screen.getByRole('button', {name: /간호사 2팀/}));
+        await user.click(screen.getAllByRole('button', {name: '간호사 추가하기'})[0]);
+        await user.click(screen.getByRole('button', {name: /간호사 3팀/}));
+        await user.click(screen.getAllByRole('button', {name: '간호사 추가하기'})[0]);
+        await user.click(screen.getByRole('button', {name: /간호사 1팀/}));
+
         await user.click(screen.getByRole('button', {name: '숙련도 설정'}));
 
         expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -45,7 +106,9 @@ describe('OnboardingWardCreatePage', () => {
         await user.selectOptions(screen.getByDisplayValue('5단계'), '3');
         await user.click(within(screen.getByRole('dialog')).getByRole('button', {name: '완료'}));
 
-        expect(screen.getAllByText('LV. 3').length).toBeGreaterThan(0);
+        await user.click(screen.getByRole('button', {name: '다음'}));
+
+        expect(screen.getAllByText((content) => content.includes('LV. 3')).length).toBeGreaterThan(0);
 
         await user.click(screen.getByRole('button', {name: '완료'}));
 

--- a/src/pages/OnboardingWardCreatePage/index.test.tsx
+++ b/src/pages/OnboardingWardCreatePage/index.test.tsx
@@ -85,6 +85,25 @@ describe('OnboardingWardCreatePage', () => {
         expect(screen.getAllByText('간호사 추가하기')[0]).toBeInTheDocument();
     });
 
+    it('disables completion when step 2 remains invalid after skipping ahead', async () => {
+        const user = userEvent.setup();
+
+        render(<OnboardingWardCreatePage />);
+
+        await user.click(screen.getByRole('button', {name: '다음'}));
+        await user.click(screen.getByRole('button', {name: '근무 추가하기'}));
+        await user.click(screen.getByRole('button', {name: '건너뛰기'}));
+
+        await user.click(screen.getByRole('button', {name: /간호사 2팀/}));
+        await user.click(screen.getAllByRole('button', {name: '간호사 추가하기'})[0]);
+        await user.click(screen.getByRole('button', {name: /간호사 3팀/}));
+        await user.click(screen.getAllByRole('button', {name: '간호사 추가하기'})[0]);
+
+        await user.click(screen.getByRole('button', {name: '다음'}));
+
+        expect(screen.getByRole('button', {name: '완료'})).toBeDisabled();
+    });
+
     it('updates skill level config and creates a mock payload on completion', async () => {
         const user = userEvent.setup();
 

--- a/src/pages/OnboardingWardCreatePage/index.tsx
+++ b/src/pages/OnboardingWardCreatePage/index.tsx
@@ -30,6 +30,8 @@ function OnboardingWardCreatePage() {
         uploadMockFile,
         saveSkillConfig,
         complete,
+        canGoNext,
+        canComplete,
     } = useOnboardingWardWizard();
     const stepContent = (() => {
         switch (draft.currentStep) {
@@ -80,6 +82,7 @@ function OnboardingWardCreatePage() {
                     onSkip={skipOrComplete}
                     onPrev={goPreviousStep}
                     onNext={draft.currentStep < 4 ? goNextStep : complete}
+                    nextDisabled={draft.currentStep < 4 ? !canGoNext : !canComplete}
                 >
                     {stepContent}
                 </OnboardingStepLayout>

--- a/src/pages/OnboardingWardCreatePage/model.test.ts
+++ b/src/pages/OnboardingWardCreatePage/model.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, it} from 'vitest';
+import {
+    addNurseDraft,
+    addShiftTypeDraft,
+    addTeamDraft,
+    canComplete,
+    canGoNext,
+    createInitialDraft,
+    deleteShiftTypeDraft,
+    getStepValidation,
+    reorderNursesWithinTeam,
+    updateNurseDraft,
+    updateShiftTypeDraft,
+} from './model';
+
+describe('OnboardingWardCreatePage model', () => {
+    it('returns validation issues for invalid shift types', () => {
+        const initialDraft = createInitialDraft();
+        const extraShiftDraft = addShiftTypeDraft({
+            ...initialDraft,
+            currentStep: 2,
+        });
+        const validation = getStepValidation(extraShiftDraft, 2);
+
+        expect(validation.isValid).toBe(false);
+        expect(validation.issues.map((issue) => issue.code)).toEqual(
+            expect.arrayContaining(['missing-shift-name', 'missing-shift-short-name']),
+        );
+        expect(canGoNext(extraShiftDraft)).toBe(false);
+    });
+
+    it('removes deleted shift ids from nurse possible shifts', () => {
+        const draft = createInitialDraft();
+        const deletedShiftId = draft.shiftTypes[0]?.id ?? '';
+        const nextDraft = deleteShiftTypeDraft(draft, deletedShiftId);
+
+        expect(nextDraft.shiftTypes.some((shiftType) => shiftType.id === deletedShiftId)).toBe(false);
+        expect(nextDraft.nurses.every((nurse) => !nurse.possibleShiftTypeIds.includes(deletedShiftId))).toBe(true);
+    });
+
+    it('flags empty teams and missing nurse names in nurse steps', () => {
+        const draft = createInitialDraft();
+        const {draft: draftWithTeam} = addTeamDraft({
+            ...draft,
+            currentStep: 3,
+        });
+        const nurseId = draftWithTeam.nurses[0]?.id ?? '';
+        const invalidDraft = updateNurseDraft(draftWithTeam, nurseId, {name: ''});
+        const validation = getStepValidation(invalidDraft, 3);
+
+        expect(validation.isValid).toBe(false);
+        expect(validation.issues.map((issue) => issue.code)).toEqual(expect.arrayContaining(['empty-team-nurses', 'missing-nurse-name']));
+        expect(canGoNext(invalidDraft)).toBe(false);
+    });
+
+    it('keeps nurse order changes scoped to the active team', () => {
+        const draft = createInitialDraft();
+        const activeTeamId = draft.teams[0]?.id ?? '';
+        const otherTeamId = draft.teams[1]?.id ?? '';
+        const otherTeamNurse = {
+            ...draft.nurses[0]!,
+            id: 'other-team-nurse',
+            teamId: otherTeamId,
+            name: '다른 팀 간호사',
+        };
+        const draftWithOtherTeamNurse = {
+            ...draft,
+            nurses: [...draft.nurses, otherTeamNurse],
+        };
+        const teamNursesBefore = draftWithOtherTeamNurse.nurses.filter((nurse) => nurse.teamId === activeTeamId);
+        const reordered = reorderNursesWithinTeam(draftWithOtherTeamNurse, activeTeamId, {
+            source: {droppableId: activeTeamId, index: 0},
+            destination: {droppableId: activeTeamId, index: 1},
+        });
+        const teamNursesAfter = reordered.nurses.filter((nurse) => nurse.teamId === activeTeamId);
+
+        expect(teamNursesAfter[0]?.id).toBe(teamNursesBefore[1]?.id);
+        expect(reordered.nurses.find((nurse) => nurse.id === otherTeamNurse.id)?.teamId).toBe(otherTeamId);
+    });
+
+    it('allows completion only when step 4 validation passes', () => {
+        const draft = createInitialDraft();
+        const withSecondTeamNurse = addNurseDraft(draft, draft.teams[1]!.id);
+        const withAllTeamNurses = addNurseDraft(withSecondTeamNurse, draft.teams[2]!.id);
+        const step4Draft = {
+            ...withAllTeamNurses,
+            currentStep: 4 as const,
+        };
+        const validShiftDraft = updateShiftTypeDraft(step4Draft, step4Draft.shiftTypes[0]!.id, {name: '데이 근무'});
+        const validNurseDraft = updateNurseDraft(validShiftDraft, validShiftDraft.nurses[0]!.id, {name: '홍길동'});
+
+        expect(canComplete(validNurseDraft)).toBe(true);
+
+        const invalidDraft = updateNurseDraft(validNurseDraft, validNurseDraft.nurses[0]!.id, {name: ''});
+
+        expect(canComplete(invalidDraft)).toBe(false);
+    });
+});

--- a/src/pages/OnboardingWardCreatePage/model.test.ts
+++ b/src/pages/OnboardingWardCreatePage/model.test.ts
@@ -95,4 +95,18 @@ describe('OnboardingWardCreatePage model', () => {
 
         expect(canComplete(invalidDraft)).toBe(false);
     });
+
+    it('blocks completion when an earlier required step is invalid', () => {
+        const draft = createInitialDraft();
+        const withSecondTeamNurse = addNurseDraft(draft, draft.teams[1]!.id);
+        const withAllTeamNurses = addNurseDraft(withSecondTeamNurse, draft.teams[2]!.id);
+        const invalidShiftDraft = addShiftTypeDraft({
+            ...withAllTeamNurses,
+            currentStep: 4,
+        });
+
+        expect(getStepValidation(invalidShiftDraft, 2).isValid).toBe(false);
+        expect(getStepValidation(invalidShiftDraft, 4).isValid).toBe(true);
+        expect(canComplete(invalidShiftDraft)).toBe(false);
+    });
 });

--- a/src/pages/OnboardingWardCreatePage/model.ts
+++ b/src/pages/OnboardingWardCreatePage/model.ts
@@ -99,6 +99,7 @@ const DEFAULT_SKILL_LEVEL_CONFIG: TSkillLevelConfig = {
 };
 const MIN_STEP = 1;
 const MAX_STEP = 4;
+const REQUIRED_COMPLETION_STEPS: TOnboardingStep[] = [2, 3, 4];
 
 let nextId = 0;
 
@@ -481,7 +482,7 @@ export const canGoNext = (draft: TOnboardingWardDraft): boolean =>
     draft.currentStep < MAX_STEP && getStepValidation(draft).isValid;
 
 export const canComplete = (draft: TOnboardingWardDraft): boolean =>
-    draft.currentStep === MAX_STEP && getStepValidation(draft, MAX_STEP).isValid;
+    draft.currentStep === MAX_STEP && REQUIRED_COMPLETION_STEPS.every((step) => getStepValidation(draft, step).isValid);
 
 export const getActionState = (draft: TOnboardingWardDraft): TOnboardingActionState => ({
     canGoPrev: canGoPrev(draft),

--- a/src/pages/OnboardingWardCreatePage/model.ts
+++ b/src/pages/OnboardingWardCreatePage/model.ts
@@ -1,3 +1,4 @@
+import {type DropResult} from '@hello-pangea/dnd';
 import {type TCreateWardDTO} from '@/shared/api/ward/type';
 
 export type TOnboardingStep = 1 | 2 | 3 | 4;
@@ -59,6 +60,33 @@ export type TMockCreateWardPayload = TCreateWardDTO & {
     };
 };
 
+export type TOnboardingValidationIssueCode =
+    | 'empty-shift-types'
+    | 'missing-shift-name'
+    | 'missing-shift-short-name'
+    | 'missing-shift-time'
+    | 'empty-team'
+    | 'empty-team-nurses'
+    | 'missing-nurse-name';
+
+export type TOnboardingValidationIssue = {
+    code: TOnboardingValidationIssueCode;
+    step: TOnboardingStep;
+    targetId?: string;
+};
+
+export type TOnboardingStepValidation = {
+    step: TOnboardingStep;
+    isValid: boolean;
+    issues: TOnboardingValidationIssue[];
+};
+
+export type TOnboardingActionState = {
+    canGoPrev: boolean;
+    canGoNext: boolean;
+    canComplete: boolean;
+};
+
 const SKILL_PALETTES: TSkillPalette[] = [
     {id: 'warm', colors: ['#FFA395', '#FFC0B6', '#FFC795', '#FFE195', '#FFF0B0']},
     {id: 'cool', colors: ['#9EC5FF', '#B7D6FF', '#CFE4FF', '#DFF0FF', '#ECF8FF']},
@@ -69,6 +97,8 @@ const DEFAULT_SKILL_LEVEL_CONFIG: TSkillLevelConfig = {
     paletteId: 'warm',
     autoAssign: true,
 };
+const MIN_STEP = 1;
+const MAX_STEP = 4;
 
 let nextId = 0;
 
@@ -136,6 +166,7 @@ const BASE_TEAMS: TOnboardingTeamDraft[] = [
     {id: createId('team'), name: '간호사 2팀'},
     {id: createId('team'), name: '간호사 3팀'},
 ];
+
 const createBaseNurses = (shiftTypes: TOnboardingWardShiftType[], teams: TOnboardingTeamDraft[]) => {
     const shiftTypeIds = shiftTypes.map((shiftType) => shiftType.id);
     const firstTeamId = teams[0]?.id ?? '';
@@ -265,6 +296,198 @@ export const applySkillLevels = (nurses: TOnboardingNurseDraft[], config: TSkill
         level: levelById.get(nurse.id) ?? levelCount,
     }));
 };
+
+export const goToStep = (draft: TOnboardingWardDraft, step: TOnboardingStep): TOnboardingWardDraft => ({
+    ...draft,
+    currentStep: step,
+});
+
+export const goNextStep = (draft: TOnboardingWardDraft): TOnboardingWardDraft => ({
+    ...draft,
+    currentStep: Math.min(MAX_STEP, draft.currentStep + 1) as TOnboardingStep,
+});
+
+export const goPreviousStep = (draft: TOnboardingWardDraft): TOnboardingWardDraft => ({
+    ...draft,
+    currentStep: Math.max(MIN_STEP, draft.currentStep - 1) as TOnboardingStep,
+});
+
+export const updateShiftTypeDraft = (
+    draft: TOnboardingWardDraft,
+    shiftTypeId: string,
+    updater: Partial<TOnboardingWardShiftType>,
+): TOnboardingWardDraft => ({
+    ...draft,
+    shiftTypes: draft.shiftTypes.map((shiftType) => (shiftType.id === shiftTypeId ? {...shiftType, ...updater} : shiftType)),
+});
+
+export const addShiftTypeDraft = (draft: TOnboardingWardDraft): TOnboardingWardDraft => ({
+    ...draft,
+    shiftTypes: [...draft.shiftTypes, createEmptyShiftType()],
+});
+
+export const deleteShiftTypeDraft = (draft: TOnboardingWardDraft, shiftTypeId: string): TOnboardingWardDraft => ({
+    ...draft,
+    shiftTypes: draft.shiftTypes.filter((shiftType) => shiftType.id !== shiftTypeId),
+    nurses: draft.nurses.map((nurse) => ({
+        ...nurse,
+        possibleShiftTypeIds: nurse.possibleShiftTypeIds.filter((value) => value !== shiftTypeId),
+    })),
+});
+
+export const updateNurseDraft = (
+    draft: TOnboardingWardDraft,
+    nurseId: string,
+    updater: Partial<TOnboardingNurseDraft>,
+): TOnboardingWardDraft => ({
+    ...draft,
+    nurses: draft.nurses.map((nurse) => (nurse.id === nurseId ? {...nurse, ...updater} : nurse)),
+});
+
+export const addTeamDraft = (draft: TOnboardingWardDraft) => {
+    const team = {
+        id: `team-new-${draft.teams.length + 1}`,
+        name: `간호사 ${draft.teams.length + 1}팀`,
+    };
+
+    return {
+        draft: {
+            ...draft,
+            teams: [...draft.teams, team],
+        },
+        addedTeamId: team.id,
+    };
+};
+
+export const addNurseDraft = (draft: TOnboardingWardDraft, teamId: string): TOnboardingWardDraft => {
+    if (!teamId) {
+        return draft;
+    }
+
+    return {
+        ...draft,
+        nurses: [...draft.nurses, createEmptyNurse(teamId, draft.shiftTypes)],
+    };
+};
+
+export const reorderNursesWithinTeam = (
+    draft: TOnboardingWardDraft,
+    teamId: string,
+    result: Pick<DropResult, 'destination' | 'source'>,
+): TOnboardingWardDraft => {
+    const {destination, source} = result;
+
+    if (!destination || !teamId || destination.index === source.index) {
+        return draft;
+    }
+
+    const teamNurses = draft.nurses.filter((nurse) => nurse.teamId === teamId);
+    const otherNurses = draft.nurses.filter((nurse) => nurse.teamId !== teamId);
+    const nextNurses = [...teamNurses];
+    const [moved] = nextNurses.splice(source.index, 1);
+
+    if (!moved) {
+        return draft;
+    }
+
+    nextNurses.splice(destination.index, 0, moved);
+
+    return {
+        ...draft,
+        nurses: [...otherNurses, ...nextNurses],
+    };
+};
+
+export const saveSkillLevelConfig = (draft: TOnboardingWardDraft, config: TSkillLevelConfig): TOnboardingWardDraft => ({
+    ...draft,
+    skillLevelConfig: config,
+    nurses: applySkillLevels(draft.nurses, config),
+});
+
+const validateShiftTypes = (draft: TOnboardingWardDraft): TOnboardingValidationIssue[] => {
+    const issues: TOnboardingValidationIssue[] = [];
+
+    if (draft.shiftTypes.length === 0) {
+        issues.push({code: 'empty-shift-types', step: 2});
+    }
+
+    draft.shiftTypes.forEach((shiftType) => {
+        if (!shiftType.name.trim()) {
+            issues.push({code: 'missing-shift-name', step: 2, targetId: shiftType.id});
+        }
+
+        if (!shiftType.shortName.trim()) {
+            issues.push({code: 'missing-shift-short-name', step: 2, targetId: shiftType.id});
+        }
+
+        if (!shiftType.isOff && (!shiftType.startTime.trim() || !shiftType.endTime.trim())) {
+            issues.push({code: 'missing-shift-time', step: 2, targetId: shiftType.id});
+        }
+    });
+
+    return issues;
+};
+
+const validateTeamsAndNurses = (draft: TOnboardingWardDraft, step: 3 | 4): TOnboardingValidationIssue[] => {
+    const issues: TOnboardingValidationIssue[] = [];
+
+    if (draft.teams.length === 0) {
+        issues.push({code: 'empty-team', step});
+    }
+
+    draft.teams.forEach((team) => {
+        const nurses = draft.nurses.filter((nurse) => nurse.teamId === team.id);
+
+        if (nurses.length === 0) {
+            issues.push({code: 'empty-team-nurses', step, targetId: team.id});
+        }
+
+        nurses.forEach((nurse) => {
+            if (!nurse.name.trim()) {
+                issues.push({code: 'missing-nurse-name', step, targetId: nurse.id});
+            }
+        });
+    });
+
+    return issues;
+};
+
+export const getStepValidation = (draft: TOnboardingWardDraft, step = draft.currentStep): TOnboardingStepValidation => {
+    let issues: TOnboardingValidationIssue[] = [];
+
+    switch (step) {
+        case 1:
+            issues = [];
+            break;
+        case 2:
+            issues = validateShiftTypes(draft);
+            break;
+        case 3:
+        case 4:
+            issues = validateTeamsAndNurses(draft, step);
+            break;
+    }
+
+    return {
+        step,
+        isValid: issues.length === 0,
+        issues,
+    };
+};
+
+export const canGoPrev = (draft: Pick<TOnboardingWardDraft, 'currentStep'>): boolean => draft.currentStep > MIN_STEP;
+
+export const canGoNext = (draft: TOnboardingWardDraft): boolean =>
+    draft.currentStep < MAX_STEP && getStepValidation(draft).isValid;
+
+export const canComplete = (draft: TOnboardingWardDraft): boolean =>
+    draft.currentStep === MAX_STEP && getStepValidation(draft, MAX_STEP).isValid;
+
+export const getActionState = (draft: TOnboardingWardDraft): TOnboardingActionState => ({
+    canGoPrev: canGoPrev(draft),
+    canGoNext: canGoNext(draft),
+    canComplete: canComplete(draft),
+});
 
 export const serializeDraft = (draft: TOnboardingWardDraft): TMockCreateWardPayload => {
     const teamById = new Map(draft.teams.map((team) => [team.id, team.name]));


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-834](https://gom3.atlassian.net/browse/DUT-834)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 온보딩 병동 생성 draft 변경 로직을 `model.ts` 중심의 순수 함수로 옮기고, wizard 훅은 상태 조합과 이벤트 위임에 집중하도록 정리했습니다.
- step별 validation 규칙과 `다음/완료` 가능 여부 계산을 분리해, 근무유형/팀/간호사 예외 케이스를 일관되게 판정하도록 변경했습니다.
- 온보딩 페이지 테스트와 model 단위 테스트를 추가해 validation gating, 건너뛰기 동작, shift 삭제 정합성을 검증했습니다.

<br>

## To Reviewers

- step 3/4 validation은 현재 "모든 팀에 최소 1명의 간호사가 있어야 함" 기준으로 고정했습니다.
- 검증은 `pnpm run test:run -- src/pages/OnboardingWardCreatePage/index.test.tsx src/pages/OnboardingWardCreatePage/model.test.ts`, `pnpm run type-check` 로 확인했습니다.


[DUT-834]: https://gom3.atlassian.net/browse/DUT-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ