### PR TITLE
[DUT-843]: shared api와 domain type 분리

### DIFF
--- a/src/entities/nurse/model/types.ts
+++ b/src/entities/nurse/model/types.ts
@@ -54,7 +54,7 @@ export type TWaitingNurse = {
     name: string;
     gender: string;
     phoneNum: string;
-    employmentDate: boolean;
+    employmentDate: string;
     /** @deprecated use profileImgUrl */
     profileImgBase64?: string;
     profileImgUrl: string;

--- a/src/shared/api/account/index.ts
+++ b/src/shared/api/account/index.ts
@@ -1,20 +1,19 @@
-import {type TAccount} from '@/entities/account';
-import {type TWard} from '@/entities/ward';
 import axiosInstance from '../client';
-import {type TEditProfileRequest, type IAccountAPI} from './type';
+import {type TWardResponse} from '../ward/type';
+import {type TAccountResponse, type TEditProfileRequest, type IAccountAPI} from './type';
 
 class AccountAPI implements IAccountAPI {
-    getAccount = async (accountId: number) => (await axiosInstance.get<TAccount>(`/accounts/v2/${accountId}`)).data;
-    getAccountMe = async () => (await axiosInstance.get<TAccount>('/accounts/me')).data;
-    getAccountMeWaiting = async () => (await axiosInstance.get<TWard>(`/accounts/waiting`)).data;
+    getAccount = async (accountId: number) => (await axiosInstance.get<TAccountResponse>(`/accounts/v2/${accountId}`)).data;
+    getAccountMe = async () => (await axiosInstance.get<TAccountResponse>('/accounts/me')).data;
+    getAccountMeWaiting = async () => (await axiosInstance.get<TWardResponse>(`/accounts/waiting`)).data;
     getDefaultProfileImages = async (): Promise<string[]> =>
         (await axiosInstance.get<{id: number; url: string}[]>(`/accounts/default-images`)).data.map((image) => image.url);
     editAccount = async ({accountId, ...dto}: TEditProfileRequest) =>
-        (await axiosInstance.put<TAccount>(`/accounts/v2/${accountId}`, dto)).data;
-    editAccountStatus = async (accountId: number, status: TAccount['status']) =>
-        (await axiosInstance.patch<TAccount>(`/accounts/${accountId}/status?status=${status}`)).data;
+        (await axiosInstance.put<TAccountResponse>(`/accounts/v2/${accountId}`, dto)).data;
+    editAccountStatus = async (accountId: number, status: TAccountResponse['status']) =>
+        (await axiosInstance.patch<TAccountResponse>(`/accounts/${accountId}/status?status=${status}`)).data;
     initAccount = async ({accountId, ...dto}: TEditProfileRequest) =>
-        (await axiosInstance.patch<TAccount>(`/accounts/v2/${accountId}/init`, dto)).data;
+        (await axiosInstance.patch<TAccountResponse>(`/accounts/v2/${accountId}/init`, dto)).data;
     deleteAccount = async (accountId: number) => (await axiosInstance.delete<void>(`/accounts/${accountId}`)).data;
 }
 

--- a/src/shared/api/account/type.ts
+++ b/src/shared/api/account/type.ts
@@ -1,17 +1,31 @@
-import {type TAccount} from '@/entities/account';
-import {type TWard} from '@/entities/ward';
+import type {TWardResponse} from '../ward/type';
+
+export type TAccountStatus = 'INITIAL' | 'NURSE_INFO_PENDING' | 'WARD_SELECT_PENDING' | 'WARD_ENTRY_PENDING' | 'LINKED' | 'DEMO';
+
+export type TAccountResponse = {
+    accountId: number;
+    nurseId: number | null;
+    wardId: number | null;
+    shiftTeamId: number | null;
+    email: string;
+    name: string;
+    profileImgBase64?: string;
+    profileImgUrl: string;
+    isManager: boolean;
+    status: TAccountStatus;
+};
 
 export interface IAccountAPI {
     // GET
-    getAccount: (accountId: number) => Promise<TAccount>;
-    getAccountMe: () => Promise<TAccount>;
-    getAccountMeWaiting: () => Promise<TWard>;
+    getAccount: (accountId: number) => Promise<TAccountResponse>;
+    getAccountMe: () => Promise<TAccountResponse>;
+    getAccountMeWaiting: () => Promise<TWardResponse>;
     getDefaultProfileImages: () => Promise<string[]>;
     // PUT
-    editAccount: (dto: TEditProfileRequest) => Promise<TAccount>;
-    editAccountStatus: (accountId: number, status: TAccount['status']) => Promise<TAccount>;
+    editAccount: (dto: TEditProfileRequest) => Promise<TAccountResponse>;
+    editAccountStatus: (accountId: number, status: TAccountStatus) => Promise<TAccountResponse>;
     // PATCH
-    initAccount: (dto: TEditProfileRequest) => Promise<TAccount>;
+    initAccount: (dto: TEditProfileRequest) => Promise<TAccountResponse>;
     // DELETE
     deleteAccount: (accountId: number) => Promise<void>;
 }

--- a/src/shared/api/auth/index.ts
+++ b/src/shared/api/auth/index.ts
@@ -1,11 +1,8 @@
-import {type TAccount} from '@/entities/account';
-import {type TWard} from '@/entities/ward';
 import axiosInstance from '../client';
-import {type IAuthAPI} from './type';
+import {type IAuthAPI, type TDemoStartResponse} from './type';
 
 class AuthAPI implements IAuthAPI {
-    demoStart = async () =>
-        (await axiosInstance.post<{wardResDto: TWard; accountResDto: TAccount; accessToken: string}>('/demo/start')).data;
+    demoStart = async () => (await axiosInstance.post<TDemoStartResponse>('/demo/start')).data;
     logout = async (accessToken: string | null) => (await axiosInstance.post('/token/blacklist', {accessToken})).data;
 }
 

--- a/src/shared/api/auth/type.ts
+++ b/src/shared/api/auth/type.ts
@@ -1,8 +1,14 @@
-import {type TAccount} from '@/entities/account';
-import {type TWard} from '@/entities/ward';
+import type {TAccountResponse} from '../account/type';
+import type {TWardResponse} from '../ward/type';
+
+export type TDemoStartResponse = {
+    wardResDto: TWardResponse;
+    accountResDto: TAccountResponse;
+    accessToken: string;
+};
 
 export interface IAuthAPI {
     // POST
-    demoStart: () => Promise<{wardResDto: TWard; accountResDto: TAccount; accessToken: string}>;
+    demoStart: () => Promise<TDemoStartResponse>;
     logout: (accessToken: string | null) => Promise<void>;
 }

--- a/src/shared/api/nurse/index.ts
+++ b/src/shared/api/nurse/index.ts
@@ -1,20 +1,20 @@
-import {type TNurse} from '@/entities/nurse';
 import axiosInstance from '../client';
-import {type INurseAPI, type TCreateNurseDTO, type TUpdateNurseDTO, type TUpdateNurseShiftTypeRequest} from './type';
+import {type INurseAPI, type TNurseResponse, type TCreateNurseDTO, type TUpdateNurseDTO, type TUpdateNurseShiftTypeRequest} from './type';
 
 class NurseAPI implements INurseAPI {
     createAccountNurse = async (accountId: number, createNurse: TCreateNurseDTO) =>
         (
-            await axiosInstance.post<TNurse>(`/nurses?accountId=${accountId}`, {
+            await axiosInstance.post<TNurseResponse>(`/nurses?accountId=${accountId}`, {
                 ...createNurse,
                 phoneNum: createNurse.phoneNum.replace(/-+/g, ''),
                 employmentDate: createNurse.employmentDate.replace(/-/g, ''),
             })
         ).data;
-    getNurse = async (nurseId: number) => (await axiosInstance.get<TNurse>(`/nurses/${nurseId}`)).data;
+    getNurse = async (nurseId: number) => (await axiosInstance.get<TNurseResponse>(`/nurses/${nurseId}`)).data;
     updateNurse = async (nurseId: number, updatedNurse: TUpdateNurseDTO) =>
-        (await axiosInstance.patch<TNurse>(`/nurses/${nurseId}`, updatedNurse)).data;
-    updateNurseStatus = async (nurseId: number, status: string) => (await axiosInstance.patch<TNurse>(`/nurses/${nurseId}`, {status})).data;
+        (await axiosInstance.patch<TNurseResponse>(`/nurses/${nurseId}`, updatedNurse)).data;
+    updateNurseStatus = async (nurseId: number, status: string) =>
+        (await axiosInstance.patch<TNurseResponse>(`/nurses/${nurseId}`, {status})).data;
     connectNurse = async (nurseId: number) => (await axiosInstance.post(`/nurses/${nurseId}/connect`)).data;
     unConnectNurse = async (nurseId: number) => (await axiosInstance.delete(`/nurses/${nurseId}/connect`)).data;
     updateNurseOrder = async (

--- a/src/shared/api/nurse/type.ts
+++ b/src/shared/api/nurse/type.ts
@@ -1,14 +1,38 @@
-import {type TNurse} from '@/entities/nurse';
+export type TNurseResponse = {
+    nurseId: number;
+    accountId: number | null;
+    shiftTeamId: number | null;
+    wardId: number;
+    name: string;
+    phoneNum: string;
+    isConnected: boolean;
+    nurseShiftTypes: {
+        nurseShiftTypeId: number;
+        name: string;
+        shortName: string;
+        isPossible: boolean;
+        isPreferred: boolean;
+    }[];
+    isWorker: boolean;
+    isDutyManager: boolean;
+    isWardManager: boolean;
+    gender: string;
+    employmentDate: string;
+    memo: string;
+    isDeleted: boolean;
+    divisionNum: number;
+    priority: number;
+};
 
 export interface INurseAPI {
     // GET
-    getNurse: (nurseId: number) => Promise<TNurse>;
+    getNurse: (nurseId: number) => Promise<TNurseResponse>;
     // POST
-    createAccountNurse: (accountId: number, createNurse: TCreateNurseDTO) => Promise<TNurse>;
+    createAccountNurse: (accountId: number, createNurse: TCreateNurseDTO) => Promise<TNurseResponse>;
     connectNurse: (nurseId: number) => Promise<void>;
     // PATCH
-    updateNurse: (nurseId: number, updatedNurse: TUpdateNurseDTO) => Promise<TNurse>;
-    updateNurseStatus: (nurseId: number, status: string) => Promise<TNurse>;
+    updateNurse: (nurseId: number, updatedNurse: TUpdateNurseDTO) => Promise<TNurseResponse>;
+    updateNurseStatus: (nurseId: number, status: string) => Promise<TNurseResponse>;
     updateNurseOrder: (
         nurseId: number,
         shiftTeamId: number,
@@ -25,12 +49,24 @@ export interface INurseAPI {
     unConnectNurse: (nurseId: number) => Promise<void>;
 }
 
-export type TCreateNurseDTO = Pick<TNurse, 'name' | 'phoneNum' | 'gender' | 'isWorker' | 'employmentDate'>;
+export type TCreateNurseDTO = {
+    name: string;
+    phoneNum: string;
+    gender: string;
+    isWorker: boolean;
+    employmentDate: string;
+};
 
-export type TUpdateNurseDTO = Pick<
-    TNurse,
-    'name' | 'phoneNum' | 'gender' | 'isWorker' | 'employmentDate' | 'isDutyManager' | 'isWardManager' | 'memo'
->;
+export type TUpdateNurseDTO = {
+    name: string;
+    phoneNum: string;
+    gender: string;
+    isWorker: boolean;
+    employmentDate: string;
+    isDutyManager: boolean;
+    isWardManager: boolean;
+    memo: string;
+};
 
 export type TUpdateNurseShiftTypeRequest = {
     isPossible?: boolean;

--- a/src/shared/api/ward/index.ts
+++ b/src/shared/api/ward/index.ts
@@ -1,30 +1,36 @@
 import qs from 'qs';
-import {type TWaitingNurse, type TNurse} from '@/entities/nurse';
-import {type TRequestShift, type TShift, type TDutyRequest} from '@/entities/shift';
-import {type TWardConstraint, type TWard, type TShiftTeam, type TWardShiftType} from '@/entities/ward';
 import axiosInstance from '../client';
-import {type TUpdateNurseDTO} from '../nurse/type';
+import {type TNurseResponse, type TUpdateNurseDTO} from '../nurse/type';
 import {
+    type TDutyRequestResponse,
     type IWardAPI,
+    type TRequestShiftResponse,
     type TCreateWardDTO,
     type TEditWardDTO,
+    type TShiftResponse,
+    type TShiftTeamResponse,
+    type TWaitingNurseResponse,
     type TWardShiftsDTO,
+    type TWardConstraintDTO,
+    type TWardConstraintResponse,
+    type TWardResponse,
+    type TWardShiftTypeResponse,
     type TUpdateShiftTeamDTO,
     type TCreateShiftTypeDTO,
 } from './type';
 
 class WardAPI implements IWardAPI {
     // Ward APIs
-    getWard = async (wardId: number) => (await axiosInstance.get<TWard>(`/wards/${wardId}`)).data;
-    createWard = async (createWardDTO: TCreateWardDTO) => (await axiosInstance.post<TWard>(`/wards`, createWardDTO)).data;
-    editWard = async (wardId: number, ward: TEditWardDTO) => (await axiosInstance.patch<TWard>(`/wards/${wardId}`, ward)).data;
+    getWard = async (wardId: number) => (await axiosInstance.get<TWardResponse>(`/wards/${wardId}`)).data;
+    createWard = async (createWardDTO: TCreateWardDTO) => (await axiosInstance.post<TWardResponse>(`/wards`, createWardDTO)).data;
+    editWard = async (wardId: number, ward: TEditWardDTO) => (await axiosInstance.patch<TWardResponse>(`/wards/${wardId}`, ward)).data;
     getWardConstraint = async (wardId: number, shiftTeamId: number) =>
-        (await axiosInstance.get<TWardConstraint>(`/wards/${wardId}/shift-teams/${shiftTeamId}/constraint`)).data;
-    updateWardConstraint = async (wardId: number, shiftTeamId: number, constraint: TWardConstraint) =>
-        (await axiosInstance.patch<TWardConstraint>(`/wards/${wardId}/shift-teams/${shiftTeamId}/constraint`, constraint)).data;
-    getWardByCode = async (code: string) => (await axiosInstance.get<TWard>(`/wards/search?code=${code}`)).data;
+        (await axiosInstance.get<TWardConstraintResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}/constraint`)).data;
+    updateWardConstraint = async (wardId: number, shiftTeamId: number, constraint: TWardConstraintDTO) =>
+        (await axiosInstance.patch<TWardConstraintResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}/constraint`, constraint)).data;
+    getWardByCode = async (code: string) => (await axiosInstance.get<TWardResponse>(`/wards/search?code=${code}`)).data;
     getWatingNurses = async (wardId: number) =>
-        (await axiosInstance.get<{nurses: TWaitingNurse[]}>(`/wards/${wardId}/waiting-nurses/v2`)).data.nurses;
+        (await axiosInstance.get<{nurses: TWaitingNurseResponse[]}>(`/wards/${wardId}/waiting-nurses/v2`)).data.nurses;
     addMeToWatingNurses = async (wardId: number) => (await axiosInstance.post(`/wards/${wardId}/waiting-nurses`)).data;
     connectWatingNurses = async (wardId: number, waitingNurseId: number, targetNurseId: number) =>
         (await axiosInstance.post(`/wards/${wardId}/waiting-nurses/${waitingNurseId}/connect?targetNurseId=${targetNurseId}`)).data;
@@ -36,13 +42,16 @@ class WardAPI implements IWardAPI {
 
     // Shift APIs
     getReqShift = async (wardId: number, shiftTeamId: number, year: number, month: number) =>
-        (await axiosInstance.get<TRequestShift>(`/wards/${wardId}/shift-teams/${shiftTeamId}/req-duty?${qs.stringify({year, month})}`))
-            .data;
+        (
+            await axiosInstance.get<TRequestShiftResponse>(
+                `/wards/${wardId}/shift-teams/${shiftTeamId}/req-duty?${qs.stringify({year, month})}`,
+            )
+        ).data;
     getShift = async (wardId: number, shiftTeamId: number, year: number, month: number) =>
-        (await axiosInstance.get<TShift>(`/wards/${wardId}/shift-teams/${shiftTeamId}/duty?${qs.stringify({year, month})}`)).data;
+        (await axiosInstance.get<TShiftResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}/duty?${qs.stringify({year, month})}`)).data;
     getRequestList = async (wardId: number, shiftTeamId: number, year: number, month: number) =>
         (
-            await axiosInstance.get<TDutyRequest[]>(
+            await axiosInstance.get<TDutyRequestResponse[]>(
                 `/wards/${wardId}/shift-teams/${shiftTeamId}/req-duty/req-list?${qs.stringify({
                     year,
                     month,
@@ -93,29 +102,29 @@ class WardAPI implements IWardAPI {
 
     // ShiftTeam APIs
     getShiftTeamNurses = async (wardId: number, shiftTeamId: number) =>
-        (await axiosInstance.get<{nurses: TNurse[]}>(`/wards/${wardId}/shift-teams/${shiftTeamId}/nurses`)).data.nurses;
+        (await axiosInstance.get<{nurses: TShiftTeamResponse['nurses']}>(`/wards/${wardId}/shift-teams/${shiftTeamId}/nurses`)).data.nurses;
     addNurseIntoShiftTeam = async (wardId: number, shiftTeamId: number, addShiftTeamNurseDTO: TUpdateNurseDTO) =>
-        (await axiosInstance.post<TNurse>(`/wards/${wardId}/shift-teams/${shiftTeamId}/nurses`, addShiftTeamNurseDTO)).data;
+        (await axiosInstance.post<TNurseResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}/nurses`, addShiftTeamNurseDTO)).data;
     removeNurseFromShiftTeam = async (wardId: number, shiftTeamId: number, nurseId: number) =>
-        (await axiosInstance.delete<TNurse>(`/wards/${wardId}/shift-teams/${shiftTeamId}/nurses/${nurseId}`)).data;
+        (await axiosInstance.delete<TNurseResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}/nurses/${nurseId}`)).data;
     getShiftTeams = async (wardId: number) =>
-        (await axiosInstance.get<{shiftTeams: TShiftTeam[]}>(`/wards/${wardId}/shift-teams`)).data.shiftTeams;
-    createShiftTeam = async (wardId: number) => (await axiosInstance.post<TShiftTeam>(`/wards/${wardId}/shift-teams`)).data;
+        (await axiosInstance.get<{shiftTeams: TShiftTeamResponse[]}>(`/wards/${wardId}/shift-teams`)).data.shiftTeams;
+    createShiftTeam = async (wardId: number) => (await axiosInstance.post<TShiftTeamResponse>(`/wards/${wardId}/shift-teams`)).data;
     buildShiftTeam = async (wardId: number, shiftTeamId: number, year: number, month: number) =>
-        (await axiosInstance.post<TShiftTeam>(`/wards/${wardId}/shift-teams/${shiftTeamId}?${qs.stringify({year, month})}`)).data;
+        (await axiosInstance.post<TShiftTeamResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}?${qs.stringify({year, month})}`)).data;
     deleteShiftTeam = async (wardId: number, shiftTeamId: number) =>
-        (await axiosInstance.delete<TShiftTeam>(`/wards/${wardId}/shift-teams/${shiftTeamId}`)).data;
+        (await axiosInstance.delete<TShiftTeamResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}`)).data;
     updateShiftTeam = async (wardId: number, shiftTeamId: number, updateShiftTeamDTO: TUpdateShiftTeamDTO) =>
-        (await axiosInstance.patch<TShiftTeam>(`/wards/${wardId}/shift-teams/${shiftTeamId}`, updateShiftTeamDTO)).data;
+        (await axiosInstance.patch<TShiftTeamResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}`, updateShiftTeamDTO)).data;
 
     // ShiftType APIs
-    getShiftTypes = async (wardId: number) => (await axiosInstance.get<TWardShiftType[]>(`/wards/${wardId}/shift-types`)).data;
+    getShiftTypes = async (wardId: number) => (await axiosInstance.get<TWardShiftTypeResponse[]>(`/wards/${wardId}/shift-types`)).data;
     createShiftType = async (wardId: number, createShiftTypeDTO: TCreateShiftTypeDTO) =>
-        (await axiosInstance.post<TWardShiftType>(`/wards/${wardId}/shift-types`, createShiftTypeDTO)).data;
+        (await axiosInstance.post<TWardShiftTypeResponse>(`/wards/${wardId}/shift-types`, createShiftTypeDTO)).data;
     deleteShiftType = async (wardId: number, shiftTypeId: number) =>
         (await axiosInstance.delete(`/wards/${wardId}/shift-types/${shiftTypeId}`)).data;
     updateShiftType = async (wardId: number, shiftTypeId: number, createShiftTypeDTO: TCreateShiftTypeDTO) =>
-        (await axiosInstance.put<TWardShiftType>(`/wards/${wardId}/shift-types/${shiftTypeId}`, createShiftTypeDTO)).data;
+        (await axiosInstance.put<TWardShiftTypeResponse>(`/wards/${wardId}/shift-types/${shiftTypeId}`, createShiftTypeDTO)).data;
 }
 
 export default new WardAPI();

--- a/src/shared/api/ward/type.ts
+++ b/src/shared/api/ward/type.ts
@@ -6,7 +6,7 @@ export type TWaitingNurseResponse = {
     name: string;
     gender: string;
     phoneNum: string;
-    employmentDate: boolean;
+    employmentDate: string;
     profileImgBase64?: string;
     profileImgUrl: string;
 };

--- a/src/shared/api/ward/type.ts
+++ b/src/shared/api/ward/type.ts
@@ -1,32 +1,133 @@
-import {type TWaitingNurse, type TNurse} from '@/entities/nurse';
-import {type TDutyRequest, type TRequestShift, type TShift} from '@/entities/shift';
-import {type TWard, type TWardConstraint, type TWardShiftType, type TShiftTeam} from '@/entities/ward';
-import {type TUpdateNurseDTO} from '../nurse/type';
+import {type TNurseResponse, type TUpdateNurseDTO} from '../nurse/type';
+
+export type TWaitingNurseResponse = {
+    waitingNurseId: number;
+    nurseId: number;
+    name: string;
+    gender: string;
+    phoneNum: string;
+    employmentDate: boolean;
+    profileImgBase64?: string;
+    profileImgUrl: string;
+};
+
+export type TWardConstraintResponse = {
+    maxContinuousWork: boolean;
+    maxContinuousWorkVal: number;
+    minNightInterval: boolean;
+    minNightIntervalVal: number;
+    maxContinuousNight: boolean;
+    maxContinuousNightVal: number;
+    minContinuousNight: boolean;
+    minContinuousNightVal: number;
+    minOffAssignAfterNight: boolean;
+    minOffAssignAfterNightVal: number;
+    excludeCertainWorkTypes: boolean;
+    excludeNightBeforeReqOff: boolean;
+};
+
+export type TWardShiftTypeResponse = {
+    wardShiftTypeId: number;
+    name: string;
+    shortName: string;
+    startTime: string;
+    endTime: string;
+    color: string;
+    isDefault: boolean;
+    isOff: boolean;
+    isCounted: boolean;
+    classification: 'DAY' | 'EVENING' | 'NIGHT' | 'OTHER_WORK' | 'OFF' | 'OTHER_LEAVE';
+};
+
+export type TShiftTeamResponse = {
+    shiftTeamId: number;
+    name: string;
+    nurseCnt: number;
+    nurses: TNurseResponse[];
+};
+
+export type TWardResponse = {
+    wardId: number;
+    name: string;
+    code: string;
+    hospitalName: string;
+    nurseCnt: number;
+    wardShiftTypes: TWardShiftTypeResponse[];
+    shiftTeams: TShiftTeamResponse[];
+};
+
+export type TShiftNurseResponse = {
+    shiftNurseId: number;
+    name: string;
+    carried: number;
+    divisionNum: number;
+    priority: number;
+    isWorker: true;
+    nurseId: number;
+};
+
+export type TDayResponse = {day: number; dayType: 'saturday' | 'sunday' | 'holiday' | 'workday'};
+
+export type TShiftResponse = {
+    lastDays: Array<TDayResponse>;
+    days: Array<TDayResponse>;
+    wardShiftTypes: TWardShiftTypeResponse[];
+    divisionShiftNurses: {
+        shiftNurse: TShiftNurseResponse;
+        lastWardShiftList: (number | null)[];
+        lastWardReqShiftList: (number | null)[];
+        wardShiftList: (number | null)[];
+        wardReqShiftList: (number | null)[];
+    }[][];
+};
+
+export type TRequestShiftResponse = {
+    days: Array<TDayResponse>;
+    wardShiftTypes: TWardShiftTypeResponse[];
+    divisionShiftNurses: {
+        shiftNurse: TShiftNurseResponse;
+        carry: number;
+        wardReqShiftList: (number | null)[];
+    }[][];
+};
+
+export type TDutyRequestResponse = {
+    wardReqShiftId: number;
+    nurseId: number;
+    nurseName: string;
+    date: number;
+    requestDate: string;
+    wardShiftTypeId: number;
+    wardShiftTypeShortName: string;
+    wardShiftTypeColor: string;
+    isRead: boolean;
+    isAccepted: boolean | null;
+};
 
 export interface IWardAPI {
     // Ward APIs
     // GET
-    getWard: (wardId: number) => Promise<TWard>;
-    getWardConstraint: (wardId: number, shiftTeamId: number) => Promise<TWardConstraint>;
-    getWardByCode: (code: string) => Promise<TWard>;
-    getWatingNurses: (wardId: number) => Promise<TWaitingNurse[]>;
+    getWard: (wardId: number) => Promise<TWardResponse>;
+    getWardConstraint: (wardId: number, shiftTeamId: number) => Promise<TWardConstraintResponse>;
+    getWardByCode: (code: string) => Promise<TWardResponse>;
+    getWatingNurses: (wardId: number) => Promise<TWaitingNurseResponse[]>;
     // POST
-    createWard: (createWardDTO: TCreateWardDTO) => Promise<TWard>;
+    createWard: (createWardDTO: TCreateWardDTO) => Promise<TWardResponse>;
     addMeToWatingNurses: (wardId: number) => Promise<void>;
     connectWatingNurses: (wardId: number, waitingNurseId: number, targetNurseId: number) => Promise<void>;
     approveWatingNurses: (wardId: number, waitingNurseId: number, shiftTeamId: number) => Promise<void>;
     // PATCH
-    editWard: (wardId: number, ward: TEditWardDTO) => Promise<TWard>;
-    updateWardConstraint: (wardId: number, shiftTeamId: number, constraint: TWardConstraint) => Promise<TWardConstraint>;
+    editWard: (wardId: number, ward: TEditWardDTO) => Promise<TWardResponse>;
+    updateWardConstraint: (wardId: number, shiftTeamId: number, constraint: TWardConstraintDTO) => Promise<TWardConstraintResponse>;
     // DELETE
     deleteWatingNurses: (wardId: number, nurseId: number) => Promise<void>;
     quitWard: (wardId: number) => Promise<void>;
 
     // Shift APIs
     // GET
-    getReqShift: (wardId: number, shiftTeamId: number, year: number, month: number) => Promise<TRequestShift>;
-    getShift: (wardId: number, shiftTeamId: number, year: number, month: number) => Promise<TShift>;
-    getRequestList: (wardId: number, shiftTeamId: number, year: number, month: number) => Promise<TDutyRequest[]>;
+    getReqShift: (wardId: number, shiftTeamId: number, year: number, month: number) => Promise<TRequestShiftResponse>;
+    getShift: (wardId: number, shiftTeamId: number, year: number, month: number) => Promise<TShiftResponse>;
+    getRequestList: (wardId: number, shiftTeamId: number, year: number, month: number) => Promise<TDutyRequestResponse[]>;
     // PATCH
     updateShift: (
         wardId: number,
@@ -51,37 +152,53 @@ export interface IWardAPI {
 
     // ShiftTeam APIs
     // GET
-    getShiftTeamNurses: (wardId: number, shiftTeamId: number) => Promise<TNurse[]>;
-    getShiftTeams: (wardId: number) => Promise<TShiftTeam[]>;
+    getShiftTeamNurses: (wardId: number, shiftTeamId: number) => Promise<TNurseResponse[]>;
+    getShiftTeams: (wardId: number) => Promise<TShiftTeamResponse[]>;
     // POST
-    addNurseIntoShiftTeam: (wardId: number, shiftTeamId: number, addShiftTeamNurseDTO: TUpdateNurseDTO) => Promise<TNurse>;
-    createShiftTeam: (wardId: number) => Promise<TShiftTeam>;
-    buildShiftTeam: (wardId: number, shiftTeamId: number, year: number, month: number) => Promise<TShiftTeam>;
+    addNurseIntoShiftTeam: (wardId: number, shiftTeamId: number, addShiftTeamNurseDTO: TUpdateNurseDTO) => Promise<TNurseResponse>;
+    createShiftTeam: (wardId: number) => Promise<TShiftTeamResponse>;
+    buildShiftTeam: (wardId: number, shiftTeamId: number, year: number, month: number) => Promise<TShiftTeamResponse>;
     // PATCH
-    updateShiftTeam: (wardId: number, shiftTeamId: number, updateShiftTeamDTO: TUpdateShiftTeamDTO) => Promise<TShiftTeam>;
+    updateShiftTeam: (wardId: number, shiftTeamId: number, updateShiftTeamDTO: TUpdateShiftTeamDTO) => Promise<TShiftTeamResponse>;
     // DELETE
-    removeNurseFromShiftTeam: (wardId: number, shiftTeamId: number, nurseId: number) => Promise<TNurse>;
-    deleteShiftTeam: (wardId: number, shiftTeamId: number) => Promise<TShiftTeam>;
+    removeNurseFromShiftTeam: (wardId: number, shiftTeamId: number, nurseId: number) => Promise<TNurseResponse>;
+    deleteShiftTeam: (wardId: number, shiftTeamId: number) => Promise<TShiftTeamResponse>;
 
     // ShiftType APIs
     // GET
-    getShiftTypes: (wardId: number) => Promise<TWardShiftType[]>;
+    getShiftTypes: (wardId: number) => Promise<TWardShiftTypeResponse[]>;
     // POST
-    createShiftType: (wardId: number, createShiftTypeDTO: TCreateShiftTypeDTO) => Promise<TWardShiftType>;
+    createShiftType: (wardId: number, createShiftTypeDTO: TCreateShiftTypeDTO) => Promise<TWardShiftTypeResponse>;
     // PUT
-    updateShiftType: (wardId: number, shiftTypeId: number, createShiftTypeDTO: TCreateShiftTypeDTO) => Promise<TWardShiftType>;
+    updateShiftType: (wardId: number, shiftTypeId: number, createShiftTypeDTO: TCreateShiftTypeDTO) => Promise<TWardShiftTypeResponse>;
     // DELETE
     deleteShiftType: (wardId: number, shiftTypeId: number) => Promise<void>;
 }
 
+export type TCreateWardShiftTypeDTO = {
+    name: string;
+    shortName: string;
+    color: string;
+    startTime: string;
+    endTime: string;
+    isOff: boolean;
+    isDefault: boolean;
+    classification: TWardShiftTypeResponse['classification'];
+};
+
 export type TCreateWardDTO = {
     name: string;
     hospitalName: string;
-    wardShiftTypes: Omit<TWardShiftType, 'wardShiftTypeId' | 'isCounted'>[];
+    wardShiftTypes: TCreateWardShiftTypeDTO[];
     shiftTeams: {nurseNames: string[]}[];
 };
 
-export type TEditWardDTO = Pick<TWard, 'name' | 'hospitalName'>;
+export type TEditWardDTO = {
+    name: string;
+    hospitalName: string;
+};
+
+export type TWardConstraintDTO = TWardConstraintResponse;
 
 export type TWardShiftsDTO = {
     shiftNurseId: number;
@@ -89,9 +206,18 @@ export type TWardShiftsDTO = {
     wardShiftTypeId: number | null;
 }[];
 
-export type TUpdateShiftTeamDTO = Pick<TShiftTeam, 'name'>;
+export type TUpdateShiftTeamDTO = {
+    name: string;
+};
 
-export type TCreateShiftTypeDTO = Pick<
-    TWardShiftType,
-    'name' | 'shortName' | 'color' | 'startTime' | 'endTime' | 'isOff' | 'isDefault' | 'isCounted' | 'classification'
->;
+export type TCreateShiftTypeDTO = {
+    name: string;
+    shortName: string;
+    color: string;
+    startTime: string;
+    endTime: string;
+    isOff: boolean;
+    isDefault: boolean;
+    isCounted: boolean;
+    classification: TWardShiftTypeResponse['classification'];
+};


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-843](https://gom3.atlassian.net/browse/DUT-843)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `shared/api/account`, `auth`, `nurse`, `ward`의 응답 타입을 entities 타입 대신 API contract 타입으로 재정의했습니다.
- `shared/api`의 DTO 타입에서 `entities` 기반 `Pick`/직접 import를 제거하고, contract 책임이 각 API 모듈 안에 머물도록 정리했습니다.
- API 구현부의 axios 제네릭도 contract 타입 기준으로 맞춰 shared 레이어의 import 방향이 FSD 경계에 맞도록 정리했습니다.

<br>

## To Reviewers

- 런타임 응답 shape 변경은 없고 타입 경계만 분리했습니다.
- `shared/api`를 직접 쓰는 호출부는 구조적 타입 호환으로 유지되지만, 추후 domain mapper를 별도 레이어로 두는 확장 여지는 있습니다.
- 검증은 `./node_modules/.bin/tsc -b`와 변경 파일 대상 `./node_modules/.bin/eslint ...`로 수행했습니다.

[DUT-843]: https://gom3.atlassian.net/browse/DUT-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * API 응답 데이터 구조를 개선하여 계정, 간호사, 병동 정보 처리의 일관성을 강화했습니다.
  * 내부 데이터 타입 체계를 업데이트하여 API 통신의 안정성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->