### PR TITLE
[DUT-836]: 공용 UI foundation 정리

### DIFF
--- a/src/pages/OnboardingWardCreatePage/components/WizardButton.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/WizardButton.tsx
@@ -1,5 +1,5 @@
 import {type ButtonHTMLAttributes} from 'react';
-import {Button} from '@/shared/ui/primitives/button';
+import Button from '@/shared/ui/Button';
 import {cn} from '@/shared/util/style';
 
 type TVariant = 'solid' | 'secondary' | 'link';
@@ -12,8 +12,8 @@ function WizardButton({children, variant = 'solid', className, ...props}: IWizar
     return (
         <Button
             type="button"
-            variant={variant === 'solid' ? 'brand' : variant === 'secondary' ? 'soft' : 'link'}
-            size={variant === 'link' ? undefined : 'pill'}
+            variant={variant === 'solid' ? 'default' : variant === 'secondary' ? 'secondary' : 'link'}
+            size={variant === 'link' ? 'md' : 'pill'}
             className={cn(variant === 'link' && 'px-0 text-gray-3 underline underline-offset-2 hover:bg-transparent', className)}
             {...props}
         >

--- a/src/pages/OnboardingWardCreatePage/components/steps/UploadStep.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/steps/UploadStep.tsx
@@ -1,7 +1,7 @@
 import {Upload} from 'lucide-react';
 import {useRef} from 'react';
 import Card from '@/shared/ui/Card';
-import {Button} from '@/shared/ui/primitives/button';
+import Button from '@/shared/ui/Button';
 import type {TOnboardingWardDraft} from '../../model';
 
 interface IUploadStepProps {
@@ -46,8 +46,9 @@ function UploadStep({draft, onUpload}: IUploadStepProps) {
                 />
                 <Button
                     type="button"
-                    variant="outline"
-                    className="mt-5 h-10 rounded-[10px] border-gray-4 bg-gray-6 px-4 font-apple text-[20px] font-medium text-gray-3 hover:bg-gray-5"
+                    variant="secondary"
+                    size="md"
+                    className="mt-5 h-10 rounded-[10px] border-gray-4 px-4 text-[20px] font-medium"
                     onClick={() => inputRef.current?.click()}
                 >
                     파일 업로드

--- a/src/pages/make-shift/view/steps/requests-shifts.tsx
+++ b/src/pages/make-shift/view/steps/requests-shifts.tsx
@@ -2,7 +2,9 @@ import {useMemo} from 'react';
 import ShiftBadge from '@/entities/shift/ui/shift-badge';
 import {useUIConfigStore} from '@/entities/ui/useUIConfig/store';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import Button from '@/shared/ui/Button';
 import PageState from '@/shared/ui/PageState';
+import StatusBadge from '@/shared/ui/StatusBadge';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
 import {useRequestsShiftsHook} from '../../model/requestsShiftsHook';
@@ -28,29 +30,32 @@ export function RequestsShifts() {
                     <p className="font-apple text-xl font-medium text-gray-3">
                         반영된 스케줄은 <span className="text-main-1">근무표에 고정</span>됩니다.
                     </p>
-                    {/* <div className="mt-4 flex flex-wrap items-center gap-2">
-                        <StatusPill label="반영된 신청 근무" count={appliedRequests.length} />
-                        <StatusPill label="반영 대기 신청" count={pendingRequests.length} />
-                    </div> */}
+                    <div className="mt-4 flex flex-wrap items-center gap-2">
+                        <StatusBadge label="반영된 신청 근무" tone="success" count={appliedRequests.length} />
+                        <StatusBadge label="반영 대기 신청" tone="brand" count={pendingRequests.length} />
+                    </div>
                 </div>
 
                 <div className="flex items-center gap-3">
-                    <button
-                        className="h-[42px] rounded-[10px] bg-gray-6 px-5 font-apple text-base font-semibold text-gray-3 disabled:opacity-50"
+                    <Button
+                        variant="secondary"
+                        size="md"
+                        className="h-[42px] rounded-[10px] px-5 font-semibold"
                         onClick={() => useCase.prev()}
                         disabled={!canPrev}
                         type="button"
                     >
                         이전
-                    </button>
-                    <button
-                        className="h-[42px] rounded-[10px] bg-main-1 px-5 font-apple text-base font-semibold text-white disabled:opacity-50"
+                    </Button>
+                    <Button
+                        size="md"
+                        className="h-[42px] rounded-[10px] px-5 font-semibold"
                         onClick={() => useCase.next()}
                         disabled={!canNext}
                         type="button"
                     >
                         다음
-                    </button>
+                    </Button>
                 </div>
             </div>
 

--- a/src/shared/ui/Button/index.test.tsx
+++ b/src/shared/ui/Button/index.test.tsx
@@ -16,6 +16,16 @@ describe('Button 컴포넌트', () => {
         expect(button).toHaveClass('border-main-1', 'bg-transparent', 'text-main-1');
     });
 
+    it('secondary variant와 md size를 조합할 수 있어야 함', () => {
+        render(
+            <Button variant="secondary" size="md">
+                보조 버튼
+            </Button>,
+        );
+
+        expect(screen.getByText('보조 버튼')).toHaveClass('bg-gray-6', 'text-gray-3', 'h-9');
+    });
+
     it('디자인 2.0 기본 버튼 스타일을 사용해야 함', () => {
         render(<Button>테스트 버튼</Button>);
 

--- a/src/shared/ui/Button/index.tsx
+++ b/src/shared/ui/Button/index.tsx
@@ -2,14 +2,34 @@ import * as React from 'react';
 import {Button as ShadcnButton} from '@/shared/ui/primitives/button';
 import {cn} from '@/shared/util/style';
 
-type TButtonProps = React.ComponentProps<typeof ShadcnButton>;
+type TButtonVariant = 'default' | 'outline' | 'secondary' | 'link';
+type TButtonSize = 'hero' | 'pill' | 'md' | 'sm';
 
-function Button({children, className, variant = 'default', ...props}: TButtonProps) {
+type TButtonProps = Omit<React.ComponentProps<typeof ShadcnButton>, 'variant' | 'size'> & {
+    variant?: TButtonVariant;
+    size?: TButtonSize;
+};
+
+const primitiveVariantMap: Record<TButtonVariant, React.ComponentProps<typeof ShadcnButton>['variant']> = {
+    default: 'brand',
+    outline: 'brandOutline',
+    secondary: 'soft',
+    link: 'link',
+};
+
+const primitiveSizeMap: Record<TButtonSize, React.ComponentProps<typeof ShadcnButton>['size']> = {
+    hero: 'hero',
+    pill: 'pill',
+    md: 'default',
+    sm: 'sm',
+};
+
+function Button({children, className, variant = 'default', size = 'hero', ...props}: TButtonProps) {
     return (
         <ShadcnButton
-            variant={variant === 'outline' ? 'brandOutline' : 'brand'}
-            size="hero"
-            className={cn('disabled:bg-main-3', className)}
+            variant={primitiveVariantMap[variant]}
+            size={primitiveSizeMap[size]}
+            className={cn(variant === 'default' && 'disabled:bg-main-3', className)}
             {...props}
         >
             {children}

--- a/src/shared/ui/PageState/index.test.tsx
+++ b/src/shared/ui/PageState/index.test.tsx
@@ -17,7 +17,11 @@ describe('PageState 컴포넌트', () => {
 
         render(<PageState tone="error" title="오류가 발생했어요" action={{label: '다시 시도', onClick}} />);
 
-        await user.click(screen.getByRole('button', {name: '다시 시도'}));
+        const button = screen.getByRole('button', {name: '다시 시도'});
+
+        expect(button).toHaveClass('h-11', 'rounded-[14px]');
+
+        await user.click(button);
 
         expect(onClick).toHaveBeenCalledTimes(1);
     });

--- a/src/shared/ui/PageState/index.tsx
+++ b/src/shared/ui/PageState/index.tsx
@@ -1,5 +1,6 @@
 import {Inbox, RotateCcw, TriangleAlert} from 'lucide-react';
 import type {ButtonHTMLAttributes, ReactNode} from 'react';
+import Button from '@/shared/ui/Button';
 import {cn} from '@/shared/util/style';
 
 type TPageStateTone = 'loading' | 'error' | 'empty';
@@ -70,15 +71,16 @@ function PageState({tone, title, description, action, layout = 'panel', classNam
 
                 {action ? (
                     <div className="mt-6 flex justify-center">
-                        <button
-                            type="button"
+                        <Button
                             onClick={action.onClick}
-                            className="inline-flex h-11 items-center justify-center gap-2 rounded-[14px] bg-main-1 px-5 font-apple text-base font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+                            type="button"
+                            size="md"
+                            className="rounded-[14px] px-5 font-semibold"
                             disabled={isLoading}
                         >
                             <RotateCcw className="size-[18px]" strokeWidth={2.2} aria-hidden="true" />
                             {action.label}
-                        </button>
+                        </Button>
                     </div>
                 ) : null}
 

--- a/src/shared/ui/PageState/index.tsx
+++ b/src/shared/ui/PageState/index.tsx
@@ -75,7 +75,7 @@ function PageState({tone, title, description, action, layout = 'panel', classNam
                             onClick={action.onClick}
                             type="button"
                             size="md"
-                            className="rounded-[14px] px-5 font-semibold"
+                            className="h-11 rounded-[14px] px-5 font-semibold"
                             disabled={isLoading}
                         >
                             <RotateCcw className="size-[18px]" strokeWidth={2.2} aria-hidden="true" />

--- a/src/shared/ui/StatusBadge/index.test.tsx
+++ b/src/shared/ui/StatusBadge/index.test.tsx
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest';
+import {render, screen} from '@/shared/util/test-utils';
+import StatusBadge from '.';
+
+describe('StatusBadge 컴포넌트', () => {
+    it('label과 count를 함께 렌더링해야 함', () => {
+        render(<StatusBadge label="반영 대기" count={3} />);
+
+        expect(screen.getByText('반영 대기')).toBeInTheDocument();
+        expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('tone과 size 조합에 맞는 스타일을 적용해야 함', () => {
+        render(<StatusBadge label="성공" tone="success" size="md" />);
+
+        expect(screen.getByText('성공').parentElement).toHaveClass('bg-[#F3FFF7]', 'text-[#237548]', 'text-base');
+    });
+});

--- a/src/shared/ui/StatusBadge/index.tsx
+++ b/src/shared/ui/StatusBadge/index.tsx
@@ -1,0 +1,41 @@
+import {cva, type VariantProps} from 'class-variance-authority';
+import {cn} from '@/shared/util/style';
+
+const statusBadgeVariants = cva('inline-flex items-center gap-2 rounded-full border font-apple font-medium whitespace-nowrap', {
+    variants: {
+        tone: {
+            neutral: 'border-sub-4.5 bg-white text-sub-2.5',
+            brand: 'border-main-light bg-[#F2F7FF] text-main-1',
+            success: 'border-[#C8E8D2] bg-[#F3FFF7] text-[#237548]',
+            warning: 'border-[#FFE0A3] bg-[#FFF9EA] text-[#A56600]',
+            danger: 'border-[#FFD3D3] bg-[#FFF6F6] text-[#B42318]',
+        },
+        size: {
+            sm: 'px-2.5 py-1 text-sm',
+            md: 'px-3.5 py-1.5 text-base',
+        },
+    },
+    defaultVariants: {
+        tone: 'neutral',
+        size: 'sm',
+    },
+});
+
+type TStatusBadgeProps = VariantProps<typeof statusBadgeVariants> & {
+    label: string;
+    count?: number;
+    className?: string;
+};
+
+function StatusBadge({label, count, tone, size, className}: TStatusBadgeProps) {
+    return (
+        <span className={cn(statusBadgeVariants({tone, size}), className)}>
+            <span>{label}</span>
+            {typeof count === 'number' ? (
+                <span className="rounded-full bg-black/6 px-2 py-0.5 text-[0.875em] leading-none">{count}</span>
+            ) : null}
+        </span>
+    );
+}
+
+export default StatusBadge;

--- a/src/shared/ui/TextField/index.tsx
+++ b/src/shared/ui/TextField/index.tsx
@@ -14,7 +14,7 @@ const TextField = forwardRef(
                     ref={ref}
                     value={value}
                     onChange={onChange}
-                    variant="flush"
+                    variant="foundation"
                     fieldSize="md"
                     className={cn(
                         'w-full rounded-[.625rem] px-6.25 font-apple text-[2.25rem] outline-1 outline-sub-4 read-only:outline-sub-5 focus:outline-main-1',

--- a/src/shared/ui/TimeInput/index.tsx
+++ b/src/shared/ui/TimeInput/index.tsx
@@ -75,7 +75,7 @@ function TimeInput({initTime, onTimeChange, className, ...props}: ITimeInputProp
         <Input
             value={time}
             onChange={HandleChange}
-            variant="flush"
+            variant="foundation"
             fieldSize="md"
             className={cn(
                 'rounded-[.625rem] px-6.25 font-poppins text-[2.25rem] outline-1 outline-sub-4 focus:text-main-1 focus:outline-main-1',


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-836](https://gom3.atlassian.net/browse/DUT-836)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `shared/ui/Button`의 variant/size 매핑을 확장해 디자인 2.0 foundation 버튼을 공용 API로 정리했습니다.
- `shared/ui/StatusBadge`를 추가하고 신청 근무 화면에서 상태 카운트 pill을 공용 컴포넌트로 사용하도록 변경했습니다.
- `PageState`, `TextField`, `TimeInput`, Onboarding 버튼 소비처를 공용 foundation 레이어 위로 정리했습니다.

<br>

## To Reviewers

- `TextField`와 `TimeInput`이 이제 `Input` primitive의 `foundation` variant를 기본 사용합니다. 기존 화면에서 외곽선/간격이 의도대로 유지되는지 확인 부탁드립니다.
- 검증: `pnpm type-check`, `pnpm test:run src/shared/ui/Button/index.test.tsx src/shared/ui/StatusBadge/index.test.tsx src/shared/ui/TextField/index.test.tsx src/shared/ui/primitives/input.test.tsx src/shared/ui/PageState/index.test.tsx`


[DUT-836]: https://gom3.atlassian.net/browse/DUT-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ