### PR TITLE
[DUT-845]: RegisterWard FSD 1차 분리

### DIFF
--- a/src/features/register-ward/model/schema.ts
+++ b/src/features/register-ward/model/schema.ts
@@ -1,0 +1,12 @@
+import * as yup from 'yup';
+
+export const registerWardSchema = yup.object().shape({
+    name: yup
+        .string()
+        .required()
+        .matches(/^[a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣|0-9|\s]{1,50}$/),
+    hospitalName: yup
+        .string()
+        .required()
+        .matches(/^[a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣|0-9|\s]{1,50}$/),
+});

--- a/src/features/register-ward/model/schema.ts
+++ b/src/features/register-ward/model/schema.ts
@@ -4,9 +4,9 @@ export const registerWardSchema = yup.object().shape({
     name: yup
         .string()
         .required()
-        .matches(/^[a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣|0-9|\s]{1,50}$/),
+        .matches(/^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9\s]{1,50}$/),
     hospitalName: yup
         .string()
         .required()
-        .matches(/^[a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣|0-9|\s]{1,50}$/),
+        .matches(/^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9\s]{1,50}$/),
 });

--- a/src/features/register-ward/model/ward.ts
+++ b/src/features/register-ward/model/ward.ts
@@ -1,0 +1,68 @@
+import {type TCreateWardDTO} from '@/shared/api/ward/type';
+
+export const DEFAULT_WARD_SHIFT_TYPES: TCreateWardDTO['wardShiftTypes'] = [
+    {
+        name: '데이',
+        shortName: 'D',
+        startTime: '07:00',
+        endTime: '15:00',
+        color: '#4DC2AD',
+        isDefault: true,
+        isOff: false,
+        classification: 'DAY',
+    },
+    {
+        name: '이브닝',
+        shortName: 'E',
+        startTime: '15:00',
+        endTime: '23:00',
+        color: '#FF8BA5',
+        isDefault: true,
+        isOff: false,
+        classification: 'EVENING',
+    },
+    {
+        name: '나이트',
+        shortName: 'N',
+        startTime: '23:00',
+        endTime: '07:00',
+        color: '#3580FF',
+        isDefault: true,
+        isOff: false,
+        classification: 'NIGHT',
+    },
+    {
+        name: '오프',
+        shortName: 'O',
+        startTime: '',
+        endTime: '',
+        color: '#465B7A',
+        isDefault: true,
+        isOff: true,
+        classification: 'OFF',
+    },
+];
+
+export function getWardShiftValidationMessage(wardShiftTypes: TCreateWardDTO['wardShiftTypes']) {
+    const invalidShiftType = wardShiftTypes.find((shiftType) => {
+        if (shiftType.name === '') return true;
+
+        if (!shiftType.isOff && (shiftType.startTime === '' || shiftType.endTime === '')) {
+            return true;
+        }
+
+        return shiftType.shortName === '';
+    });
+
+    if (!invalidShiftType) return null;
+
+    if (invalidShiftType.name === '') {
+        return '근무 이름을 입력해주세요.';
+    }
+
+    if (!invalidShiftType.isOff && (invalidShiftType.startTime === '' || invalidShiftType.endTime === '')) {
+        return `${invalidShiftType.name}근무의 근무 시간을 입력해주세요.`;
+    }
+
+    return `${invalidShiftType.name}근무의 근무 약자를 입력해주세요.`;
+}

--- a/src/features/register-ward/ui/RegisterWardShiftTeamsSection.tsx
+++ b/src/features/register-ward/ui/RegisterWardShiftTeamsSection.tsx
@@ -1,6 +1,7 @@
 import {produce} from 'immer';
 import {type Dispatch, type SetStateAction} from 'react';
 import {CancelIcon, EnterIcon, PlusIcon, XIcon} from '@/shared/assets/svg';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 
 interface IRegisterWardShiftTeamsSectionProps {
     shiftTeams: string[][];
@@ -8,6 +9,7 @@ interface IRegisterWardShiftTeamsSectionProps {
 }
 
 function RegisterWardShiftTeamsSection({shiftTeams, setShiftTeams}: IRegisterWardShiftTeamsSectionProps) {
+    const {t} = useTypedTranslation();
     const appendClipboardTextToNurse = async (index: number) => {
         const nurses = (await navigator.clipboard.readText()).split('\n').map((x) => x.replace(/\r/g, ''));
 
@@ -21,8 +23,8 @@ function RegisterWardShiftTeamsSection({shiftTeams, setShiftTeams}: IRegisterWar
     return (
         <div className="mt-5 w-full shrink-0 rounded-[1.25rem] bg-white px-11.25 py-7.5 shadow-banner">
             <div className="mb-6.25 flex items-center">
-                <p className="font-apple text-[1.25rem] font-medium text-sub-3">병동내 간호사</p>
-                <p className="ml-6 font-apple text-[1rem] text-main-2">* 본인은 제외해주세요</p>
+                <p className="font-apple text-[1.25rem] font-medium text-sub-3">{t('feature.registerWard.shiftTeams.title')}</p>
+                <p className="ml-6 font-apple text-[1rem] text-main-2">{t('feature.registerWard.shiftTeams.excludeMe')}</p>
                 <div
                     className="ml-auto flex cursor-pointer gap-[.625rem]"
                     onClick={() => {
@@ -34,7 +36,7 @@ function RegisterWardShiftTeamsSection({shiftTeams, setShiftTeams}: IRegisterWar
                     }}
                 >
                     <PlusIcon className="h-6 w-6 stroke-main-2" />
-                    <p className="font-apple text-[1rem] font-medium text-main-2">팀 추가하기</p>
+                    <p className="font-apple text-[1rem] font-medium text-main-2">{t('feature.registerWard.shiftTeams.addTeam')}</p>
                 </div>
             </div>
             {shiftTeams.map((shiftTeam, index) => (
@@ -42,8 +44,10 @@ function RegisterWardShiftTeamsSection({shiftTeams, setShiftTeams}: IRegisterWar
                     <div className="flex justify-between">
                         <div className="flex">
                             <div className="flex h-9 w-45 items-center justify-center gap-[.75rem] rounded-t-[.625rem] bg-sub-2 font-apple text-white">
-                                <p className="text-[1.25rem] font-medium">간호사 {index + 1}팀</p>
-                                <p className="text-[.875rem]">{shiftTeam.length}명</p>
+                                <p className="text-[1.25rem] font-medium">
+                                    {t('feature.registerWard.shiftTeams.teamName', {index: index + 1})}
+                                </p>
+                                <p className="text-[.875rem]">{t('feature.registerWard.shiftTeams.count', {count: shiftTeam.length})}</p>
                             </div>
                         </div>
                         <CancelIcon
@@ -78,7 +82,7 @@ function RegisterWardShiftTeamsSection({shiftTeams, setShiftTeams}: IRegisterWar
                         ))}
                         <p className="flex h-7 w-27 items-center justify-center rounded-[.3125rem] border-[.0625rem] border-main-1 bg-white font-apple text-[1rem] text-sub-1">
                             <input
-                                placeholder="이름 추가"
+                                placeholder={t('feature.registerWard.shiftTeams.addNamePlaceholder')}
                                 className="w-[70%] focus:outline-none"
                                 onKeyDown={(e) => {
                                     if ((e.ctrlKey || e.metaKey) && (e.key === 'v' || e.key === 'V')) {
@@ -94,10 +98,13 @@ function RegisterWardShiftTeamsSection({shiftTeams, setShiftTeams}: IRegisterWar
 
                                     if (e.key === 'Enter') {
                                         e.preventDefault();
+
+                                        const value = e.currentTarget.value;
+
+                                        e.currentTarget.value = '';
                                         setShiftTeams(
                                             produce(shiftTeams, (draft) => {
-                                                draft[index].push(e.currentTarget.value);
-                                                e.currentTarget.value = '';
+                                                draft[index].push(value);
                                             }),
                                         );
                                     }

--- a/src/features/register-ward/ui/RegisterWardShiftTeamsSection.tsx
+++ b/src/features/register-ward/ui/RegisterWardShiftTeamsSection.tsx
@@ -1,0 +1,115 @@
+import {produce} from 'immer';
+import {type Dispatch, type SetStateAction} from 'react';
+import {CancelIcon, EnterIcon, PlusIcon, XIcon} from '@/shared/assets/svg';
+
+interface IRegisterWardShiftTeamsSectionProps {
+    shiftTeams: string[][];
+    setShiftTeams: Dispatch<SetStateAction<string[][]>>;
+}
+
+function RegisterWardShiftTeamsSection({shiftTeams, setShiftTeams}: IRegisterWardShiftTeamsSectionProps) {
+    const appendClipboardTextToNurse = async (index: number) => {
+        const nurses = (await navigator.clipboard.readText()).split('\n').map((x) => x.replace(/\r/g, ''));
+
+        setShiftTeams(
+            produce(shiftTeams, (draft) => {
+                draft[index] = draft[index].concat(nurses);
+            }),
+        );
+    };
+
+    return (
+        <div className="mt-5 w-full shrink-0 rounded-[1.25rem] bg-white px-11.25 py-7.5 shadow-banner">
+            <div className="mb-6.25 flex items-center">
+                <p className="font-apple text-[1.25rem] font-medium text-sub-3">병동내 간호사</p>
+                <p className="ml-6 font-apple text-[1rem] text-main-2">* 본인은 제외해주세요</p>
+                <div
+                    className="ml-auto flex cursor-pointer gap-[.625rem]"
+                    onClick={() => {
+                        setShiftTeams(
+                            produce(shiftTeams, (draft) => {
+                                draft.push([]);
+                            }),
+                        );
+                    }}
+                >
+                    <PlusIcon className="h-6 w-6 stroke-main-2" />
+                    <p className="font-apple text-[1rem] font-medium text-main-2">팀 추가하기</p>
+                </div>
+            </div>
+            {shiftTeams.map((shiftTeam, index) => (
+                <div key={index} className="mt-5">
+                    <div className="flex justify-between">
+                        <div className="flex">
+                            <div className="flex h-9 w-45 items-center justify-center gap-[.75rem] rounded-t-[.625rem] bg-sub-2 font-apple text-white">
+                                <p className="text-[1.25rem] font-medium">간호사 {index + 1}팀</p>
+                                <p className="text-[.875rem]">{shiftTeam.length}명</p>
+                            </div>
+                        </div>
+                        <CancelIcon
+                            className="h-6 w-6 cursor-pointer self-center"
+                            onClick={() => {
+                                setShiftTeams(
+                                    produce(shiftTeams, (draft) => {
+                                        draft.splice(index, 1);
+                                    }),
+                                );
+                            }}
+                        />
+                    </div>
+                    <div className="flex w-full flex-wrap gap-[.625rem] rounded-[.625rem] rounded-tl-none border-[.0313rem] border-sub-3 bg-main-bg p-7.5">
+                        {shiftTeam.map((name, nameIndex) => (
+                            <div
+                                key={nameIndex}
+                                className="flex h-7 items-center gap-[.25rem] rounded-[.3125rem] border-[.0313rem] border-main-2 bg-main-4 px-[.5rem]"
+                            >
+                                <p className="font-apple text-[1rem] text-sub-1">{name}</p>
+                                <XIcon
+                                    className="h-4.5 w-4.5 cursor-pointer"
+                                    onClick={() => {
+                                        setShiftTeams(
+                                            produce(shiftTeams, (draft) => {
+                                                draft[index].splice(nameIndex, 1);
+                                            }),
+                                        );
+                                    }}
+                                />
+                            </div>
+                        ))}
+                        <p className="flex h-7 w-27 items-center justify-center rounded-[.3125rem] border-[.0625rem] border-main-1 bg-white font-apple text-[1rem] text-sub-1">
+                            <input
+                                placeholder="이름 추가"
+                                className="w-[70%] focus:outline-none"
+                                onKeyDown={(e) => {
+                                    if ((e.ctrlKey || e.metaKey) && (e.key === 'v' || e.key === 'V')) {
+                                        e.preventDefault();
+                                        appendClipboardTextToNurse(index);
+
+                                        return;
+                                    }
+
+                                    if (e.nativeEvent.isComposing) return;
+
+                                    if (e.currentTarget.value === '') return;
+
+                                    if (e.key === 'Enter') {
+                                        e.preventDefault();
+                                        setShiftTeams(
+                                            produce(shiftTeams, (draft) => {
+                                                draft[index].push(e.currentTarget.value);
+                                                e.currentTarget.value = '';
+                                            }),
+                                        );
+                                    }
+                                }}
+                            />
+                            <EnterIcon className="h-6 w-6" />
+                        </p>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default RegisterWardShiftTeamsSection;

--- a/src/features/register-ward/ui/RegisterWardShiftTypesSection.tsx
+++ b/src/features/register-ward/ui/RegisterWardShiftTypesSection.tsx
@@ -4,6 +4,7 @@ import {type TWardShiftType} from '@/entities/ward';
 import CreateShiftModal from '@/features/ward/CreateShiftModal';
 import {type TCreateShiftTypeDTO, type TCreateWardDTO} from '@/shared/api/ward/type';
 import {PenIcon, PlusIcon} from '@/shared/assets/svg';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 
 interface IRegisterWardShiftTypesSectionProps {
     wardShiftTypes: TCreateWardDTO['wardShiftTypes'];
@@ -11,13 +12,14 @@ interface IRegisterWardShiftTypesSectionProps {
 }
 
 function RegisterWardShiftTypesSection({wardShiftTypes, setWardShiftTypes}: IRegisterWardShiftTypesSectionProps) {
+    const {t} = useTypedTranslation();
     const [openModal, setOpenModal] = useState(false);
     const [tempShiftType, setTempShiftType] = useState<TWardShiftType | null>(null);
 
     return (
         <div className="mt-5 w-full shrink-0 rounded-[1.25rem] bg-white px-11.25 py-7.5 shadow-banner">
             <div className="flex items-center justify-between">
-                <p className="font-apple text-[1.25rem] font-medium text-sub-3">근무 유형</p>
+                <p className="font-apple text-[1.25rem] font-medium text-sub-3">{t('feature.registerWard.shiftTypes.title')}</p>
                 <div
                     className="flex cursor-pointer gap-[.625rem]"
                     onClick={() => {
@@ -25,17 +27,17 @@ function RegisterWardShiftTypesSection({wardShiftTypes, setWardShiftTypes}: IReg
                     }}
                 >
                     <PlusIcon className="h-6 w-6 stroke-main-2" />
-                    <p className="font-apple text-[1rem] font-medium text-main-2">근무 •휴가 추가하기</p>
+                    <p className="font-apple text-[1rem] font-medium text-main-2">{t('feature.registerWard.shiftTypes.addAction')}</p>
                 </div>
             </div>
             <div className="relative mt-5 rounded-[.625rem] bg-main-bg">
                 <div className="flex items-center gap-12 pt-5 text-center font-apple text-[.875rem] font-medium text-sub-2.5">
-                    <p className="flex-2">근무 명</p>
-                    <p className="flex-1">약자</p>
-                    <p className="flex-3">근무 시간</p>
-                    <p className="flex-1">색상</p>
-                    <p className="flex-1">유형</p>
-                    <p className="flex-1">수정</p>
+                    <p className="flex-2">{t('feature.registerWard.shiftTypes.column.name')}</p>
+                    <p className="flex-1">{t('feature.registerWard.shiftTypes.column.shortName')}</p>
+                    <p className="flex-3">{t('feature.registerWard.shiftTypes.column.workTime')}</p>
+                    <p className="flex-1">{t('feature.registerWard.shiftTypes.column.color')}</p>
+                    <p className="flex-1">{t('feature.registerWard.shiftTypes.column.category')}</p>
+                    <p className="flex-1">{t('feature.registerWard.shiftTypes.column.edit')}</p>
                 </div>
                 {wardShiftTypes.map((shiftType, index) => (
                     <div key={index} className="flex h-18.5 items-center gap-12 border-b-[.0313rem] border-sub-4.5 last:border-0">
@@ -71,7 +73,7 @@ function RegisterWardShiftTypesSection({wardShiftTypes, setWardShiftTypes}: IReg
                         </div>
                         <div className="flex flex-1 justify-center">
                             <div className="rounded-[1.875rem] border-[.0313rem] border-main-2 px-[.875rem] py-[.3125rem] font-apple text-[.875rem] text-main-2">
-                                {shiftType.isOff ? '휴가' : '근무'}
+                                {shiftType.isOff ? t('feature.registerWard.shiftTypes.leave') : t('feature.registerWard.shiftTypes.work')}
                             </div>
                         </div>
                         <div className="flex flex-1 justify-center">
@@ -93,7 +95,7 @@ function RegisterWardShiftTypesSection({wardShiftTypes, setWardShiftTypes}: IReg
                     }}
                     shiftType={tempShiftType}
                     onSubmit={(shiftType: TCreateShiftTypeDTO) => {
-                        if (tempShiftType && tempShiftType.wardShiftTypeId !== null) {
+                        if (tempShiftType) {
                             setWardShiftTypes(
                                 produce(wardShiftTypes, (draft) => {
                                     draft[tempShiftType.wardShiftTypeId] = shiftType;

--- a/src/features/register-ward/ui/RegisterWardShiftTypesSection.tsx
+++ b/src/features/register-ward/ui/RegisterWardShiftTypesSection.tsx
@@ -1,0 +1,126 @@
+import {produce} from 'immer';
+import {type Dispatch, type SetStateAction, useState} from 'react';
+import {type TWardShiftType} from '@/entities/ward';
+import CreateShiftModal from '@/features/ward/CreateShiftModal';
+import {type TCreateShiftTypeDTO, type TCreateWardDTO} from '@/shared/api/ward/type';
+import {PenIcon, PlusIcon} from '@/shared/assets/svg';
+
+interface IRegisterWardShiftTypesSectionProps {
+    wardShiftTypes: TCreateWardDTO['wardShiftTypes'];
+    setWardShiftTypes: Dispatch<SetStateAction<TCreateWardDTO['wardShiftTypes']>>;
+}
+
+function RegisterWardShiftTypesSection({wardShiftTypes, setWardShiftTypes}: IRegisterWardShiftTypesSectionProps) {
+    const [openModal, setOpenModal] = useState(false);
+    const [tempShiftType, setTempShiftType] = useState<TWardShiftType | null>(null);
+
+    return (
+        <div className="mt-5 w-full shrink-0 rounded-[1.25rem] bg-white px-11.25 py-7.5 shadow-banner">
+            <div className="flex items-center justify-between">
+                <p className="font-apple text-[1.25rem] font-medium text-sub-3">근무 유형</p>
+                <div
+                    className="flex cursor-pointer gap-[.625rem]"
+                    onClick={() => {
+                        setOpenModal(true);
+                    }}
+                >
+                    <PlusIcon className="h-6 w-6 stroke-main-2" />
+                    <p className="font-apple text-[1rem] font-medium text-main-2">근무 •휴가 추가하기</p>
+                </div>
+            </div>
+            <div className="relative mt-5 rounded-[.625rem] bg-main-bg">
+                <div className="flex items-center gap-12 pt-5 text-center font-apple text-[.875rem] font-medium text-sub-2.5">
+                    <p className="flex-2">근무 명</p>
+                    <p className="flex-1">약자</p>
+                    <p className="flex-3">근무 시간</p>
+                    <p className="flex-1">색상</p>
+                    <p className="flex-1">유형</p>
+                    <p className="flex-1">수정</p>
+                </div>
+                {wardShiftTypes.map((shiftType, index) => (
+                    <div key={index} className="flex h-18.5 items-center gap-12 border-b-[.0313rem] border-sub-4.5 last:border-0">
+                        <div className="flex flex-2 items-center justify-center font-apple text-[1.25rem] font-medium text-sub-1 underline">
+                            {shiftType.name}
+                        </div>
+                        <div className="flex flex-1 items-center justify-center text-[1.25rem]">
+                            <p className="h-8 w-8 rounded-[.3125rem] bg-white p-0 text-center text-[1.25rem] text-sub-1 outline-[.0313rem] outline-sub-4.5">
+                                {shiftType.shortName}
+                            </p>
+                        </div>
+                        <div className="flex flex-3 items-center justify-center gap-4.5">
+                            {shiftType.isOff ? (
+                                <p className="font-poppins text-[1.25rem] font-light text-sub-2.5">-</p>
+                            ) : (
+                                <>
+                                    <p className="h-7.5 w-full rounded-[.3125rem] bg-white p-0 text-center text-[1.25rem] text-sub-1 outline-[.0313rem] outline-sub-4.5">
+                                        {shiftType.startTime}
+                                    </p>
+                                    <p className="font-poppins text-[1.25rem] font-light text-sub-2.5">~</p>
+                                    <p className="h-7.5 w-full rounded-[.3125rem] bg-white p-0 text-center text-[1.25rem] text-sub-1 outline-[.0313rem] outline-sub-4.5">
+                                        {shiftType.endTime}
+                                    </p>
+                                </>
+                            )}
+                        </div>
+
+                        <div className="relative flex flex-1 items-center justify-center font-apple text-[2.25rem] font-semibold text-sub-2.5">
+                            <div
+                                className="h-8 w-8 rounded-[.4375rem] border-[.0625rem] border-sub-4"
+                                style={{backgroundColor: shiftType.color}}
+                            />
+                        </div>
+                        <div className="flex flex-1 justify-center">
+                            <div className="rounded-[1.875rem] border-[.0313rem] border-main-2 px-[.875rem] py-[.3125rem] font-apple text-[.875rem] text-main-2">
+                                {shiftType.isOff ? '휴가' : '근무'}
+                            </div>
+                        </div>
+                        <div className="flex flex-1 justify-center">
+                            <PenIcon
+                                className="h-9 w-9 cursor-pointer"
+                                onClick={() => {
+                                    setTempShiftType({...shiftType, wardShiftTypeId: index, isCounted: true});
+                                    setOpenModal(true);
+                                }}
+                            />
+                        </div>
+                    </div>
+                ))}
+                <CreateShiftModal
+                    open={openModal}
+                    close={() => {
+                        setTempShiftType(null);
+                        setOpenModal(false);
+                    }}
+                    shiftType={tempShiftType}
+                    onSubmit={(shiftType: TCreateShiftTypeDTO) => {
+                        if (tempShiftType && tempShiftType.wardShiftTypeId !== null) {
+                            setWardShiftTypes(
+                                produce(wardShiftTypes, (draft) => {
+                                    draft[tempShiftType.wardShiftTypeId] = shiftType;
+                                }),
+                            );
+                        } else {
+                            setWardShiftTypes(
+                                produce(wardShiftTypes, (draft) => {
+                                    draft.push(shiftType);
+                                }),
+                            );
+                        }
+
+                        setTempShiftType(null);
+                    }}
+                    onDelete={() =>
+                        tempShiftType &&
+                        setWardShiftTypes(
+                            produce(wardShiftTypes, (draft) => {
+                                draft.splice(tempShiftType.wardShiftTypeId, 1);
+                            }),
+                        )
+                    }
+                />
+            </div>
+        </div>
+    );
+}
+
+export default RegisterWardShiftTypesSection;

--- a/src/pages/RegisterPage/ui/RegisterWard.tsx
+++ b/src/pages/RegisterPage/ui/RegisterWard.tsx
@@ -37,7 +37,7 @@ function RegisterWard() {
 
     useEffect(() => {
         if (accountMe?.status !== 'WARD_SELECT_PENDING') navigate(ROUTE.REGISTER);
-    }, [accountMe]);
+    }, [accountMe, navigate]);
 
     return (
         <div className="relative mx-auto mt-30.75 flex h-[calc(100%-7.6875rem)] w-[52%] flex-col items-center bg-[#FDFCFE]">

--- a/src/pages/RegisterPage/ui/RegisterWard.tsx
+++ b/src/pages/RegisterPage/ui/RegisterWard.tsx
@@ -1,74 +1,22 @@
 import {yupResolver} from '@hookform/resolvers/yup';
-import {produce} from 'immer';
 import {useEffect, useState} from 'react';
 import {useForm} from 'react-hook-form';
 import {useNavigate} from 'react-router';
 import {match} from 'ts-pattern';
-import * as yup from 'yup';
-import {type TWardShiftType} from '@/entities/ward';
 import useRegister from '@/features/auth/useRegister';
-import CreateShiftModal from '@/features/ward/CreateShiftModal';
-import {type TCreateShiftTypeDTO, type TCreateWardDTO} from '@/shared/api/ward/type';
-import {BackIcon, CancelIcon, EnterIcon, FullLogo, LogoSymbolFill, PenIcon, PlusIcon, XIcon} from '@/shared/assets/svg';
+import {registerWardSchema} from '@/features/register-ward/model/schema';
+import {DEFAULT_WARD_SHIFT_TYPES, getWardShiftValidationMessage} from '@/features/register-ward/model/ward';
+import RegisterWardShiftTeamsSection from '@/features/register-ward/ui/RegisterWardShiftTeamsSection';
+import RegisterWardShiftTypesSection from '@/features/register-ward/ui/RegisterWardShiftTypesSection';
+import {type TCreateWardDTO} from '@/shared/api/ward/type';
+import {BackIcon, FullLogo, LogoSymbolFill} from '@/shared/assets/svg';
 import ROUTE from '@/shared/constant/path';
 import Button from '@/shared/ui/Button';
 import TextField from '@/shared/ui/TextField';
 
-const schema = yup.object().shape({
-    name: yup
-        .string()
-        .required()
-        .matches(/^[a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣|0-9|\s]{1,50}$/),
-    hospitalName: yup
-        .string()
-        .required()
-        .matches(/^[a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣|0-9|\s]{1,50}$/),
-});
-
 function RegisterWard() {
     const [shiftTeams, setShiftTeams] = useState<string[][]>([[]]);
-    const [wardShiftTypes, setWardShiftTypes] = useState<TCreateWardDTO['wardShiftTypes']>([
-        {
-            name: '데이',
-            shortName: 'D',
-            startTime: '07:00',
-            endTime: '15:00',
-            color: '#4DC2AD',
-            isDefault: true,
-            isOff: false,
-            classification: 'DAY',
-        },
-        {
-            name: '이브닝',
-            shortName: 'E',
-            startTime: '15:00',
-            endTime: '23:00',
-            color: '#FF8BA5',
-            isDefault: true,
-            isOff: false,
-            classification: 'EVENING',
-        },
-        {
-            name: '나이트',
-            shortName: 'N',
-            startTime: '23:00',
-            endTime: '07:00',
-            color: '#3580FF',
-            isDefault: true,
-            isOff: false,
-            classification: 'NIGHT',
-        },
-        {
-            name: '오프',
-            shortName: 'O',
-            startTime: '',
-            endTime: '',
-            color: '#465B7A',
-            isDefault: true,
-            isOff: true,
-            classification: 'OFF',
-        },
-    ]);
+    const [wardShiftTypes, setWardShiftTypes] = useState<TCreateWardDTO['wardShiftTypes']>(DEFAULT_WARD_SHIFT_TYPES);
     const {
         formState: {errors, isValid},
         register,
@@ -79,24 +27,13 @@ function RegisterWard() {
             name: '',
             hospitalName: '',
         },
-        resolver: yupResolver(schema),
+        resolver: yupResolver(registerWardSchema),
     });
-    const [openModal, setOpenModal] = useState(false);
-    const [tempShiftType, setTempShiftType] = useState<TWardShiftType | null>(null);
     const {
         state: {accountMe},
         actions: {createWard},
     } = useRegister();
     const navigate = useNavigate();
-    const appendClipboardTextToNurse = async (index: number) => {
-        const nurses = (await navigator.clipboard.readText()).split('\n').map((x) => x.replace(/\r/g, ''));
-
-        setShiftTeams(
-            produce(shiftTeams, (draft) => {
-                draft[index] = draft[index].concat(nurses);
-            }),
-        );
-    };
 
     useEffect(() => {
         if (accountMe?.status !== 'WARD_SELECT_PENDING') navigate(ROUTE.REGISTER);
@@ -110,27 +47,11 @@ function RegisterWard() {
             </div>
             <form
                 onSubmit={handleSubmit((d) => {
-                    if (
-                        wardShiftTypes.some((x) => {
-                            if (x.name === '') {
-                                alert('근무 이름을 입력해주세요.');
+                    const validationMessage = getWardShiftValidationMessage(wardShiftTypes);
 
-                                return true;
-                            }
+                    if (validationMessage) {
+                        alert(validationMessage);
 
-                            if (!x.isOff && (x.startTime === '' || x.endTime === '')) {
-                                alert(`${x.name}근무의 근무 시간을 입력해주세요.`);
-
-                                return true;
-                            }
-
-                            if (x.shortName === '') {
-                                alert(`${x.name}근무의 근무 약자를 입력해주세요.`);
-
-                                return true;
-                            }
-                        })
-                    ) {
                         return;
                     }
 
@@ -173,201 +94,8 @@ function RegisterWard() {
                         />
                     </div>
                 </div>
-                <div className="mt-5 w-full shrink-0 rounded-[1.25rem] bg-white px-11.25 py-7.5 shadow-banner">
-                    <div className="flex items-center justify-between">
-                        <p className="font-apple text-[1.25rem] font-medium text-sub-3">근무 유형</p>
-                        <div
-                            className="flex cursor-pointer gap-[.625rem]"
-                            onClick={() => {
-                                setOpenModal(true);
-                            }}
-                        >
-                            <PlusIcon className="h-6 w-6 stroke-main-2" />
-                            <p className="font-apple text-[1rem] font-medium text-main-2">근무 •휴가 추가하기</p>
-                        </div>
-                    </div>
-                    <div className="relative mt-5 rounded-[.625rem] bg-main-bg">
-                        <div className="flex items-center gap-12 pt-5 text-center font-apple text-[.875rem] font-medium text-sub-2.5">
-                            <p className="flex-2">근무 명</p>
-                            <p className="flex-1">약자</p>
-                            <p className="flex-3">근무 시간</p>
-                            <p className="flex-1">색상</p>
-                            <p className="flex-1">유형</p>
-                            <p className="flex-1">수정</p>
-                        </div>
-                        {wardShiftTypes.map((shiftType, index) => (
-                            <div key={index} className={`flex h-18.5 items-center gap-12 border-b-[.0313rem] border-sub-4.5 last:border-0`}>
-                                <div className="flex flex-2 items-center justify-center font-apple text-[1.25rem] font-medium text-sub-1 underline">
-                                    {shiftType.name}
-                                </div>
-                                <div className="flex flex-1 items-center justify-center text-[1.25rem]">
-                                    <p className="h-8 w-8 rounded-[.3125rem] bg-white p-0 text-center text-[1.25rem] text-sub-1 outline-[.0313rem] outline-sub-4.5">
-                                        {shiftType.shortName}
-                                    </p>
-                                </div>
-                                <div className="flex flex-3 items-center justify-center gap-4.5">
-                                    {shiftType.isOff ? (
-                                        <p className="font-poppins text-[1.25rem] font-light text-sub-2.5">-</p>
-                                    ) : (
-                                        <>
-                                            <p className="h-7.5 w-full rounded-[.3125rem] bg-white p-0 text-center text-[1.25rem] text-sub-1 outline-[.0313rem] outline-sub-4.5">
-                                                {shiftType.startTime}
-                                            </p>
-                                            <p className="font-poppins text-[1.25rem] font-light text-sub-2.5">~</p>
-                                            <p className="h-7.5 w-full rounded-[.3125rem] bg-white p-0 text-center text-[1.25rem] text-sub-1 outline-[.0313rem] outline-sub-4.5">
-                                                {shiftType.endTime}
-                                            </p>
-                                        </>
-                                    )}
-                                </div>
-
-                                <div className="relative flex flex-1 items-center justify-center font-apple text-[2.25rem] font-semibold text-sub-2.5">
-                                    <div
-                                        className={`h-8 w-8 rounded-[.4375rem] border-[.0625rem] border-sub-4`}
-                                        style={{backgroundColor: shiftType.color}}
-                                    />
-                                </div>
-                                <div className="flex flex-1 justify-center">
-                                    <div className="rounded-[1.875rem] border-[.0313rem] border-main-2 px-[.875rem] py-[.3125rem] font-apple text-[.875rem] text-main-2">
-                                        {shiftType.isOff ? '휴가' : '근무'}
-                                    </div>
-                                </div>
-                                <div className="flex flex-1 justify-center">
-                                    <PenIcon
-                                        className="h-9 w-9 cursor-pointer"
-                                        onClick={() => {
-                                            setTempShiftType({...shiftType, wardShiftTypeId: index, isCounted: true});
-                                            setOpenModal(true);
-                                        }}
-                                    />
-                                </div>
-                            </div>
-                        ))}
-                        <CreateShiftModal
-                            open={openModal}
-                            close={() => {
-                                setTempShiftType(null);
-                                setOpenModal(false);
-                            }}
-                            shiftType={tempShiftType}
-                            onSubmit={(shiftType: TCreateShiftTypeDTO) => {
-                                if (tempShiftType && tempShiftType.wardShiftTypeId !== null) {
-                                    setWardShiftTypes(
-                                        produce(wardShiftTypes, (draft) => {
-                                            draft[tempShiftType.wardShiftTypeId] = shiftType;
-                                        }),
-                                    );
-                                } else {
-                                    setWardShiftTypes(
-                                        produce(wardShiftTypes, (draft) => {
-                                            draft.push(shiftType);
-                                        }),
-                                    );
-                                }
-
-                                setTempShiftType(null);
-                            }}
-                            onDelete={() =>
-                                tempShiftType &&
-                                setWardShiftTypes(
-                                    produce(wardShiftTypes, (draft) => {
-                                        draft.splice(tempShiftType.wardShiftTypeId, 1);
-                                    }),
-                                )
-                            }
-                        />
-                    </div>
-                </div>
-                <div className="mt-5 w-full shrink-0 rounded-[1.25rem] bg-white px-11.25 py-7.5 shadow-banner">
-                    <div className="mb-6.25 flex items-center">
-                        <p className="font-apple text-[1.25rem] font-medium text-sub-3">병동내 간호사</p>
-                        <p className="ml-6 font-apple text-[1rem] text-main-2">* 본인은 제외해주세요</p>
-                        <div
-                            className="ml-auto flex cursor-pointer gap-[.625rem]"
-                            onClick={() => {
-                                setShiftTeams(
-                                    produce(shiftTeams, (draft) => {
-                                        draft.push([]);
-                                    }),
-                                );
-                            }}
-                        >
-                            <PlusIcon className="h-6 w-6 stroke-main-2" />
-                            <p className="font-apple text-[1rem] font-medium text-main-2">팀 추가하기</p>
-                        </div>
-                    </div>
-                    {shiftTeams.map((shiftTeam, index) => (
-                        <div key={index} className="mt-5">
-                            <div className="flex justify-between">
-                                <div className="flex">
-                                    <div className="flex h-9 w-45 items-center justify-center gap-[.75rem] rounded-t-[.625rem] bg-sub-2 font-apple text-white">
-                                        <p className="text-[1.25rem] font-medium">간호사 {index + 1}팀</p>
-                                        <p className="text-[.875rem]">{shiftTeam.length}명</p>
-                                    </div>
-                                </div>
-                                <CancelIcon
-                                    className="h-6 w-6 cursor-pointer self-center"
-                                    onClick={() => {
-                                        setShiftTeams(
-                                            produce(shiftTeams, (draft) => {
-                                                draft.splice(index, 1);
-                                            }),
-                                        );
-                                    }}
-                                />
-                            </div>
-                            <div className="flex w-full flex-wrap gap-[.625rem] rounded-[.625rem] rounded-tl-none border-[.0313rem] border-sub-3 bg-main-bg p-7.5">
-                                {shiftTeam.map((name, nameIndex) => (
-                                    <div
-                                        key={nameIndex}
-                                        className="flex h-7 items-center gap-[.25rem] rounded-[.3125rem] border-[.0313rem] border-main-2 bg-main-4 px-[.5rem]"
-                                    >
-                                        <p className="font-apple text-[1rem] text-sub-1">{name}</p>
-                                        <XIcon
-                                            className="h-4.5 w-4.5 cursor-pointer"
-                                            onClick={() => {
-                                                setShiftTeams(
-                                                    produce(shiftTeams, (draft) => {
-                                                        draft[index].splice(nameIndex, 1);
-                                                    }),
-                                                );
-                                            }}
-                                        />
-                                    </div>
-                                ))}
-                                <p className="flex h-7 w-27 items-center justify-center rounded-[.3125rem] border-[.0625rem] border-main-1 bg-white font-apple text-[1rem] text-sub-1">
-                                    <input
-                                        placeholder="이름 추가"
-                                        className="w-[70%] focus:outline-none"
-                                        onKeyDown={(e) => {
-                                            if ((e.ctrlKey || e.metaKey) && (e.key === 'v' || e.key === 'V')) {
-                                                e.preventDefault();
-                                                appendClipboardTextToNurse(index);
-
-                                                return;
-                                            }
-
-                                            if (e.nativeEvent.isComposing) return;
-
-                                            if (e.currentTarget.value === '') return;
-
-                                            if (e.key === 'Enter') {
-                                                e.preventDefault();
-                                                setShiftTeams(
-                                                    produce(shiftTeams, (draft) => {
-                                                        draft[index].push(e.currentTarget.value);
-                                                        e.currentTarget.value = '';
-                                                    }),
-                                                );
-                                            }
-                                        }}
-                                    />
-                                    <EnterIcon className="h-6 w-6" />
-                                </p>
-                            </div>
-                        </div>
-                    ))}
-                </div>
+                <RegisterWardShiftTypesSection wardShiftTypes={wardShiftTypes} setWardShiftTypes={setWardShiftTypes} />
+                <RegisterWardShiftTeamsSection shiftTeams={shiftTeams} setShiftTeams={setShiftTeams} />
                 <Button type="submit" disabled={!isValid} className="mt-10 h-15 w-30 self-end text-center text-[2rem] font-semibold">
                     저장
                 </Button>

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -101,6 +101,30 @@ export const en: TLocale = {
         auth: {
             sessionExpired: 'Your login has expired. Please sign in again.',
         },
+        registerWard: {
+            shiftTypes: {
+                title: 'Shift types',
+                addAction: 'Add work/leave type',
+                leave: 'Leave',
+                work: 'Work',
+                column: {
+                    name: 'Shift name',
+                    shortName: 'Abbr.',
+                    workTime: 'Work hours',
+                    color: 'Color',
+                    category: 'Category',
+                    edit: 'Edit',
+                },
+            },
+            shiftTeams: {
+                title: 'Nurses in ward',
+                excludeMe: '* Exclude yourself',
+                addTeam: 'Add team',
+                teamName: 'Nurse Team {{index}}',
+                count: '{{count}}',
+                addNamePlaceholder: 'Add name',
+            },
+        },
         shiftEditor: {
             panel: {
                 histories: 'History',

--- a/src/shared/locales/ko.ts
+++ b/src/shared/locales/ko.ts
@@ -99,6 +99,30 @@ export const ko = {
         auth: {
             sessionExpired: '로그인이 만료되었습니다. 다시 로그인해주세요.',
         },
+        registerWard: {
+            shiftTypes: {
+                title: '근무 유형',
+                addAction: '근무 •휴가 추가하기',
+                leave: '휴가',
+                work: '근무',
+                column: {
+                    name: '근무 명',
+                    shortName: '약자',
+                    workTime: '근무 시간',
+                    color: '색상',
+                    category: '유형',
+                    edit: '수정',
+                },
+            },
+            shiftTeams: {
+                title: '병동내 간호사',
+                excludeMe: '* 본인은 제외해주세요',
+                addTeam: '팀 추가하기',
+                teamName: '간호사 {{index}}팀',
+                count: '{{count}}명',
+                addNamePlaceholder: '이름 추가',
+            },
+        },
         shiftEditor: {
             panel: {
                 histories: '기록',


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-845](https://gom3.atlassian.net/browse/DUT-845)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `RegisterWard` 페이지에서 근무 유형 섹션과 병동내 간호사 섹션을 `register-ward` feature UI로 분리했습니다.
- 병동 생성 폼 스키마, 기본 근무 유형 목록, 근무 유형 검증 로직을 page 밖 model로 이동해 page 책임을 축소했습니다.
- `RegisterWard.tsx`가 상위 폼 조합과 제출 흐름만 담당하도록 정리했습니다.

<br>

## To Reviewers

- 기존 병동 생성 플로우 동작을 유지하면서 FSD 분리만 진행했습니다.
- 검증은 `pnpm type-check`, 변경 파일 대상 `pnpm exec eslint ...`까지 수행했습니다.
- 별도 컴포넌트 테스트는 현재 대상 파일에 기존 테스트가 없어 추가하지 않았습니다.


[DUT-845]: https://gom3.atlassian.net/browse/DUT-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 병동 근무 유형 관리 인터페이스 추가 (추가, 편집, 삭제 기능 포함)
  * 간호사 팀 관리 기능 개선 (팀 생성, 멤버 추가/제거, 복사-붙여넣기 지원)
  * 병동 등록 양식의 유효성 검사 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->