### PR TITLE
[DUT-837]: 공용 UI foundation variant 정리

### DIFF
--- a/src/pages/OnboardingWardCreatePage/components/SectionHeader.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/SectionHeader.tsx
@@ -1,3 +1,4 @@
+import BaseSectionHeader from '@/shared/ui/SectionHeader';
 import type {TOnboardingStep} from '../model';
 
 const STEP_LABELS: Record<TOnboardingStep, {title: string; description: string}> = {
@@ -22,16 +23,7 @@ const STEP_LABELS: Record<TOnboardingStep, {title: string; description: string}>
 function SectionHeader({step}: {step: TOnboardingStep}) {
     const label = STEP_LABELS[step];
 
-    return (
-        <div className="mb-10 flex items-start justify-between">
-            <div className="space-y-6">
-                <h1 className="max-w-[541px] font-apple text-[32px] leading-[1.18] font-semibold whitespace-pre-line text-text-1">
-                    {label.title}
-                </h1>
-                <p className="font-apple text-[20px] font-medium text-gray-3">{label.description}</p>
-            </div>
-        </div>
-    );
+    return <BaseSectionHeader className="mb-10 max-w-[541px]" title={label.title} description={label.description} />;
 }
 
 export default SectionHeader;

--- a/src/pages/OnboardingWardCreatePage/components/WizardButton.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/WizardButton.tsx
@@ -12,13 +12,9 @@ function WizardButton({children, variant = 'solid', className, ...props}: IWizar
     return (
         <Button
             type="button"
-            className={cn(
-                'h-[42px] rounded-[10px] px-5 font-apple text-[20px] font-semibold',
-                variant === 'solid' && 'bg-main-1 text-white hover:bg-main-2',
-                variant === 'secondary' && 'bg-gray-6 text-gray-3 hover:bg-gray-5',
-                variant === 'link' && 'px-0 text-gray-3 underline underline-offset-2 hover:bg-transparent',
-                className,
-            )}
+            variant={variant === 'solid' ? 'brand' : variant === 'secondary' ? 'soft' : 'link'}
+            size={variant === 'link' ? undefined : 'pill'}
+            className={cn(variant === 'link' && 'px-0 text-gray-3 underline underline-offset-2 hover:bg-transparent', className)}
             {...props}
         >
             {children}

--- a/src/pages/OnboardingWardCreatePage/components/steps/NurseStep.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/steps/NurseStep.tsx
@@ -138,7 +138,9 @@ function NurseStep({
                                             <Input
                                                 value={nurse.name}
                                                 onChange={(event) => onNurseChange(nurse.id, {name: event.target.value})}
-                                                className="h-10 border-none bg-transparent px-0 font-apple text-[20px] font-medium text-sub-1 shadow-none"
+                                                variant="flush"
+                                                fieldSize="md"
+                                                className="font-apple text-[20px] font-medium text-sub-1"
                                             />
                                             {step === 4 ? <SkillBadge level={nurse.level} config={draft.skillLevelConfig} /> : null}
                                             <div className="flex flex-wrap gap-2">
@@ -168,7 +170,9 @@ function NurseStep({
                                             <Input
                                                 value={nurse.memo}
                                                 onChange={(event) => onNurseChange(nurse.id, {memo: event.target.value})}
-                                                className="h-10 border-none bg-transparent px-0 font-apple text-[20px] font-medium text-sub-1 shadow-none"
+                                                variant="flush"
+                                                fieldSize="md"
+                                                className="font-apple text-[20px] font-medium text-sub-1"
                                                 placeholder="비고"
                                             />
                                             <div className="flex justify-center">

--- a/src/pages/OnboardingWardCreatePage/components/steps/ShiftTypeStep.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/steps/ShiftTypeStep.tsx
@@ -1,8 +1,7 @@
 import {Pencil, Plus, X} from 'lucide-react';
+import Card from '@/shared/ui/Card';
 import {Input} from '@/shared/ui/primitives/input';
 import type {TOnboardingWardShiftType} from '../../model';
-
-const STEP_CARD_BASE_CLASS = 'rounded-[20px] border border-gray-6 bg-white p-8 shadow-[0_4px_34px_0_rgba(237,233,245,1)]';
 
 interface IShiftTypeStepProps {
     shiftTypes: TOnboardingWardShiftType[];
@@ -13,7 +12,7 @@ interface IShiftTypeStepProps {
 
 function ShiftTypeStep({shiftTypes, onChange, onAdd, onDelete}: IShiftTypeStepProps) {
     return (
-        <div className={STEP_CARD_BASE_CLASS}>
+        <Card variant="elevated" padding="lg">
             <div className="mb-6 flex items-center justify-between">
                 <p className="font-apple text-[20px] font-medium text-gray-3">근무 유형</p>
                 <button type="button" className="flex items-center gap-2 font-apple text-[16px] font-medium text-main-1" onClick={onAdd}>
@@ -38,14 +37,18 @@ function ShiftTypeStep({shiftTypes, onChange, onAdd, onDelete}: IShiftTypeStepPr
                         <Input
                             value={shiftType.name}
                             onChange={(event) => onChange(shiftType.id, {name: event.target.value})}
-                            className="h-11 rounded-[10px] border-gray-5 font-apple text-[18px] text-sub-1"
+                            variant="foundation"
+                            fieldSize="lg"
+                            className="font-apple"
                             placeholder="근무명"
                         />
                         <Input
                             value={shiftType.shortName}
                             maxLength={2}
                             onChange={(event) => onChange(shiftType.id, {shortName: event.target.value.toUpperCase()})}
-                            className="h-11 rounded-[10px] border-gray-5 text-center font-poppins text-[18px] text-sub-1"
+                            variant="foundation"
+                            fieldSize="lg"
+                            className="text-center font-poppins"
                             placeholder="-"
                         />
                         <select
@@ -68,7 +71,9 @@ function ShiftTypeStep({shiftTypes, onChange, onAdd, onDelete}: IShiftTypeStepPr
                                 value={shiftType.startTime}
                                 disabled={shiftType.isOff}
                                 onChange={(event) => onChange(shiftType.id, {startTime: event.target.value})}
-                                className="h-11 rounded-[10px] border-gray-5 text-center font-poppins text-[18px]"
+                                variant="foundation"
+                                fieldSize="lg"
+                                className="text-center font-poppins"
                                 placeholder="07:00"
                             />
                             <span className="font-poppins text-[18px] text-gray-3">~</span>
@@ -76,7 +81,9 @@ function ShiftTypeStep({shiftTypes, onChange, onAdd, onDelete}: IShiftTypeStepPr
                                 value={shiftType.endTime}
                                 disabled={shiftType.isOff}
                                 onChange={(event) => onChange(shiftType.id, {endTime: event.target.value})}
-                                className="h-11 rounded-[10px] border-gray-5 text-center font-poppins text-[18px]"
+                                variant="foundation"
+                                fieldSize="lg"
+                                className="text-center font-poppins"
                                 placeholder="15:00"
                             />
                         </div>
@@ -101,7 +108,7 @@ function ShiftTypeStep({shiftTypes, onChange, onAdd, onDelete}: IShiftTypeStepPr
                     </div>
                 ))}
             </div>
-        </div>
+        </Card>
     );
 }
 

--- a/src/pages/OnboardingWardCreatePage/components/steps/UploadStep.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/steps/UploadStep.tsx
@@ -1,5 +1,6 @@
 import {Upload} from 'lucide-react';
 import {useRef} from 'react';
+import Card from '@/shared/ui/Card';
 import {Button} from '@/shared/ui/primitives/button';
 import type {TOnboardingWardDraft} from '../../model';
 
@@ -13,8 +14,10 @@ function UploadStep({draft, onUpload}: IUploadStepProps) {
 
     return (
         <div className="space-y-6">
-            <div
-                className="flex min-h-[204px] flex-col items-center justify-center rounded-[20px] border border-dashed border-gray-5 bg-gray-7 px-10 py-[60px]"
+            <Card
+                variant="muted"
+                padding="none"
+                className="flex min-h-[204px] flex-col items-center justify-center px-10 py-[60px]"
                 onDragOver={(event) => event.preventDefault()}
                 onDrop={(event) => {
                     event.preventDefault();
@@ -50,11 +53,11 @@ function UploadStep({draft, onUpload}: IUploadStepProps) {
                     파일 업로드
                     <Upload className="h-5 w-5" />
                 </Button>
-            </div>
+            </Card>
             {draft.uploadedFileName ? (
-                <div className="rounded-[10px] border border-main-3 bg-main-light px-5 py-4 font-apple text-[18px] text-main-1">
+                <Card variant="success" padding="none" className="rounded-[10px] px-5 py-4 font-apple text-[18px]">
                     업로드됨: {draft.uploadedFileName}
-                </div>
+                </Card>
             ) : null}
         </div>
     );

--- a/src/pages/OnboardingWardCreatePage/index.tsx
+++ b/src/pages/OnboardingWardCreatePage/index.tsx
@@ -1,3 +1,4 @@
+import Card from '@/shared/ui/Card';
 import HeaderLogo from './components/HeaderLogo';
 import OnboardingStepLayout from './components/OnboardingStepLayout';
 import SectionHeader from './components/SectionHeader';
@@ -87,7 +88,7 @@ function OnboardingWardCreatePage() {
                     {stepContent}
                 </OnboardingStepLayout>
                 {completedPayload ? (
-                    <div className="mt-10 rounded-[20px] border border-gray-6 bg-white p-6">
+                    <Card className="mt-10">
                         <p className="mb-4 font-apple text-[20px] font-semibold text-text-1">Mock CreateWard Payload</p>
                         <pre
                             data-testid="mock-create-ward-payload"
@@ -95,7 +96,7 @@ function OnboardingWardCreatePage() {
                         >
                             {completedPayload}
                         </pre>
-                    </div>
+                    </Card>
                 ) : null}
             </div>
         </div>

--- a/src/shared/ui/Button/index.test.tsx
+++ b/src/shared/ui/Button/index.test.tsx
@@ -13,6 +13,14 @@ describe('Button 컴포넌트', () => {
 
         const button = screen.getByText('테스트 버튼');
 
-        expect(button).toHaveClass('border-main-1 text-main-1 transition-all');
+        expect(button).toHaveClass('border-main-1', 'bg-transparent', 'text-main-1');
+    });
+
+    it('디자인 2.0 기본 버튼 스타일을 사용해야 함', () => {
+        render(<Button>테스트 버튼</Button>);
+
+        const button = screen.getByText('테스트 버튼');
+
+        expect(button).toHaveClass('rounded-[50px]', 'font-apple', 'text-[2.25rem]', 'bg-main-1');
     });
 });

--- a/src/shared/ui/Button/index.tsx
+++ b/src/shared/ui/Button/index.tsx
@@ -7,14 +7,9 @@ type TButtonProps = React.ComponentProps<typeof ShadcnButton>;
 function Button({children, className, variant = 'default', ...props}: TButtonProps) {
     return (
         <ShadcnButton
-            variant={variant}
-            className={cn(
-                'rounded-[50px] border-[.125rem] font-apple text-[2.25rem] font-semibold disabled:bg-main-3',
-                variant === 'outline'
-                    ? 'border-main-1 bg-transparent text-main-1 transition-all hover:bg-main-4'
-                    : 'bg-main-1 text-white hover:bg-main-2',
-                className,
-            )}
+            variant={variant === 'outline' ? 'brandOutline' : 'brand'}
+            size="hero"
+            className={cn('disabled:bg-main-3', className)}
             {...props}
         >
             {children}

--- a/src/shared/ui/Card/index.tsx
+++ b/src/shared/ui/Card/index.tsx
@@ -1,0 +1,37 @@
+import {cva, type VariantProps} from 'class-variance-authority';
+import type {HTMLAttributes, ReactNode} from 'react';
+import {cn} from '@/shared/util/style';
+
+const cardVariants = cva('rounded-[20px] border', {
+    variants: {
+        variant: {
+            default: 'border-gray-6 bg-white',
+            elevated: 'border-gray-6 bg-white shadow-[0_4px_34px_0_rgba(237,233,245,1)]',
+            muted: 'border-gray-5 border-dashed bg-gray-7',
+            success: 'border-main-3 bg-main-light text-main-1',
+        },
+        padding: {
+            none: '',
+            md: 'p-6',
+            lg: 'p-8',
+        },
+    },
+    defaultVariants: {
+        variant: 'default',
+        padding: 'md',
+    },
+});
+
+interface ICardProps extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof cardVariants> {
+    children: ReactNode;
+}
+
+function Card({children, className, variant, padding, ...props}: ICardProps) {
+    return (
+        <div className={cn(cardVariants({variant, padding}), className)} {...props}>
+            {children}
+        </div>
+    );
+}
+
+export default Card;

--- a/src/shared/ui/SectionHeader/index.tsx
+++ b/src/shared/ui/SectionHeader/index.tsx
@@ -1,0 +1,24 @@
+import type {HTMLAttributes, ReactNode} from 'react';
+import {cn} from '@/shared/util/style';
+
+interface ISectionHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+    title: ReactNode;
+    description?: ReactNode;
+    titleClassName?: string;
+    descriptionClassName?: string;
+}
+
+function SectionHeader({title, description, className, titleClassName, descriptionClassName, ...props}: ISectionHeaderProps) {
+    return (
+        <div className={cn('space-y-6', className)} {...props}>
+            <h1 className={cn('font-apple text-[32px] leading-[1.18] font-semibold whitespace-pre-line text-text-1', titleClassName)}>
+                {title}
+            </h1>
+            {description ? (
+                <p className={cn('font-apple text-[20px] font-medium text-gray-3', descriptionClassName)}>{description}</p>
+            ) : null}
+        </div>
+    );
+}
+
+export default SectionHeader;

--- a/src/shared/ui/TextField/index.tsx
+++ b/src/shared/ui/TextField/index.tsx
@@ -14,6 +14,8 @@ const TextField = forwardRef(
                     ref={ref}
                     value={value}
                     onChange={onChange}
+                    variant="flush"
+                    fieldSize="md"
                     className={cn(
                         'w-full rounded-[.625rem] px-6.25 font-apple text-[2.25rem] outline-1 outline-sub-4 read-only:outline-sub-5 focus:outline-main-1',
                         error && 'outline-red focus:outline-red',

--- a/src/shared/ui/TimeInput/index.tsx
+++ b/src/shared/ui/TimeInput/index.tsx
@@ -75,6 +75,8 @@ function TimeInput({initTime, onTimeChange, className, ...props}: ITimeInputProp
         <Input
             value={time}
             onChange={HandleChange}
+            variant="flush"
+            fieldSize="md"
             className={cn(
                 'rounded-[.625rem] px-6.25 font-poppins text-[2.25rem] outline-1 outline-sub-4 focus:text-main-1 focus:outline-main-1',
                 className,

--- a/src/shared/ui/primitives/button.tsx
+++ b/src/shared/ui/primitives/button.tsx
@@ -14,12 +14,18 @@ const buttonVariants = cva(
                 secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
                 ghost: 'hover:bg-accent hover:text-accent-foreground',
                 link: 'text-primary underline-offset-4 hover:underline',
+                brand: 'border-[.125rem] border-main-1 bg-main-1 text-white hover:bg-main-2',
+                brandOutline: 'border-[.125rem] border-main-1 bg-transparent text-main-1 hover:bg-main-4',
+                soft: 'border border-transparent bg-gray-6 text-gray-3 hover:bg-gray-5',
+                subtle: 'border border-transparent bg-main-light text-main-1 hover:bg-main-light/80',
             },
             size: {
                 default: 'h-9 px-4 py-2',
                 sm: 'h-8 rounded-md px-3 text-xs',
                 lg: 'h-10 rounded-md px-8',
                 icon: 'h-9 w-9',
+                pill: 'h-[42px] rounded-[10px] px-5 font-apple text-[20px] font-semibold',
+                hero: 'rounded-[50px] px-8 py-4 font-apple text-[2.25rem] font-semibold',
             },
         },
         defaultVariants: {

--- a/src/shared/ui/primitives/input.test.tsx
+++ b/src/shared/ui/primitives/input.test.tsx
@@ -1,0 +1,11 @@
+import {describe, expect, it} from 'vitest';
+import {render, screen} from '@/shared/util/test-utils';
+import {Input} from './input';
+
+describe('Input 프리미티브', () => {
+    it('foundation variant와 lg size를 조합할 수 있어야 함', () => {
+        render(<Input variant="foundation" fieldSize="lg" aria-label="foundation-input" />);
+
+        expect(screen.getByLabelText('foundation-input')).toHaveClass('rounded-[10px]', 'border-gray-5', 'h-11');
+    });
+});

--- a/src/shared/ui/primitives/input.tsx
+++ b/src/shared/ui/primitives/input.tsx
@@ -1,22 +1,37 @@
+import {cva, type VariantProps} from 'class-variance-authority';
 import * as React from 'react';
 import {cn} from '@/shared/util/style';
 
-export type TInputProps = React.ComponentProps<'input'>;
+const inputVariants = cva(
+    'flex w-full transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+    {
+        variants: {
+            variant: {
+                default:
+                    'rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:ring-1 focus-visible:ring-ring',
+                foundation:
+                    'rounded-[10px] border border-gray-5 bg-white px-3 text-[18px] text-sub-1 shadow-none focus-visible:border-main-1',
+                flush: 'border-none bg-transparent px-0 shadow-none focus-visible:ring-0',
+            },
+            fieldSize: {
+                default: 'h-9',
+                md: 'h-10',
+                lg: 'h-11',
+            },
+        },
+        defaultVariants: {
+            variant: 'default',
+            fieldSize: 'default',
+        },
+    },
+);
 
-const Input = React.forwardRef<HTMLInputElement, TInputProps>(({className, type, ...props}, ref) => {
-    return (
-        <input
-            ref={ref}
-            type={type}
-            className={cn(
-                'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
-                className,
-            )}
-            {...props}
-        />
-    );
+export interface IInputProps extends Omit<React.ComponentProps<'input'>, 'size'>, VariantProps<typeof inputVariants> {}
+
+const Input = React.forwardRef<HTMLInputElement, IInputProps>(({className, type, variant, fieldSize, ...props}, ref) => {
+    return <input ref={ref} type={type} className={cn(inputVariants({variant, fieldSize}), className)} {...props} />;
 });
 
 Input.displayName = 'Input';
 
-export {Input};
+export {Input, inputVariants};


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-837](https://gom3.atlassian.net/browse/DUT-837)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `shared/ui/primitives/button`과 `shared/ui/primitives/input`에 디자인 2.0용 variant/size 조합을 추가했습니다.
- `shared/ui/Card`, `shared/ui/SectionHeader` 공용 컴포넌트를 추가하고 온보딩 페이지가 공통 foundation을 사용하도록 정리했습니다.
- 기존 `shared/ui/Button`, `TextField`, `TimeInput`이 새 foundation을 재사용하도록 맞추고 관련 테스트를 보강했습니다.

<br>

## To Reviewers

- 온보딩 워드 생성 플로우에서 버튼/입력 필드의 시각적 스타일이 기존 의도와 동일한지 확인 부탁드립니다.
- 새 `button`/`input` variant는 다른 페이지에서도 재사용할 수 있도록 추가한 것이므로, 이름 체계가 foundation 정책과 맞는지 봐주시면 됩니다.


[DUT-837]: https://gom3.atlassian.net/browse/DUT-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ