### PR TITLE
[DUT-838]: 로딩/에러/빈 상태 UI 공용화

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -1,6 +1,8 @@
 import {Suspense, lazy} from 'react';
 import {Route, Routes} from 'react-router-dom';
 import ROUTE from '@/shared/constant/path.ts';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import PageState from '@/shared/ui/PageState';
 import {AuthLayout, MainLayout, NotAuthLayout} from '@/widgets/layouts';
 
 const LandingPage = lazy(() => import('@/pages/LandingPage/index.ts'));
@@ -18,8 +20,19 @@ const MemberPage = lazy(() => import('@/pages/MemberPage/index.tsx'));
 const ProfilePage = lazy(() => import('@/pages/ProfilePage/index.tsx'));
 
 export const Router = () => {
+    const {t} = useTypedTranslation();
+
     return (
-        <Suspense fallback={<div></div>}>
+        <Suspense
+            fallback={
+                <PageState
+                    tone="loading"
+                    layout="screen"
+                    title={t('page.state.loadingTitle')}
+                    description={t('page.state.loadingDescription')}
+                />
+            }
+        >
             <Routes>
                 <Route path={ROUTE.ROOT} element={<LandingPage />} />
                 <Route path={ROUTE.REFRESH} element={<RefreshPage />} />

--- a/src/pages/RefreshPage/index.tsx
+++ b/src/pages/RefreshPage/index.tsx
@@ -1,9 +1,9 @@
 import {useEffect} from 'react';
-import {TailSpin} from 'react-loader-spinner';
 import {useLocation} from 'react-router-dom';
 import useRefresh from '@/features/auth/useRefresh';
 import ROUTE from '@/shared/constant/path';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import PageState from '@/shared/ui/PageState';
 
 function RefreshPage() {
     const {refresh} = useRefresh();
@@ -34,12 +34,7 @@ function RefreshPage() {
         };
     }, [refresh, next]);
 
-    return (
-        <div className="flex h-screen w-screen flex-col items-center justify-center">
-            {t('page.refresh.loading')}
-            <TailSpin color="#844AFF" />
-        </div>
-    );
+    return <PageState tone="loading" layout="screen" title={t('page.refresh.loading')} description={t('page.state.loadingDescription')} />;
 }
 
 export default RefreshPage;

--- a/src/pages/duty/model/dutyHook.ts
+++ b/src/pages/duty/model/dutyHook.ts
@@ -205,6 +205,9 @@ export function useDutyHook() {
 
         shiftToExcel(month, shift);
     };
+    const handleRetry = () => {
+        void dutyQuery.refetch();
+    };
 
     return {
         state: {
@@ -231,6 +234,7 @@ export function useDutyHook() {
             goNextMonthMake: handleGoNextMonthMake,
             postShift: handlePostShift,
             exportExcel: handleExportExcel,
+            retry: handleRetry,
             onKeyDown,
             onPaste,
         },

--- a/src/pages/duty/view/index.tsx
+++ b/src/pages/duty/view/index.tsx
@@ -1,6 +1,7 @@
 import {MakeShiftEditorView} from '@/features/shift-editor';
 import {ChevronLeftIcon, ChevronRightIcon} from '@/shared/assets/svg';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import PageState from '@/shared/ui/PageState';
 import {type TDutyHook} from '../model/dutyHook';
 
 type TDutyPageViewProps = {
@@ -121,14 +122,15 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
 
                 <div className="mt-6 min-h-0 flex-1 overflow-auto">
                     {state.status === 'pending' && (
-                        <div className="flex h-full min-h-[300px] items-center justify-center">
-                            <p className="font-apple text-2xl font-semibold text-gray-3">{t('page.duty.loading')}</p>
-                        </div>
+                        <PageState tone="loading" title={t('page.duty.loading')} description={t('page.state.loadingDescription')} />
                     )}
                     {state.status === 'error' && (
-                        <div className="flex h-full min-h-[300px] items-center justify-center">
-                            <p className="font-apple text-2xl font-semibold text-gray-3">{t('page.duty.error')}</p>
-                        </div>
+                        <PageState
+                            tone="error"
+                            title={t('page.duty.error')}
+                            description={t('page.state.errorDescription')}
+                            action={{label: t('page.state.retry'), onClick: handlers.retry}}
+                        />
                     )}
                     {state.status === 'success' && state.shift && (
                         <div

--- a/src/pages/make-shift/model/make-shift-store.ts
+++ b/src/pages/make-shift/model/make-shift-store.ts
@@ -47,6 +47,7 @@ export type TMakeShiftStore = {
     // overview status (MVP)
     shiftStatus: TShiftStatus;
     shiftExists: boolean;
+    reloadToken: number;
 
     // actions (no business logic beyond state transitions)
     startFromStep: (opts: {step: TMakeShiftStep; openRestoreDraftModal: boolean}) => void;
@@ -65,6 +66,7 @@ export type TMakeShiftStore = {
 
     setShiftStatus: (status: TShiftStatus) => void;
     setShiftExists: (exists: boolean) => void;
+    requestReload: () => void;
 };
 
 export const useMakeShiftStore = create<TMakeShiftStore>()(
@@ -80,6 +82,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
 
         shiftStatus: 'idle',
         shiftExists: false,
+        reloadToken: 0,
 
         startFromStep: ({step, openRestoreDraftModal}) => {
             set(() => ({
@@ -164,6 +167,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
 
         setShiftStatus: (shiftStatus) => set(() => ({shiftStatus})),
         setShiftExists: (shiftExists) => set(() => ({shiftExists})),
+        requestReload: () => set((state) => ({reloadToken: state.reloadToken + 1})),
     })),
 );
 

--- a/src/pages/make-shift/model/make-shift-use-case.ts
+++ b/src/pages/make-shift/model/make-shift-use-case.ts
@@ -10,6 +10,7 @@ export function useMakeShiftUseCase() {
     const goPrev = useMakeShiftStore((s) => s.goPrev);
     const goNext = useMakeShiftStore((s) => s.goNext);
     const goToStep = useMakeShiftStore((s) => s.goToStep);
+    const requestReload = useMakeShiftStore((s) => s.requestReload);
     const start = useCallback(() => {
         const persisted = editor.getPersisted();
         const savedStep = loadPersistedStep();
@@ -57,6 +58,9 @@ export function useMakeShiftUseCase() {
     const closeModal = useCallback(() => {
         closeRestoreDraftModal();
     }, [closeRestoreDraftModal]);
+    const retryOverview = useCallback(() => {
+        requestReload();
+    }, [requestReload]);
     // make-shift 단계에서 에디터 state가 필요할 때 대비 (예: 완료 조건 체크)
     const editorState = {
         doc: useShiftEditorStore((s) => s.doc),
@@ -74,5 +78,6 @@ export function useMakeShiftUseCase() {
         next,
         goToStep: jump,
         editorState,
+        retryOverview,
     };
 }

--- a/src/pages/make-shift/model/requestsShiftsHook.ts
+++ b/src/pages/make-shift/model/requestsShiftsHook.ts
@@ -92,6 +92,7 @@ export function useRequestsShiftsHook() {
     const wardShiftTypeMap = useMemo(() => buildShiftTypeMap(shiftTypeSource), [shiftTypeSource]);
     const appliedRequests = useMemo(() => buildAppliedRequests(requestQuery.data ?? null), [requestQuery.data]);
     const queryError = requestQuery.error ?? requestListQuery.error ?? shiftTypesQuery.error;
+    const retry = () => Promise.all([requestQuery.refetch(), requestListQuery.refetch(), shiftTypesQuery.refetch()]);
 
     return {
         state: {
@@ -107,6 +108,9 @@ export function useRequestsShiftsHook() {
         status: {
             loading: requestQuery.isLoading || requestListQuery.isLoading || shiftTypesQuery.isLoading,
             error: Boolean(queryError),
+        },
+        actions: {
+            retry,
         },
     };
 }

--- a/src/pages/make-shift/model/use-bootstrap.ts
+++ b/src/pages/make-shift/model/use-bootstrap.ts
@@ -31,6 +31,7 @@ export function useMakeShiftBootstrap(wardId: number | null) {
     const month = useMakeShiftStore((s) => s.month);
     const currentShiftTeamId = useMakeShiftStore((s) => s.currentShiftTeamId);
     const shiftStatus = useMakeShiftStore((s) => s.shiftStatus);
+    const reloadToken = useMakeShiftStore((s) => s.reloadToken);
 
     useEffect(() => {
         if (!wardId) {
@@ -85,7 +86,7 @@ export function useMakeShiftBootstrap(wardId: number | null) {
         return () => {
             cancelled = true;
         };
-    }, [setCurrentShiftTeamId, setShiftExists, setShiftStatus, setShiftTeams, wardId]);
+    }, [reloadToken, setCurrentShiftTeamId, setShiftExists, setShiftStatus, setShiftTeams, wardId]);
 
     useEffect(() => {
         if (!wardId) return;
@@ -131,7 +132,7 @@ export function useMakeShiftBootstrap(wardId: number | null) {
         return () => {
             cancelled = true;
         };
-    }, [currentShiftTeamId, month, setShiftExists, setShiftStatus, wardId, year]);
+    }, [currentShiftTeamId, month, reloadToken, setShiftExists, setShiftStatus, wardId, year]);
 
     useEffect(() => {
         let cancelled = false;
@@ -160,7 +161,7 @@ export function useMakeShiftBootstrap(wardId: number | null) {
         return () => {
             cancelled = true;
         };
-    }, [currentShiftTeamId, shiftStatus, wardId]);
+    }, [currentShiftTeamId, reloadToken, shiftStatus, wardId]);
 
     useEffect(() => {
         // MVP: 에디터 초기 doc은 데모 데이터로 시작 (이후 real shift->doc 빌드로 교체)

--- a/src/pages/make-shift/view/index.tsx
+++ b/src/pages/make-shift/view/index.tsx
@@ -1,6 +1,7 @@
 import {useNavigate} from 'react-router';
 import ROUTE from '@/shared/constant/path';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import PageState from '@/shared/ui/PageState';
 import {useMakeShiftStore, canGoNext, canGoPrev} from '../model/make-shift-store';
 import {useMakeShiftUseCase} from '../model/make-shift-use-case';
 import {MakeShiftHeader} from './make-shift-header';
@@ -90,18 +91,29 @@ export const MakeShiftPageView = () => {
             <div className="mt-[14px] flex flex-1 flex-col rounded-[20px] bg-white">
                 {isOverview ? (
                     <div className="flex flex-1 items-center justify-center px-10 py-16">
-                        <div className="text-center">
-                            <p className="font-apple text-2xl font-semibold text-gray-3">
-                                {shiftStatus === 'pending' && t('page.makeShift.overview.loading')}
-                                {shiftStatus === 'success' &&
-                                    shiftExists &&
-                                    t('page.makeShift.overview.shiftExists', {teamName: currentShiftTeamName, month})}
-                                {((shiftStatus === 'success' && !shiftExists) || shiftStatus === 'error') &&
-                                    t('page.makeShift.overview.shiftEmpty', {teamName: currentShiftTeamName, month})}
-                                {shiftStatus === 'idle' && t('page.makeShift.overview.checking')}
-                            </p>
+                        {shiftStatus === 'pending' || shiftStatus === 'idle' ? (
+                            <PageState
+                                tone="loading"
+                                title={
+                                    shiftStatus === 'pending' ? t('page.makeShift.overview.loading') : t('page.makeShift.overview.checking')
+                                }
+                                description={t('page.state.loadingDescription')}
+                                className="py-0"
+                            />
+                        ) : shiftStatus === 'error' ? (
+                            <PageState
+                                tone="error"
+                                title={t('page.makeShift.overview.error')}
+                                description={t('page.state.errorDescription')}
+                                action={{label: t('page.state.retry'), onClick: useCase.retryOverview}}
+                                className="py-0"
+                            />
+                        ) : hasCurrentMonthShift ? (
+                            <div className="text-center">
+                                <p className="font-apple text-2xl font-semibold text-gray-3">
+                                    {t('page.makeShift.overview.shiftExists', {teamName: currentShiftTeamName, month})}
+                                </p>
 
-                            {hasCurrentMonthShift ? (
                                 <div className="mt-6 flex items-center justify-center gap-8">
                                     <button
                                         className="rounded-[20px] bg-main-light px-[42px] py-[22px] font-apple text-2xl font-semibold text-main-1"
@@ -118,19 +130,25 @@ export const MakeShiftPageView = () => {
                                         {t('page.makeShift.overview.createShift', {month: nextMonth})}
                                     </button>
                                 </div>
-                            ) : (
-                                <div className="mt-6 flex justify-center">
+                            </div>
+                        ) : (
+                            <PageState
+                                tone="empty"
+                                title={t('page.makeShift.overview.shiftEmpty', {teamName: currentShiftTeamName, month})}
+                                description={t('page.state.emptyDescription')}
+                                className="py-0"
+                            >
+                                <div className="mt-1 flex justify-center">
                                     <button
-                                        className="rounded-[20px] bg-main-light px-10 py-4 font-apple text-xl font-semibold text-main-1 disabled:opacity-50"
+                                        className="rounded-[20px] bg-main-light px-10 py-4 font-apple text-xl font-semibold text-main-1"
                                         onClick={handleCreateCurrentMonth}
-                                        disabled={shiftStatus === 'pending'}
                                         type="button"
                                     >
                                         {t('page.makeShift.overview.createShift', {month})}
                                     </button>
                                 </div>
-                            )}
-                        </div>
+                            </PageState>
+                        )}
                     </div>
                 ) : (
                     <>

--- a/src/pages/make-shift/view/steps/fixed-shifts.tsx
+++ b/src/pages/make-shift/view/steps/fixed-shifts.tsx
@@ -13,6 +13,8 @@ import {
 } from '@/features/shift-editor';
 import CountDutyByDay from '@/features/shift-editor/ui/complex-view/count-duty-by-day';
 import ShiftCalendar from '@/features/shift-editor/ui/complex-view/shift-calendar';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import PageState from '@/shared/ui/PageState';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
 
@@ -32,6 +34,7 @@ function isSameDocShape(a: TDutyDoc, b: TDutyDoc): boolean {
 
 export function FixedShifts() {
     const useCase = useMakeShiftUseCase();
+    const {t} = useTypedTranslation();
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
     const canNext = useMakeShiftStore((s) => canGoNext(s));
     const editorDoc = useShiftEditorStore((s) => s.doc);
@@ -97,14 +100,15 @@ export function FixedShifts() {
 
             <div className="mt-8 flex min-h-0 flex-1 outline-none" onKeyDown={onKeyDown} onPaste={onPaste} ref={editorRef} tabIndex={0}>
                 {dutyQuery.isLoading && (
-                    <div className="flex flex-1 items-center justify-center rounded-[20px] bg-white shadow-banner">
-                        <p className="font-apple text-base text-gray-3">근무표를 불러오는 중입니다...</p>
-                    </div>
+                    <PageState tone="loading" title="근무표를 불러오는 중이에요" description={t('page.state.loadingDescription')} />
                 )}
                 {dutyQuery.isError && (
-                    <div className="flex flex-1 items-center justify-center rounded-[20px] bg-white shadow-banner">
-                        <p className="font-apple text-base text-gray-3">근무표를 불러오지 못했어요.</p>
-                    </div>
+                    <PageState
+                        tone="error"
+                        title="고정 근무 데이터를 불러오지 못했어요"
+                        description={t('page.state.errorDescription')}
+                        action={{label: t('page.state.retry'), onClick: () => void dutyQuery.refetch()}}
+                    />
                 )}
                 {!dutyQuery.isLoading && !dutyQuery.isError && dutyQuery.data && (
                     <div

--- a/src/pages/make-shift/view/steps/requests-shifts.tsx
+++ b/src/pages/make-shift/view/steps/requests-shifts.tsx
@@ -1,17 +1,21 @@
 import {useMemo} from 'react';
 import ShiftBadge from '@/entities/shift/ui/shift-badge';
 import {useUIConfigStore} from '@/entities/ui/useUIConfig/store';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import PageState from '@/shared/ui/PageState';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
 import {useRequestsShiftsHook} from '../../model/requestsShiftsHook';
 
 export function RequestsShifts() {
     const useCase = useMakeShiftUseCase();
+    const {t} = useTypedTranslation();
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
     const canNext = useMakeShiftStore((s) => canGoNext(s));
     const {
         state: {requestShift, requestList, wardShiftTypeMap, appliedRequests},
         status: {loading, error},
+        actions: {retry},
     } = useRequestsShiftsHook();
     const {separateWeekendColor} = useUIConfigStore();
     const pendingRequests = useMemo(() => requestList?.filter((x) => x.isAccepted === null) ?? [], [requestList]);
@@ -53,14 +57,23 @@ export function RequestsShifts() {
             <div className="mt-6 flex min-h-0 flex-1 gap-6">
                 {/* 캘린더 */}
                 <div className="min-w-0 flex-1">
-                    {loading && <div className="p-6 font-apple text-base font-medium text-gray-4">신청 근무 데이터를 불러오는 중...</div>}
+                    {loading && (
+                        <PageState
+                            tone="loading"
+                            title="신청 근무 데이터를 불러오는 중이에요"
+                            description={t('page.state.loadingDescription')}
+                        />
+                    )}
                     {!loading && error && (
-                        <div className="p-6 font-apple text-base font-medium text-gray-4">
-                            데이터를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.
-                        </div>
+                        <PageState
+                            tone="error"
+                            title="신청 근무 데이터를 불러오지 못했어요"
+                            description={t('page.state.errorDescription')}
+                            action={{label: t('page.state.retry'), onClick: () => void retry()}}
+                        />
                     )}
                     {!loading && !error && !requestShift && (
-                        <div className="p-6 font-apple text-base font-medium text-gray-4">이번 달 신청 근무표가 없어요.</div>
+                        <PageState tone="empty" title="이번 달 신청 근무표가 아직 없어요" description={t('page.state.emptyDescription')} />
                     )}
 
                     {!loading && !error && requestShift && (

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -2,6 +2,13 @@ import {type TLocale} from './ko';
 
 export const en: TLocale = {
     page: {
+        state: {
+            loadingTitle: 'Preparing the screen',
+            loadingDescription: 'Please wait a moment.',
+            emptyDescription: 'Content will appear here once it becomes available.',
+            errorDescription: 'Please try again shortly. If the issue continues, refresh and check again.',
+            retry: 'Retry',
+        },
         landing: {
             title: 'Duty Schedule\nNow Easier!',
         },
@@ -11,6 +18,7 @@ export const en: TLocale = {
                 shiftExists: '{{teamName}} has a schedule for {{month}}.',
                 shiftEmpty: "{{teamName}}'s {{month}} schedule is empty.",
                 checking: 'Checking schedule status.',
+                error: 'Failed to check the schedule status.',
                 viewShift: 'View {{month}} duty schedule',
                 createShift: 'Create {{month}} duty schedule',
             },

--- a/src/shared/locales/ko.ts
+++ b/src/shared/locales/ko.ts
@@ -1,5 +1,12 @@
 export const ko = {
     page: {
+        state: {
+            loadingTitle: '화면을 준비하고 있어요',
+            loadingDescription: '잠시만 기다려 주세요.',
+            emptyDescription: '조건이 충족되면 여기에 내용이 표시됩니다.',
+            errorDescription: '잠시 후 다시 시도해 주세요. 문제가 계속되면 새로고침 후 다시 확인해 주세요.',
+            retry: '다시 시도',
+        },
         landing: {
             title: '근무표\n이제 더 간편하게!',
         },
@@ -9,6 +16,7 @@ export const ko = {
                 shiftExists: '{{teamName}}의 {{month}}월 근무표가 존재합니다.',
                 shiftEmpty: '{{teamName}}의 {{month}}월 근무표가 비어있어요',
                 checking: '근무표 상태를 확인 중입니다.',
+                error: '근무표 상태를 확인하지 못했어요.',
                 viewShift: '{{month}}월 근무표 보러가기',
                 createShift: '{{month}}월 근무표 생성하기',
             },

--- a/src/shared/ui/PageState/index.test.tsx
+++ b/src/shared/ui/PageState/index.test.tsx
@@ -1,0 +1,24 @@
+import {describe, expect, it, vi} from 'vitest';
+import {render, screen, userEvent} from '@/shared/util/test-utils';
+import PageState from './index';
+
+describe('PageState 컴포넌트', () => {
+    it('loading 상태에서 title과 description을 렌더링한다', () => {
+        render(<PageState tone="loading" title="불러오는 중" description="잠시만 기다려 주세요." />);
+
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.getByText('불러오는 중')).toBeInTheDocument();
+        expect(screen.getByText('잠시만 기다려 주세요.')).toBeInTheDocument();
+    });
+
+    it('error 상태에서 재시도 액션을 실행한다', async () => {
+        const onClick = vi.fn();
+        const user = userEvent.setup();
+
+        render(<PageState tone="error" title="오류가 발생했어요" action={{label: '다시 시도', onClick}} />);
+
+        await user.click(screen.getByRole('button', {name: '다시 시도'}));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/shared/ui/PageState/index.tsx
+++ b/src/shared/ui/PageState/index.tsx
@@ -1,0 +1,91 @@
+import {Inbox, RotateCcw, TriangleAlert} from 'lucide-react';
+import type {ButtonHTMLAttributes, ReactNode} from 'react';
+import {cn} from '@/shared/util/style';
+
+type TPageStateTone = 'loading' | 'error' | 'empty';
+type TPageStateLayout = 'screen' | 'panel' | 'inline';
+
+type TPageStateAction = {
+    label: string;
+    onClick: ButtonHTMLAttributes<HTMLButtonElement>['onClick'];
+};
+
+type TPageStateProps = {
+    tone: TPageStateTone;
+    title: string;
+    description?: string;
+    action?: TPageStateAction;
+    layout?: TPageStateLayout;
+    className?: string;
+    children?: ReactNode;
+};
+
+const containerClassName: Record<TPageStateLayout, string> = {
+    screen: 'flex min-h-screen w-full items-center justify-center px-6 py-10',
+    panel: 'flex h-full min-h-[300px] w-full items-center justify-center px-6 py-10',
+    inline: 'flex w-full items-center justify-center px-4 py-6',
+};
+const cardClassName: Record<TPageStateTone, string> = {
+    loading: 'border-main-3/40 bg-white/95',
+    error: 'border-red/20 bg-white/95',
+    empty: 'border-gray-6 bg-gray-7/70',
+};
+const iconWrapperClassName: Record<TPageStateTone, string> = {
+    loading: 'bg-main-light text-main-1',
+    error: 'bg-[#FFE7EA] text-red',
+    empty: 'bg-white text-sub-3',
+};
+
+function PageStateIcon({tone}: {tone: TPageStateTone}) {
+    if (tone === 'loading') {
+        return <div className="size-[42px] animate-spin rounded-full border-[3px] border-main-2/25 border-t-main-1" aria-label="loading" />;
+    }
+
+    if (tone === 'error') {
+        return <TriangleAlert className="size-8" strokeWidth={2.2} aria-hidden="true" />;
+    }
+
+    return <Inbox className="size-8" strokeWidth={2.2} aria-hidden="true" />;
+}
+
+function PageState({tone, title, description, action, layout = 'panel', className, children}: TPageStateProps) {
+    const isLoading = tone === 'loading';
+
+    return (
+        <div className={cn(containerClassName[layout], className)}>
+            <div
+                className={cn(
+                    'w-full max-w-[34rem] rounded-[28px] border px-8 py-9 text-center shadow-[0_20px_60px_rgba(18,23,38,0.06)]',
+                    cardClassName[tone],
+                )}
+                role={tone === 'error' ? 'alert' : 'status'}
+                aria-live={tone === 'error' ? 'assertive' : 'polite'}
+            >
+                <div className={cn('mx-auto flex size-[4.5rem] items-center justify-center rounded-[22px]', iconWrapperClassName[tone])}>
+                    <PageStateIcon tone={tone} />
+                </div>
+
+                <h2 className="mt-5 font-apple text-[1.75rem] font-semibold tracking-[-0.02em] text-sub-1">{title}</h2>
+                {description ? <p className="mt-3 font-apple text-base leading-7 text-gray-3">{description}</p> : null}
+
+                {action ? (
+                    <div className="mt-6 flex justify-center">
+                        <button
+                            type="button"
+                            onClick={action.onClick}
+                            className="inline-flex h-11 items-center justify-center gap-2 rounded-[14px] bg-main-1 px-5 font-apple text-base font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+                            disabled={isLoading}
+                        >
+                            <RotateCcw className="size-[18px]" strokeWidth={2.2} aria-hidden="true" />
+                            {action.label}
+                        </button>
+                    </div>
+                ) : null}
+
+                {children ? <div className="mt-5">{children}</div> : null}
+            </div>
+        </div>
+    );
+}
+
+export default PageState;


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-838](https://gom3.atlassian.net/browse/DUT-838)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `PageState` 공용 컴포넌트를 추가해 loading / error / empty 상태의 레이아웃과 CTA 패턴을 공용화했습니다.
- `Router` Suspense fallback과 `RefreshPage` 로딩 화면을 공용 상태 UI로 교체해 빈 `div` fallback을 제거했습니다.
- `duty`, `make-shift` overview, 신청 근무, 고정 근무 화면의 로딩/에러/빈 상태를 같은 패턴으로 정리하고 재시도 가능한 구간에는 `retry` 액션을 연결했습니다.
- `make-shift` overview는 동일 조건 재조회가 가능하도록 bootstrap reload 트리거를 추가했고, 신규 상태 컴포넌트 렌더링 테스트를 추가했습니다.

<br>

## To Reviewers

- `make-shift` overview와 step 화면에서 새 상태 카드의 여백과 시각 톤이 기존 화면 밀도와 어색하지 않은지 봐주세요.
- overview `retry`는 현재 선택된 연/월/팀 기준으로 bootstrap을 다시 실행하는 방식입니다.
- 검증: `./node_modules/.bin/vitest run src/shared/ui/PageState/index.test.tsx`, `./node_modules/.bin/tsc -b`, `./node_modules/.bin/eslint ...`


[DUT-838]: https://gom3.atlassian.net/browse/DUT-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ