### PR TITLE
fix: stabilize cypress e2e ci install

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,6 +16,8 @@ jobs:
         run: npm install -g pnpm
       - name: npm ci
         run: PUPPETEER_DOWNLOAD_BASE_URL="https://storage.googleapis.com/chrome-for-testing-public" pnpm install --frozen-lockfile
+      - name: Install Cypress binary
+        run: pnpm exec cypress install
       - name: Cypress run
         uses: cypress-io/github-action@v6
         env:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,12 @@
         "changeset:version": "changeset version",
         "type-check": "tsc -b"
     },
+    "pnpm": {
+        "onlyBuiltDependencies": [
+            "cypress",
+            "puppeteer"
+        ]
+    },
     "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
## Summary
- add an explicit Cypress binary install step in the E2E workflow
- allow pnpm build scripts for cypress and puppeteer at the repo level
- unblock GitHub Actions from failing at `cypress verify` before tests start

## Verification
- pnpm install --frozen-lockfile
- pnpm exec cypress verify
- pnpm test:run