### PR TITLE
[DUT-835]: 온보딩 병동 생성 payload adapter 및 파싱 응답 반영 준비

### DIFF
--- a/src/pages/OnboardingWardCreatePage/adapter.test.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 import {applyParsedWardData, buildCreateWardPayload, buildMockCreateWardPayload} from './adapter';
-import {createInitialDraft} from './model';
+import {createInitialDraft, saveSkillLevelConfig} from './model';
 
 describe('OnboardingWardCreatePage adapter', () => {
     it('builds create ward payload outside the UI draft layer', () => {
@@ -84,7 +84,11 @@ describe('OnboardingWardCreatePage adapter', () => {
     });
 
     it('builds a mock preview payload with parse-friendly nurse metadata', () => {
-        const draft = createInitialDraft();
+        const draft = saveSkillLevelConfig(createInitialDraft(), {
+            levelCount: 3,
+            paletteId: 'warm',
+            autoAssign: true,
+        });
         const payload = buildMockCreateWardPayload(draft);
 
         expect(payload.nurses[0]).toMatchObject({

--- a/src/pages/OnboardingWardCreatePage/adapter.test.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from 'vitest';
+import {applyParsedWardData, buildCreateWardPayload, buildMockCreateWardPayload} from './adapter';
+import {createInitialDraft} from './model';
+
+describe('OnboardingWardCreatePage adapter', () => {
+    it('builds create ward payload outside the UI draft layer', () => {
+        const draft = createInitialDraft();
+        const payload = buildCreateWardPayload(draft);
+
+        expect(payload).toEqual({
+            name: draft.wardName,
+            hospitalName: draft.hospitalName,
+            wardShiftTypes: draft.shiftTypes.map(({id: _id, ...shiftType}) => shiftType),
+            shiftTeams: draft.teams.map((team) => ({
+                nurseNames: draft.nurses.filter((nurse) => nurse.teamId === team.id).map((nurse) => nurse.name),
+            })),
+        });
+    });
+
+    it('applies parsed response data as draft bootstrap values', () => {
+        const draft = createInitialDraft();
+        const nextDraft = applyParsedWardData(draft, {
+            fileName: 'ward.xlsx',
+            wardName: '중환자실',
+            hospitalName: '듀팅병원',
+            shiftTypes: [
+                {name: '데이', shortName: 'D', color: '#111111', classification: 'DAY'},
+                {name: '오프', shortName: 'O', color: '#222222', isOff: true, classification: 'OFF'},
+            ],
+            nurses: [
+                {
+                    name: '신규 간호사',
+                    teamName: 'A팀',
+                    possibleShiftShortNames: ['D'],
+                    employmentDate: '2025-01-01',
+                    level: 2,
+                },
+            ],
+        });
+
+        expect(nextDraft.uploadedFileName).toBe('ward.xlsx');
+        expect(nextDraft.wardName).toBe('중환자실');
+        expect(nextDraft.hospitalName).toBe('듀팅병원');
+        expect(nextDraft.teams).toHaveLength(1);
+        expect(nextDraft.teams[0]?.name).toBe('A팀');
+        expect(nextDraft.nurses[0]?.teamId).toBe(nextDraft.teams[0]?.id);
+        expect(nextDraft.nurses[0]?.possibleShiftTypeIds).toEqual([nextDraft.shiftTypes[0]?.id]);
+    });
+
+    it('builds a mock preview payload with parse-friendly nurse metadata', () => {
+        const draft = createInitialDraft();
+        const payload = buildMockCreateWardPayload(draft);
+
+        expect(payload.nurses[0]).toMatchObject({
+            name: draft.nurses[0]?.name,
+            teamName: draft.teams[0]?.name,
+        });
+        expect(payload.skillLevelConfig.palette).toHaveLength(draft.skillLevelConfig.levelCount);
+    });
+});

--- a/src/pages/OnboardingWardCreatePage/adapter.test.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.test.ts
@@ -47,6 +47,42 @@ describe('OnboardingWardCreatePage adapter', () => {
         expect(nextDraft.nurses[0]?.possibleShiftTypeIds).toEqual([nextDraft.shiftTypes[0]?.id]);
     });
 
+    it('infers standard shift classifications from parsed short names', () => {
+        const draft = createInitialDraft();
+        const nextDraft = applyParsedWardData(draft, {
+            shiftTypes: [
+                {name: '데이', shortName: 'D'},
+                {name: '이브닝', shortName: 'E'},
+                {name: '나이트', shortName: 'N'},
+                {name: '오프', shortName: 'O', isOff: true},
+            ],
+        });
+
+        expect(nextDraft.shiftTypes.map((shiftType) => shiftType.classification)).toEqual(['DAY', 'EVENING', 'NIGHT', 'OFF']);
+    });
+
+    it('falls back to default possible shifts when parsed shift mappings are empty', () => {
+        const draft = createInitialDraft();
+        const nextDraft = applyParsedWardData(draft, {
+            nurses: [
+                {
+                    name: '신규 간호사',
+                    teamName: draft.teams[0]?.name,
+                    possibleShiftShortNames: [],
+                },
+                {
+                    name: '다른 간호사',
+                    teamName: draft.teams[0]?.name,
+                    possibleShiftShortNames: ['UNKNOWN'],
+                },
+            ],
+        });
+        const defaultShiftTypeIds = nextDraft.shiftTypes.filter((shiftType) => !shiftType.isOff).map((shiftType) => shiftType.id);
+
+        expect(nextDraft.nurses[0]?.possibleShiftTypeIds).toEqual(defaultShiftTypeIds);
+        expect(nextDraft.nurses[1]?.possibleShiftTypeIds).toEqual(defaultShiftTypeIds);
+    });
+
     it('builds a mock preview payload with parse-friendly nurse metadata', () => {
         const draft = createInitialDraft();
         const payload = buildMockCreateWardPayload(draft);

--- a/src/pages/OnboardingWardCreatePage/adapter.test.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.test.ts
@@ -7,13 +7,13 @@ describe('OnboardingWardCreatePage adapter', () => {
         const draft = createInitialDraft();
         const payload = buildCreateWardPayload(draft);
 
-        expect(payload).toEqual({
-            name: draft.wardName,
-            hospitalName: draft.hospitalName,
-            wardShiftTypes: draft.shiftTypes.map(({id: _id, ...shiftType}) => shiftType),
-            shiftTeams: draft.teams.map((team) => ({
-                nurseNames: draft.nurses.filter((nurse) => nurse.teamId === team.id).map((nurse) => nurse.name),
-            })),
+        expect(payload).toHaveProperty('name', draft.wardName);
+        expect(payload).toHaveProperty('hospitalName', draft.hospitalName);
+        expect(payload.wardShiftTypes).toHaveLength(draft.shiftTypes.length);
+        expect(payload.wardShiftTypes[0]).not.toHaveProperty('id');
+        expect(payload.shiftTeams).toHaveLength(draft.teams.length);
+        expect(payload.shiftTeams[0]).toEqual({
+            nurseNames: ['홍길동', '김하늘', '박연우', '이서윤'],
         });
     });
 
@@ -81,6 +81,21 @@ describe('OnboardingWardCreatePage adapter', () => {
 
         expect(nextDraft.nurses[0]?.possibleShiftTypeIds).toEqual(defaultShiftTypeIds);
         expect(nextDraft.nurses[1]?.possibleShiftTypeIds).toEqual(defaultShiftTypeIds);
+    });
+
+    it('fills missing parsed employmentDate with today', () => {
+        const draft = createInitialDraft();
+        const today = new Date().toISOString().slice(0, 10);
+        const nextDraft = applyParsedWardData(draft, {
+            nurses: [
+                {
+                    name: '신규 간호사',
+                    teamName: draft.teams[0]?.name,
+                },
+            ],
+        });
+
+        expect(nextDraft.nurses[0]?.employmentDate).toBe(today);
     });
 
     it('builds a mock preview payload with parse-friendly nurse metadata', () => {

--- a/src/pages/OnboardingWardCreatePage/adapter.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.ts
@@ -55,6 +55,16 @@ const SHIFT_TIME_RANGES: Record<string, {startTime: string; endTime: string}> = 
     N: {startTime: '23:00', endTime: '07:00'},
 };
 const createLocalId = (prefix: string) => `${prefix}-${uuidv4()}`;
+const getTodayDate = () => new Date().toISOString().slice(0, 10);
+const requireFirstTeamId = (teams: TOnboardingTeamDraft[]) => {
+    const firstTeamId = teams[0]?.id;
+
+    if (!firstTeamId) {
+        throw new Error('Onboarding draft invariant violated: empty-team');
+    }
+
+    return firstTeamId;
+};
 const inferClassificationFromShortName = (shortName: string, isOff: boolean): TOnboardingWardShiftType['classification'] => {
     if (isOff) return 'OFF';
 
@@ -129,7 +139,7 @@ const remapTeamIds = (
 ): TOnboardingNurseDraft[] => {
     const prevTeamNameById = new Map(prevTeams.map((team) => [team.id, team.name]));
     const nextTeamIdByName = new Map(nextTeams.map((team) => [team.name, team.id]));
-    const fallbackTeamId = nextTeams[0]?.id ?? '';
+    const fallbackTeamId = requireFirstTeamId(nextTeams);
 
     return nurses.map((nurse) => ({
         ...nurse,
@@ -161,7 +171,7 @@ const buildParsedNurses = (
     const teamIdByName = new Map(teams.map((team) => [team.name, team.id]));
     const shiftIdByShortName = new Map(shiftTypes.map((shiftType) => [shiftType.shortName, shiftType.id]));
     const defaultShiftTypeIds = shiftTypes.filter((shiftType) => !shiftType.isOff).map((shiftType) => shiftType.id);
-    const fallbackTeamId = teams[0]?.id ?? '';
+    const fallbackTeamId = requireFirstTeamId(teams);
 
     return parsedNurses.map((nurse, index) => {
         const possibleShiftTypeIds =
@@ -175,7 +185,7 @@ const buildParsedNurses = (
             name: nurse.name ?? '',
             memo: nurse.memo ?? '',
             isWorker: nurse.isWorker ?? true,
-            employmentDate: nurse.employmentDate ?? '2024-01-01',
+            employmentDate: nurse.employmentDate ?? getTodayDate(),
             possibleShiftTypeIds: possibleShiftTypeIds.length > 0 ? possibleShiftTypeIds : defaultShiftTypeIds,
             level: nurse.level ?? null,
         };

--- a/src/pages/OnboardingWardCreatePage/adapter.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.ts
@@ -1,3 +1,4 @@
+import {v4 as uuidv4} from 'uuid';
 import {type TCreateWardDTO} from '@/shared/api/ward/type';
 import {
     createEmptyShiftType,
@@ -48,7 +49,12 @@ export type TOnboardingParsedWardData = {
     skillLevelConfig?: Partial<TSkillLevelConfig>;
 };
 
-const createLocalId = (prefix: string) => `${prefix}-${crypto.randomUUID()}`;
+const SHIFT_TIME_RANGES: Record<string, {startTime: string; endTime: string}> = {
+    D: {startTime: '07:00', endTime: '15:00'},
+    E: {startTime: '15:00', endTime: '23:00'},
+    N: {startTime: '23:00', endTime: '07:00'},
+};
+const createLocalId = (prefix: string) => `${prefix}-${uuidv4()}`;
 const inferClassificationFromShortName = (shortName: string, isOff: boolean): TOnboardingWardShiftType['classification'] => {
     if (isOff) return 'OFF';
 
@@ -60,21 +66,18 @@ const inferClassificationFromShortName = (shortName: string, isOff: boolean): TO
         case 'N':
             return 'NIGHT';
         case 'O':
+            // Parse payloads can contain an "O" short name before isOff is normalized.
             return 'OFF';
         default:
             return 'OTHER_WORK';
     }
 };
 const normalizeUploadedShiftTypes = (shiftTypes: TOnboardingWardShiftType[]): TOnboardingWardShiftType[] =>
-    shiftTypes.map((shiftType) =>
-        shiftType.shortName === 'D'
-            ? {...shiftType, startTime: '07:00', endTime: '15:00'}
-            : shiftType.shortName === 'E'
-              ? {...shiftType, startTime: '15:00', endTime: '23:00'}
-              : shiftType.shortName === 'N'
-                ? {...shiftType, startTime: '23:00', endTime: '07:00'}
-                : shiftType,
-    );
+    shiftTypes.map((shiftType) => {
+        const timeRange = SHIFT_TIME_RANGES[shiftType.shortName];
+
+        return timeRange ? {...shiftType, ...timeRange} : shiftType;
+    });
 const toDraftShiftType = (parsed: TOnboardingParsedShiftType): TOnboardingWardShiftType => {
     const base = createEmptyShiftType();
     const shortName = parsed.shortName ?? base.shortName;
@@ -229,7 +232,7 @@ export const buildMockCreateWardPayload = (draft: TOnboardingWardDraft): TMockCr
         })),
         skillLevelConfig: {
             ...draft.skillLevelConfig,
-            palette: palette.colors,
+            palette: palette.colors.slice(0, draft.skillLevelConfig.levelCount),
         },
     };
 };

--- a/src/pages/OnboardingWardCreatePage/adapter.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.ts
@@ -1,0 +1,213 @@
+import {type TCreateWardDTO} from '@/shared/api/ward/type';
+import {
+    createEmptyShiftType,
+    getSkillPalette,
+    type TOnboardingNurseDraft,
+    type TOnboardingTeamDraft,
+    type TOnboardingWardDraft,
+    type TOnboardingWardShiftType,
+    type TSkillLevelConfig,
+} from './model';
+
+export type TMockCreateWardPayload = TCreateWardDTO & {
+    nurses: Array<{
+        name: string;
+        memo: string;
+        isWorker: boolean;
+        employmentDate: string;
+        teamName: string;
+        level: number | null;
+        possibleShiftShortNames: string[];
+    }>;
+    skillLevelConfig: TSkillLevelConfig & {
+        palette: string[];
+    };
+};
+
+export type TOnboardingParsedShiftType = Partial<Omit<TCreateWardDTO['wardShiftTypes'][number], 'isCounted'>> & {
+    name?: string;
+    shortName?: string;
+};
+
+export type TOnboardingParsedTeam = {
+    name: string;
+};
+
+export type TOnboardingParsedNurse = Partial<Pick<TOnboardingNurseDraft, 'name' | 'memo' | 'isWorker' | 'employmentDate' | 'level'>> & {
+    teamName?: string;
+    possibleShiftShortNames?: string[];
+};
+
+export type TOnboardingParsedWardData = {
+    fileName?: string;
+    wardName?: string;
+    hospitalName?: string;
+    shiftTypes?: TOnboardingParsedShiftType[];
+    teams?: TOnboardingParsedTeam[];
+    nurses?: TOnboardingParsedNurse[];
+    skillLevelConfig?: Partial<TSkillLevelConfig>;
+};
+
+const createLocalId = (prefix: string) => `${prefix}-${crypto.randomUUID()}`;
+const normalizeUploadedShiftTypes = (shiftTypes: TOnboardingWardShiftType[]): TOnboardingWardShiftType[] =>
+    shiftTypes.map((shiftType) =>
+        shiftType.shortName === 'D'
+            ? {...shiftType, startTime: '07:00', endTime: '15:00'}
+            : shiftType.shortName === 'E'
+              ? {...shiftType, startTime: '15:00', endTime: '23:00'}
+              : shiftType.shortName === 'N'
+                ? {...shiftType, startTime: '23:00', endTime: '07:00'}
+                : shiftType,
+    );
+const toDraftShiftType = (parsed: TOnboardingParsedShiftType): TOnboardingWardShiftType => {
+    const base = createEmptyShiftType();
+
+    return {
+        ...base,
+        id: createLocalId('shift'),
+        name: parsed.name ?? base.name,
+        shortName: parsed.shortName ?? base.shortName,
+        startTime: parsed.startTime ?? base.startTime,
+        endTime: parsed.endTime ?? base.endTime,
+        color: parsed.color ?? base.color,
+        isDefault: parsed.isDefault ?? false,
+        isOff: parsed.isOff ?? false,
+        classification: parsed.classification ?? (parsed.isOff ? 'OFF' : base.classification),
+    };
+};
+const buildDraftTeams = (names: string[]): TOnboardingTeamDraft[] =>
+    names.map((name, index) => ({
+        id: createLocalId(`team-${index + 1}`),
+        name,
+    }));
+const remapPossibleShiftTypeIds = (
+    nurses: TOnboardingNurseDraft[],
+    prevShiftTypes: TOnboardingWardShiftType[],
+    nextShiftTypes: TOnboardingWardShiftType[],
+): TOnboardingNurseDraft[] => {
+    const prevShortNameById = new Map(prevShiftTypes.map((shiftType) => [shiftType.id, shiftType.shortName]));
+    const nextIdByShortName = new Map(nextShiftTypes.map((shiftType) => [shiftType.shortName, shiftType.id]));
+    const defaultShiftTypeIds = nextShiftTypes.filter((shiftType) => !shiftType.isOff).map((shiftType) => shiftType.id);
+
+    return nurses.map((nurse) => {
+        const nextPossibleShiftTypeIds = nurse.possibleShiftTypeIds
+            .map((shiftTypeId) => prevShortNameById.get(shiftTypeId))
+            .map((shortName) => (shortName ? nextIdByShortName.get(shortName) : undefined))
+            .filter((shiftTypeId): shiftTypeId is string => Boolean(shiftTypeId));
+
+        return {
+            ...nurse,
+            possibleShiftTypeIds: nextPossibleShiftTypeIds.length > 0 ? nextPossibleShiftTypeIds : defaultShiftTypeIds,
+        };
+    });
+};
+const remapTeamIds = (
+    nurses: TOnboardingNurseDraft[],
+    prevTeams: TOnboardingTeamDraft[],
+    nextTeams: TOnboardingTeamDraft[],
+): TOnboardingNurseDraft[] => {
+    const prevTeamNameById = new Map(prevTeams.map((team) => [team.id, team.name]));
+    const nextTeamIdByName = new Map(nextTeams.map((team) => [team.name, team.id]));
+    const fallbackTeamId = nextTeams[0]?.id ?? '';
+
+    return nurses.map((nurse) => ({
+        ...nurse,
+        teamId: nextTeamIdByName.get(prevTeamNameById.get(nurse.teamId) ?? '') ?? fallbackTeamId,
+    }));
+};
+const buildParsedTeams = (parsed: TOnboardingParsedWardData): TOnboardingTeamDraft[] | null => {
+    const teamNames = new Set<string>();
+
+    parsed.teams?.forEach((team) => {
+        if (team.name.trim()) teamNames.add(team.name.trim());
+    });
+
+    parsed.nurses?.forEach((nurse) => {
+        if (nurse.teamName?.trim()) teamNames.add(nurse.teamName.trim());
+    });
+
+    if (teamNames.size === 0) {
+        return null;
+    }
+
+    return buildDraftTeams(Array.from(teamNames));
+};
+const buildParsedNurses = (
+    parsedNurses: TOnboardingParsedNurse[],
+    teams: TOnboardingTeamDraft[],
+    shiftTypes: TOnboardingWardShiftType[],
+): TOnboardingNurseDraft[] => {
+    const teamIdByName = new Map(teams.map((team) => [team.name, team.id]));
+    const shiftIdByShortName = new Map(shiftTypes.map((shiftType) => [shiftType.shortName, shiftType.id]));
+    const defaultShiftTypeIds = shiftTypes.filter((shiftType) => !shiftType.isOff).map((shiftType) => shiftType.id);
+    const fallbackTeamId = teams[0]?.id ?? '';
+
+    return parsedNurses.map((nurse, index) => ({
+        id: createLocalId(`nurse-${index + 1}`),
+        teamId: teamIdByName.get(nurse.teamName?.trim() ?? '') ?? fallbackTeamId,
+        name: nurse.name ?? '',
+        memo: nurse.memo ?? '',
+        isWorker: nurse.isWorker ?? true,
+        employmentDate: nurse.employmentDate ?? '2024-01-01',
+        possibleShiftTypeIds:
+            nurse.possibleShiftShortNames
+                ?.map((shortName) => shiftIdByShortName.get(shortName))
+                .filter((shiftTypeId): shiftTypeId is string => Boolean(shiftTypeId)) ?? defaultShiftTypeIds,
+        level: nurse.level ?? null,
+    }));
+};
+
+export const applyParsedWardData = (draft: TOnboardingWardDraft, parsed: TOnboardingParsedWardData): TOnboardingWardDraft => {
+    const nextShiftTypes = parsed.shiftTypes
+        ? normalizeUploadedShiftTypes(parsed.shiftTypes.map(toDraftShiftType))
+        : normalizeUploadedShiftTypes(draft.shiftTypes);
+    const nextTeams = buildParsedTeams(parsed) ?? draft.teams;
+    const nextNurses = parsed.nurses
+        ? buildParsedNurses(parsed.nurses, nextTeams, nextShiftTypes)
+        : remapTeamIds(remapPossibleShiftTypeIds(draft.nurses, draft.shiftTypes, nextShiftTypes), draft.teams, nextTeams);
+
+    return {
+        ...draft,
+        uploadedFileName: parsed.fileName ?? draft.uploadedFileName,
+        wardName: parsed.wardName ?? draft.wardName,
+        hospitalName: parsed.hospitalName ?? draft.hospitalName,
+        shiftTypes: nextShiftTypes,
+        teams: nextTeams,
+        nurses: nextNurses,
+        skillLevelConfig: parsed.skillLevelConfig ? {...draft.skillLevelConfig, ...parsed.skillLevelConfig} : draft.skillLevelConfig,
+    };
+};
+
+export const buildCreateWardPayload = (draft: TOnboardingWardDraft): TCreateWardDTO => ({
+    name: draft.wardName,
+    hospitalName: draft.hospitalName,
+    wardShiftTypes: draft.shiftTypes.map(({id: _id, ...shiftType}) => shiftType),
+    shiftTeams: draft.teams.map((team) => ({
+        nurseNames: draft.nurses.filter((nurse) => nurse.teamId === team.id).map((nurse) => nurse.name),
+    })),
+});
+
+export const buildMockCreateWardPayload = (draft: TOnboardingWardDraft): TMockCreateWardPayload => {
+    const teamById = new Map(draft.teams.map((team) => [team.id, team.name]));
+    const shiftTypeById = new Map(draft.shiftTypes.map((shiftType) => [shiftType.id, shiftType]));
+    const palette = getSkillPalette(draft.skillLevelConfig.paletteId);
+
+    return {
+        ...buildCreateWardPayload(draft),
+        nurses: draft.nurses.map((nurse) => ({
+            name: nurse.name,
+            memo: nurse.memo,
+            isWorker: nurse.isWorker,
+            employmentDate: nurse.employmentDate,
+            teamName: teamById.get(nurse.teamId) ?? '',
+            level: nurse.level,
+            possibleShiftShortNames: nurse.possibleShiftTypeIds
+                .map((shiftTypeId) => shiftTypeById.get(shiftTypeId)?.shortName ?? '')
+                .filter(Boolean),
+        })),
+        skillLevelConfig: {
+            ...draft.skillLevelConfig,
+            palette: palette.colors,
+        },
+    };
+};

--- a/src/pages/OnboardingWardCreatePage/adapter.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.ts
@@ -49,6 +49,22 @@ export type TOnboardingParsedWardData = {
 };
 
 const createLocalId = (prefix: string) => `${prefix}-${crypto.randomUUID()}`;
+const inferClassificationFromShortName = (shortName: string, isOff: boolean): TOnboardingWardShiftType['classification'] => {
+    if (isOff) return 'OFF';
+
+    switch (shortName.toUpperCase()) {
+        case 'D':
+            return 'DAY';
+        case 'E':
+            return 'EVENING';
+        case 'N':
+            return 'NIGHT';
+        case 'O':
+            return 'OFF';
+        default:
+            return 'OTHER_WORK';
+    }
+};
 const normalizeUploadedShiftTypes = (shiftTypes: TOnboardingWardShiftType[]): TOnboardingWardShiftType[] =>
     shiftTypes.map((shiftType) =>
         shiftType.shortName === 'D'
@@ -61,18 +77,20 @@ const normalizeUploadedShiftTypes = (shiftTypes: TOnboardingWardShiftType[]): TO
     );
 const toDraftShiftType = (parsed: TOnboardingParsedShiftType): TOnboardingWardShiftType => {
     const base = createEmptyShiftType();
+    const shortName = parsed.shortName ?? base.shortName;
+    const isOff = parsed.isOff ?? false;
 
     return {
         ...base,
         id: createLocalId('shift'),
         name: parsed.name ?? base.name,
-        shortName: parsed.shortName ?? base.shortName,
+        shortName,
         startTime: parsed.startTime ?? base.startTime,
         endTime: parsed.endTime ?? base.endTime,
         color: parsed.color ?? base.color,
         isDefault: parsed.isDefault ?? false,
-        isOff: parsed.isOff ?? false,
-        classification: parsed.classification ?? (parsed.isOff ? 'OFF' : base.classification),
+        isOff,
+        classification: parsed.classification ?? inferClassificationFromShortName(shortName, isOff),
     };
 };
 const buildDraftTeams = (names: string[]): TOnboardingTeamDraft[] =>
@@ -142,19 +160,23 @@ const buildParsedNurses = (
     const defaultShiftTypeIds = shiftTypes.filter((shiftType) => !shiftType.isOff).map((shiftType) => shiftType.id);
     const fallbackTeamId = teams[0]?.id ?? '';
 
-    return parsedNurses.map((nurse, index) => ({
-        id: createLocalId(`nurse-${index + 1}`),
-        teamId: teamIdByName.get(nurse.teamName?.trim() ?? '') ?? fallbackTeamId,
-        name: nurse.name ?? '',
-        memo: nurse.memo ?? '',
-        isWorker: nurse.isWorker ?? true,
-        employmentDate: nurse.employmentDate ?? '2024-01-01',
-        possibleShiftTypeIds:
+    return parsedNurses.map((nurse, index) => {
+        const possibleShiftTypeIds =
             nurse.possibleShiftShortNames
                 ?.map((shortName) => shiftIdByShortName.get(shortName))
-                .filter((shiftTypeId): shiftTypeId is string => Boolean(shiftTypeId)) ?? defaultShiftTypeIds,
-        level: nurse.level ?? null,
-    }));
+                .filter((shiftTypeId): shiftTypeId is string => Boolean(shiftTypeId)) ?? defaultShiftTypeIds;
+
+        return {
+            id: createLocalId(`nurse-${index + 1}`),
+            teamId: teamIdByName.get(nurse.teamName?.trim() ?? '') ?? fallbackTeamId,
+            name: nurse.name ?? '',
+            memo: nurse.memo ?? '',
+            isWorker: nurse.isWorker ?? true,
+            employmentDate: nurse.employmentDate ?? '2024-01-01',
+            possibleShiftTypeIds: possibleShiftTypeIds.length > 0 ? possibleShiftTypeIds : defaultShiftTypeIds,
+            level: nurse.level ?? null,
+        };
+    });
 };
 
 export const applyParsedWardData = (draft: TOnboardingWardDraft, parsed: TOnboardingParsedWardData): TOnboardingWardDraft => {

--- a/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
+++ b/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
@@ -75,28 +75,32 @@ function useOnboardingWardWizard() {
 
         setDraft((prev) => reorderNursesWithinTeam(prev, activeTeamId, {destination, source}));
     };
-    const uploadMockFile = (fileName: string) => {
+    const applyUploadedFile = (fileName: string) => {
         setDraft((prev) => applyParsedWardData(prev, {fileName}));
     };
     const saveSkillConfig = (config: TSkillLevelConfig) => {
         setDraft((prev) => saveSkillLevelConfig(prev, config));
     };
-    const complete = () => {
+    const complete = async () => {
         if (!canComplete(draft)) {
             return;
         }
 
-        const submission = onboardingWardCreateExecutor(draft);
-        const stringified = JSON.stringify(submission.previewPayload, null, 2);
+        try {
+            const submission = await onboardingWardCreateExecutor(draft);
+            const stringified = JSON.stringify(submission.previewPayload, null, 2);
 
-        console.info('createWardPayload', submission.wardCreatePayload);
-        console.info('mockCreateWardPayload', submission.previewPayload);
-        setCompletedPayload(stringified);
-        toast.success(submission.successMessage);
+            console.info('createWardPayload', submission.wardCreatePayload);
+            console.info('mockCreateWardPayload', submission.previewPayload);
+            setCompletedPayload(stringified);
+            toast.success(submission.successMessage);
+        } catch (error) {
+            console.error('Failed to complete onboarding ward creation.', error);
+        }
     };
     const skipOrComplete = () => {
         if (draft.currentStep === MAX_STEP) {
-            complete();
+            void complete();
 
             return;
         }
@@ -123,7 +127,7 @@ function useOnboardingWardWizard() {
         addNurse,
         updateNurse,
         handleNurseDragEnd,
-        uploadMockFile,
+        applyUploadedFile,
         saveSkillConfig,
         complete,
         currentStepValidation: getStepValidation(draft),

--- a/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
+++ b/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
@@ -1,8 +1,8 @@
 import {type DropResult} from '@hello-pangea/dnd';
 import {useEffect, useState} from 'react';
 import toast from 'react-hot-toast';
+import {applyParsedWardData} from '../adapter';
 import {
-    applyMockUpload,
     addNurseDraft,
     addShiftTypeDraft,
     addTeamDraft,
@@ -14,7 +14,6 @@ import {
     getStepValidation,
     goNextStep as goNextStepDraft,
     goPreviousStep as goPreviousStepDraft,
-    serializeDraft,
     reorderNursesWithinTeam,
     saveSkillLevelConfig,
     type TOnboardingWardDraft,
@@ -22,6 +21,7 @@ import {
     updateNurseDraft,
     updateShiftTypeDraft,
 } from '../model';
+import {onboardingWardCreateExecutor} from '../submission';
 import type {TSortMode} from '../types';
 
 const MAX_STEP = 4;
@@ -76,7 +76,7 @@ function useOnboardingWardWizard() {
         setDraft((prev) => reorderNursesWithinTeam(prev, activeTeamId, {destination, source}));
     };
     const uploadMockFile = (fileName: string) => {
-        setDraft((prev) => applyMockUpload(prev, fileName));
+        setDraft((prev) => applyParsedWardData(prev, {fileName}));
     };
     const saveSkillConfig = (config: TSkillLevelConfig) => {
         setDraft((prev) => saveSkillLevelConfig(prev, config));
@@ -86,12 +86,13 @@ function useOnboardingWardWizard() {
             return;
         }
 
-        const payload = serializeDraft(draft);
-        const stringified = JSON.stringify(payload, null, 2);
+        const submission = onboardingWardCreateExecutor(draft);
+        const stringified = JSON.stringify(submission.previewPayload, null, 2);
 
-        console.info('mockCreateWardPayload', payload);
+        console.info('createWardPayload', submission.wardCreatePayload);
+        console.info('mockCreateWardPayload', submission.previewPayload);
         setCompletedPayload(stringified);
-        toast.success('mock 병동 생성 payload를 만들었습니다.');
+        toast.success(submission.successMessage);
     };
     const skipOrComplete = () => {
         if (draft.currentStep === MAX_STEP) {

--- a/src/pages/OnboardingWardCreatePage/index.tsx
+++ b/src/pages/OnboardingWardCreatePage/index.tsx
@@ -27,7 +27,7 @@ function OnboardingWardCreatePage() {
         addNurse,
         updateNurse,
         handleNurseDragEnd,
-        uploadMockFile,
+        applyUploadedFile,
         saveSkillConfig,
         complete,
         canGoNext,
@@ -36,7 +36,7 @@ function OnboardingWardCreatePage() {
     const stepContent = (() => {
         switch (draft.currentStep) {
             case 1:
-                return <UploadStep draft={draft} onUpload={(file) => uploadMockFile(file.name)} />;
+                return <UploadStep draft={draft} onUpload={(file) => applyUploadedFile(file.name)} />;
             case 2:
                 return (
                     <ShiftTypeStep
@@ -81,7 +81,7 @@ function OnboardingWardCreatePage() {
                     step={draft.currentStep}
                     onSkip={skipOrComplete}
                     onPrev={goPreviousStep}
-                    onNext={draft.currentStep < 4 ? goNextStep : complete}
+                    onNext={draft.currentStep < 4 ? goNextStep : () => void complete()}
                     nextDisabled={draft.currentStep < 4 ? !canGoNext : !canComplete}
                 >
                     {stepContent}

--- a/src/pages/OnboardingWardCreatePage/model.ts
+++ b/src/pages/OnboardingWardCreatePage/model.ts
@@ -45,21 +45,6 @@ export type TOnboardingWardDraft = {
     skillLevelConfig: TSkillLevelConfig;
 };
 
-export type TMockCreateWardPayload = TCreateWardDTO & {
-    nurses: Array<{
-        name: string;
-        memo: string;
-        isWorker: boolean;
-        employmentDate: string;
-        teamName: string;
-        level: number | null;
-        possibleShiftShortNames: string[];
-    }>;
-    skillLevelConfig: TSkillLevelConfig & {
-        palette: string[];
-    };
-};
-
 export type TOnboardingValidationIssueCode =
     | 'empty-shift-types'
     | 'missing-shift-name'
@@ -167,7 +152,6 @@ const BASE_TEAMS: TOnboardingTeamDraft[] = [
     {id: createId('team'), name: '간호사 2팀'},
     {id: createId('team'), name: '간호사 3팀'},
 ];
-
 const createBaseNurses = (shiftTypes: TOnboardingWardShiftType[], teams: TOnboardingTeamDraft[]) => {
     const shiftTypeIds = shiftTypes.map((shiftType) => shiftType.id);
     const firstTeamId = teams[0]?.id ?? '';
@@ -255,20 +239,6 @@ export const createInitialDraft = (): TOnboardingWardDraft => {
         skillLevelConfig: DEFAULT_SKILL_LEVEL_CONFIG,
     };
 };
-
-export const applyMockUpload = (draft: TOnboardingWardDraft, fileName: string): TOnboardingWardDraft => ({
-    ...draft,
-    uploadedFileName: fileName,
-    shiftTypes: draft.shiftTypes.map((shiftType) =>
-        shiftType.shortName === 'D'
-            ? {...shiftType, startTime: '07:00', endTime: '15:00'}
-            : shiftType.shortName === 'E'
-              ? {...shiftType, startTime: '15:00', endTime: '23:00'}
-              : shiftType.shortName === 'N'
-                ? {...shiftType, startTime: '23:00', endTime: '07:00'}
-                : shiftType,
-    ),
-});
 
 export const applySkillLevels = (nurses: TOnboardingNurseDraft[], config: TSkillLevelConfig): TOnboardingNurseDraft[] => {
     const levelCount = Math.min(Math.max(config.levelCount, 2), 5);
@@ -428,7 +398,6 @@ const validateShiftTypes = (draft: TOnboardingWardDraft): TOnboardingValidationI
 
     return issues;
 };
-
 const validateTeamsAndNurses = (draft: TOnboardingWardDraft, step: 3 | 4): TOnboardingValidationIssue[] => {
     const issues: TOnboardingValidationIssue[] = [];
 
@@ -478,8 +447,7 @@ export const getStepValidation = (draft: TOnboardingWardDraft, step = draft.curr
 
 export const canGoPrev = (draft: Pick<TOnboardingWardDraft, 'currentStep'>): boolean => draft.currentStep > MIN_STEP;
 
-export const canGoNext = (draft: TOnboardingWardDraft): boolean =>
-    draft.currentStep < MAX_STEP && getStepValidation(draft).isValid;
+export const canGoNext = (draft: TOnboardingWardDraft): boolean => draft.currentStep < MAX_STEP && getStepValidation(draft).isValid;
 
 export const canComplete = (draft: TOnboardingWardDraft): boolean =>
     draft.currentStep === MAX_STEP && REQUIRED_COMPLETION_STEPS.every((step) => getStepValidation(draft, step).isValid);
@@ -489,33 +457,3 @@ export const getActionState = (draft: TOnboardingWardDraft): TOnboardingActionSt
     canGoNext: canGoNext(draft),
     canComplete: canComplete(draft),
 });
-
-export const serializeDraft = (draft: TOnboardingWardDraft): TMockCreateWardPayload => {
-    const teamById = new Map(draft.teams.map((team) => [team.id, team.name]));
-    const shiftTypeById = new Map(draft.shiftTypes.map((shiftType) => [shiftType.id, shiftType]));
-    const palette = getSkillPalette(draft.skillLevelConfig.paletteId);
-
-    return {
-        name: draft.wardName,
-        hospitalName: draft.hospitalName,
-        wardShiftTypes: draft.shiftTypes.map(({id: _id, ...shiftType}) => shiftType),
-        shiftTeams: draft.teams.map((team) => ({
-            nurseNames: draft.nurses.filter((nurse) => nurse.teamId === team.id).map((nurse) => nurse.name),
-        })),
-        nurses: draft.nurses.map((nurse) => ({
-            name: nurse.name,
-            memo: nurse.memo,
-            isWorker: nurse.isWorker,
-            employmentDate: nurse.employmentDate,
-            teamName: teamById.get(nurse.teamId) ?? '',
-            level: nurse.level,
-            possibleShiftShortNames: nurse.possibleShiftTypeIds
-                .map((shiftTypeId) => shiftTypeById.get(shiftTypeId)?.shortName ?? '')
-                .filter(Boolean),
-        })),
-        skillLevelConfig: {
-            ...draft.skillLevelConfig,
-            palette: palette.colors,
-        },
-    };
-};

--- a/src/pages/OnboardingWardCreatePage/submission.ts
+++ b/src/pages/OnboardingWardCreatePage/submission.ts
@@ -1,0 +1,21 @@
+import type {TCreateWardDTO} from '@/shared/api/ward/type';
+import {buildCreateWardPayload, buildMockCreateWardPayload, type TMockCreateWardPayload} from './adapter';
+import type {TOnboardingWardDraft} from './model';
+
+export type TOnboardingWardCreateSubmission = {
+    mode: 'mock';
+    wardCreatePayload: TCreateWardDTO;
+    previewPayload: TMockCreateWardPayload;
+    successMessage: string;
+};
+
+export type TOnboardingWardCreateExecutor = (draft: TOnboardingWardDraft) => TOnboardingWardCreateSubmission;
+
+export const mockOnboardingWardCreateExecutor: TOnboardingWardCreateExecutor = (draft) => ({
+    mode: 'mock',
+    wardCreatePayload: buildCreateWardPayload(draft),
+    previewPayload: buildMockCreateWardPayload(draft),
+    successMessage: 'mock 병동 생성 payload를 만들었습니다.',
+});
+
+export const onboardingWardCreateExecutor = mockOnboardingWardCreateExecutor;

--- a/src/pages/OnboardingWardCreatePage/submission.ts
+++ b/src/pages/OnboardingWardCreatePage/submission.ts
@@ -9,9 +9,9 @@ export type TOnboardingWardCreateSubmission = {
     successMessage: string;
 };
 
-export type TOnboardingWardCreateExecutor = (draft: TOnboardingWardDraft) => TOnboardingWardCreateSubmission;
+export type TOnboardingWardCreateExecutor = (draft: TOnboardingWardDraft) => Promise<TOnboardingWardCreateSubmission>;
 
-export const mockOnboardingWardCreateExecutor: TOnboardingWardCreateExecutor = (draft) => ({
+export const mockOnboardingWardCreateExecutor: TOnboardingWardCreateExecutor = async (draft) => ({
     mode: 'mock',
     wardCreatePayload: buildCreateWardPayload(draft),
     previewPayload: buildMockCreateWardPayload(draft),


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-835](https://gom3.atlassian.net/browse/DUT-835)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 온보딩 병동 생성 draft에서 payload 생성 로직을 분리해 `createWard` 요청 adapter와 mock preview payload builder를 추가했습니다.
- 엑셀 파싱 응답이 들어올 때 병동/팀/간호사/근무유형 초깃값을 draft에 주입할 수 있는 parsed data adapter를 추가했습니다.
- 완료 처리 로직을 executor 기반으로 분리해 현재는 mock submitter를 사용하고, 이후 실제 API submitter로 교체할 수 있게 만들었습니다.
- adapter 동작을 검증하는 테스트를 추가하고, 기존 온보딩 페이지 테스트/타입체크를 통과시켰습니다.

<br>

## To Reviewers

- 실제 엑셀 파싱 API 스키마가 확정되면 `adapter.ts`의 parsed data 타입에 맞춰 필드명만 연결하면 됩니다.
- 현재 완료 시점에는 mock preview를 유지하고 있으며, 실제 생성 API 연결은 `submission.ts` executor 교체 기준으로 이어가면 됩니다.
- 검증: `pnpm test:run src/pages/OnboardingWardCreatePage/model.test.ts src/pages/OnboardingWardCreatePage/adapter.test.ts src/pages/OnboardingWardCreatePage/index.test.tsx`, `pnpm type-check`, `pnpm eslint src/pages/OnboardingWardCreatePage/model.ts src/pages/OnboardingWardCreatePage/adapter.ts src/pages/OnboardingWardCreatePage/adapter.test.ts src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts src/pages/OnboardingWardCreatePage/submission.ts`

[DUT-835]: https://gom3.atlassian.net/browse/DUT-835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 업로드된 병동 데이터 파싱을 기반으로 초안에 적용하고 미리보기 페이로드를 생성하는 기능 추가
  * 제출 실행기가 비동기적으로 실행되어 완료 메시지와 미리보기를 반환

* **Tests**
  * 병동 데이터 파싱·변환·페이로드 생성에 대한 포괄적 테스트 추가

* **Refactor**
  * 온보딩 마법사 업로드/완료 흐름 및 데이터 변환 로직 재구성
<!-- end of auto-generated comment: release notes by coderabbit.ai -->