### PR TITLE
[DUT-850]: 자동완성 실제 API 경로 연결

### DIFF
--- a/src/pages/make-shift/model/ai-schedule-api-provider.test.ts
+++ b/src/pages/make-shift/model/ai-schedule-api-provider.test.ts
@@ -1,0 +1,70 @@
+import {describe, expect, it, vi} from 'vitest';
+import {apiAiScheduleProvider} from './ai-schedule-api-provider';
+
+const {generateAiAutofillSchedule} = vi.hoisted(() => ({
+    generateAiAutofillSchedule: vi.fn(),
+}));
+
+vi.mock('@/shared/api', () => ({
+    WardAPI: {
+        generateAiAutofillSchedule,
+    },
+}));
+
+describe('apiAiScheduleProvider', () => {
+    it('converts editor doc into the API payload and forwards the response', async () => {
+        const response = {
+            generation_id: 1,
+            schedule: {1: ['D', ''], 2: ['N', 'O']},
+            validation: {
+                valid: true,
+                hard_constraints_violated: [],
+                soft_constraints_violated: [],
+                warnings: [],
+            },
+            metrics: {
+                night_shift_counts: {},
+                weekend_shift_counts: {},
+                fairness_score: 0,
+                satisfaction_estimate: 0,
+                constraint_violations: 0,
+                revision_estimate: 0,
+            },
+            explainable_reasons: [],
+            status: 'GENERATED',
+            llm_model: 'gpt',
+            generation_time_ms: 100,
+            created_at: '2026-03-21T00:00:00.000Z',
+        };
+
+        generateAiAutofillSchedule.mockResolvedValue(response);
+
+        const result = await apiAiScheduleProvider.generate({
+            wardId: 10,
+            shiftTeamId: 20,
+            year: 2026,
+            month: 3,
+            doc: {
+                columns: ['2026-03-01', '2026-03-02'],
+                rows: [
+                    {workerId: '1', cells: ['D', null]},
+                    {workerId: '2', cells: ['N', 'O']},
+                ],
+                workerMeta: {
+                    1: {name: 'Kim'},
+                    2: {name: 'Lee'},
+                },
+            },
+        });
+
+        expect(generateAiAutofillSchedule).toHaveBeenCalledWith(10, 20, {
+            year: 2026,
+            month: 3,
+            schedule: {
+                1: ['D', ''],
+                2: ['N', 'O'],
+            },
+        });
+        expect(result).toEqual(response);
+    });
+});

--- a/src/pages/make-shift/model/ai-schedule-api-provider.ts
+++ b/src/pages/make-shift/model/ai-schedule-api-provider.ts
@@ -1,23 +1,16 @@
-import axiosInstance from '@/shared/api/client';
-import type {TAiScheduleResponse} from '@/shared/types/ai-schedule';
+import {WardAPI} from '@/shared/api';
+import type {TGenerateAiAutofillScheduleDTO} from '@/shared/api/ward/type';
 import type {TAiScheduleProvider} from './ai-schedule-contract';
-
-type TAiScheduleApiPayload = {
-    year: number;
-    month: number;
-    schedule: Record<string, string[]>;
-};
 
 export const apiAiScheduleProvider: TAiScheduleProvider = {
     generate: async ({wardId, shiftTeamId, year, month, doc}) => {
         const schedule = Object.fromEntries(doc.rows.map((row) => [row.workerId, row.cells.map((cell) => cell ?? '')]));
-        const payload: TAiScheduleApiPayload = {
+        const payload: TGenerateAiAutofillScheduleDTO = {
             year,
             month,
             schedule,
         };
 
-        return (await axiosInstance.post<TAiScheduleResponse>(`/wards/${wardId}/shift-teams/${shiftTeamId}/duty/ai-autofill`, payload))
-            .data;
+        return WardAPI.generateAiAutofillSchedule(wardId, shiftTeamId, payload);
     },
 };

--- a/src/pages/make-shift/model/ai-schedule-provider.test.ts
+++ b/src/pages/make-shift/model/ai-schedule-provider.test.ts
@@ -1,0 +1,97 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {TAiScheduleRequest} from './ai-schedule-contract';
+import {requestAiSchedule} from './ai-schedule-provider';
+
+const {apiGenerate, mockGenerate} = vi.hoisted(() => ({
+    apiGenerate: vi.fn(),
+    mockGenerate: vi.fn(),
+}));
+
+vi.mock('./ai-schedule-api-provider', () => ({
+    apiAiScheduleProvider: {
+        generate: apiGenerate,
+    },
+}));
+
+vi.mock('./ai-schedule-mock', () => ({
+    mockAiScheduleProvider: {
+        generate: mockGenerate,
+    },
+}));
+
+const request: TAiScheduleRequest = {
+    wardId: 1,
+    shiftTeamId: 2,
+    year: 2026,
+    month: 3,
+    doc: {
+        columns: ['2026-03-01'],
+        rows: [{workerId: '1', cells: ['D']}],
+        workerMeta: {1: {name: '간호사 1'}},
+    },
+};
+
+const response = {
+    generation_id: 1,
+    schedule: {1: ['D']},
+    validation: {
+        valid: true,
+        hard_constraints_violated: [],
+        soft_constraints_violated: [],
+        warnings: [],
+    },
+    metrics: {
+        night_shift_counts: {},
+        weekend_shift_counts: {},
+        fairness_score: 0,
+        satisfaction_estimate: 0,
+        constraint_violations: 0,
+        revision_estimate: 0,
+    },
+    explainable_reasons: [],
+    status: 'GENERATED',
+    llm_model: 'gpt',
+    generation_time_ms: 100,
+    created_at: '2026-03-21T00:00:00.000Z',
+};
+
+describe('requestAiSchedule', () => {
+    beforeEach(() => {
+        vi.unstubAllEnvs();
+        apiGenerate.mockReset();
+        mockGenerate.mockReset();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('uses api provider by default', async () => {
+        apiGenerate.mockResolvedValue(response);
+
+        const result = await requestAiSchedule(request);
+
+        expect(apiGenerate).toHaveBeenCalledWith(request);
+        expect(mockGenerate).not.toHaveBeenCalled();
+        expect(result).toEqual({ok: true, response});
+    });
+
+    it('uses mock provider only when feature flag is explicitly set', async () => {
+        vi.stubEnv('VITE_AI_SCHEDULE_PROVIDER', 'mock');
+        mockGenerate.mockResolvedValue(response);
+
+        const result = await requestAiSchedule(request);
+
+        expect(mockGenerate).toHaveBeenCalledWith(request);
+        expect(apiGenerate).not.toHaveBeenCalled();
+        expect(result).toEqual({ok: true, response});
+    });
+
+    it('returns the provider error message for retry UX', async () => {
+        apiGenerate.mockRejectedValue(new Error('AI 생성 실패'));
+
+        const result = await requestAiSchedule(request);
+
+        expect(result).toEqual({ok: false, message: 'AI 생성 실패'});
+    });
+});

--- a/src/pages/make-shift/model/ai-schedule-provider.ts
+++ b/src/pages/make-shift/model/ai-schedule-provider.ts
@@ -5,11 +5,7 @@ import {mockAiScheduleProvider} from './ai-schedule-mock';
 type TProviderName = 'mock' | 'api';
 
 function getProviderName(): TProviderName {
-    const mode = (import.meta.env.VITE_AI_SCHEDULE_PROVIDER ?? 'mock').toLowerCase();
-
-    if (mode === 'api') return 'api';
-
-    return 'mock';
+    return (import.meta.env.VITE_AI_SCHEDULE_PROVIDER ?? 'api').toLowerCase() === 'mock' ? 'mock' : 'api';
 }
 
 function getAiScheduleProvider(): TAiScheduleProvider {

--- a/src/shared/api/ward/index.ts
+++ b/src/shared/api/ward/index.ts
@@ -4,6 +4,7 @@ import {type TNurseResponse, type TUpdateNurseDTO} from '../nurse/type';
 import {
     type TDutyRequestResponse,
     type IWardAPI,
+    type TGenerateAiAutofillScheduleDTO,
     type TRequestShiftResponse,
     type TCreateWardDTO,
     type TEditWardDTO,
@@ -93,6 +94,8 @@ class WardAPI implements IWardAPI {
                 isAccepted,
             })
         ).data;
+    generateAiAutofillSchedule = async (wardId: number, shiftTeamId: number, payload: TGenerateAiAutofillScheduleDTO) =>
+        (await axiosInstance.post(`/wards/${wardId}/shift-teams/${shiftTeamId}/duty/ai-autofill`, payload)).data;
     postShift = async (wardId: number, shiftTeamId: number, year: number, month: number) =>
         (
             await axiosInstance.post(

--- a/src/shared/api/ward/type.ts
+++ b/src/shared/api/ward/type.ts
@@ -1,4 +1,5 @@
 import {type TNurseResponse, type TUpdateNurseDTO} from '../nurse/type';
+import type {TAiScheduleResponse} from '@/shared/types/ai-schedule';
 
 export type TWaitingNurseResponse = {
     waitingNurseId: number;
@@ -104,6 +105,12 @@ export type TDutyRequestResponse = {
     isAccepted: boolean | null;
 };
 
+export type TGenerateAiAutofillScheduleDTO = {
+    year: number;
+    month: number;
+    schedule: Record<string, string[]>;
+};
+
 export interface IWardAPI {
     // Ward APIs
     // GET
@@ -147,6 +154,11 @@ export interface IWardAPI {
         wardShiftTypeId: number | null,
     ) => Promise<void>;
     acceptRequestShift: (wardId: number, reqShiftId: number, isAccepted: boolean | null) => Promise<void>;
+    generateAiAutofillSchedule: (
+        wardId: number,
+        shiftTeamId: number,
+        payload: TGenerateAiAutofillScheduleDTO,
+    ) => Promise<TAiScheduleResponse>;
     // POST
     postShift: (wardId: number, shiftTeamId: number, year: number, month: number) => Promise<void>;
 


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-850](https://gom3.atlassian.net/browse/DUT-850)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- AI 자동완성 provider의 기본 경로를 실제 API 호출로 전환하고, `VITE_AI_SCHEDULE_PROVIDER=mock` 일 때만 mock fallback이 동작하도록 정리했습니다.
- `WardAPI` 에 자동완성 endpoint contract를 추가하고, editor 문서 값을 API payload로 변환하는 경로를 공용 API 레이어로 이동했습니다.
- 성공 응답은 기존 `AiAutofill` 화면의 `commands.applySchedule(...)` 흐름으로 editor state에 반영되며, 실패 시 서버 메시지를 유지한 채 재시도 UX가 동작하도록 provider 테스트를 추가했습니다.
- 자동완성 API provider 선택과 payload 변환을 검증하는 테스트를 추가했습니다.

<br>

## To Reviewers

- 현재 `AiAutofill` 화면의 성공 시 editor 반영과 실패 시 재시도 배너 UX는 기존 구현을 그대로 사용하고, 이번 변경은 실제 API가 그 경로를 타도록 연결하는 데 집중했습니다.
- `DUT-831` 의 하위 작업 중 `DUT-839`, `DUT-840` 는 완료 상태이고, 이번 `DUT-850` 변경으로 남아 있던 실제 API 연결도 채워졌습니다. 백엔드 endpoint가 운영 환경에서 정상 응답한다는 전제라면 부모 이슈를 닫을 수 있는 수준으로 판단했습니다.
- 검증은 `pnpm test:run -- src/pages/make-shift/model/ai-schedule-provider.test.ts src/pages/make-shift/model/ai-schedule-api-provider.test.ts src/pages/make-shift/model/ai-autofill-state.test.ts` 와 `pnpm type-check` 로 수행했습니다.

[DUT-850]: https://gom3.atlassian.net/browse/DUT-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * AI 일정 자동 생성 기능의 내부 구조를 개선하고 API 통합을 강화했습니다.
  * AI 일정 제공자의 기본 설정을 API 기반으로 변경했습니다.

* **테스트**
  * AI 일정 생성 및 제공자 기능에 대한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->