### PR TITLE
[DUT-829]: 신청근무 페이지 디자인 2.0 정리

### DIFF
--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -1,6 +1,6 @@
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {produce} from 'immer';
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect} from 'react';
 import {match} from 'ts-pattern';
 import {events, sendEvent} from '@/analytics';
 import {type TRequestShift} from '@/entities/shift';
@@ -14,13 +14,22 @@ import {type TFocus} from './type';
 import {findNurse, keydownEventMapper, moveFocus} from './utils';
 
 const useRequestShift = (activeEffect = false) => {
-    const {year, month, focus, foldedLevels, currentShiftTeamId, oldCurrentShiftTeamId, wardShiftTypeMap, readonly, setState} =
-        useRequestShiftStore();
+    const {
+        year,
+        month,
+        focus,
+        foldedLevels,
+        currentShiftTeamId,
+        oldCurrentShiftTeamId,
+        wardShiftTypeMap,
+        readonly,
+        changeStatus,
+        setState,
+    } = useRequestShiftStore();
     const {
         state: {wardId},
     } = useAuth();
     const queryClient = useQueryClient();
-    const [changeStatus, setChangeStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
     const shiftTeamsQueryOptions = wardQueryOptions.shiftTeams(wardId ?? 0);
     const requestListQueryOptions = wardQueryOptions.requestList(wardId ?? 0, currentShiftTeamId ?? 0, year, month);
     const requestShiftQueryOptions = wardQueryOptions.request(wardId ?? 0, currentShiftTeamId ?? 0, year, month);
@@ -29,10 +38,20 @@ const useRequestShift = (activeEffect = false) => {
     const shiftTeamQueryKey = shiftTeamsQueryOptions.queryKey;
     const wardConstraintQueryKey = wardConstraintQueryOptions.queryKey;
     const dutyRequestQueryKey = requestListQueryOptions.queryKey;
-    const {data: shiftTeams} = useQuery({
+    const {
+        data: shiftTeams,
+        status: shiftTeamsStatus,
+        refetch: refetchShiftTeams,
+    } = useQuery({
         ...shiftTeamsQueryOptions,
         queryFn: async () => {
             const res = await WardAPI.getShiftTeams(wardId!);
+
+            if (res.length === 0) {
+                setState('currentShiftTeamId', null);
+
+                return res;
+            }
 
             if (currentShiftTeamId) {
                 if (res.every((x) => x.shiftTeamId !== currentShiftTeamId)) {
@@ -46,11 +65,19 @@ const useRequestShift = (activeEffect = false) => {
         },
         enabled: !!wardId,
     });
-    const {data: dutyRequestList} = useQuery({
+    const {
+        data: dutyRequestList,
+        status: dutyRequestStatus,
+        refetch: refetchDutyRequestList,
+    } = useQuery({
         ...requestListQueryOptions,
         enabled: wardId !== null && currentShiftTeamId !== null,
     });
-    const {data: requestShift, status: shiftStatus} = useQuery({
+    const {
+        data: requestShift,
+        status: shiftStatus,
+        refetch: refetchRequestShift,
+    } = useQuery({
         ...requestShiftQueryOptions,
         queryFn: async (): Promise<TRequestShift> => {
             const res = await WardAPI.getReqShift(wardId!, currentShiftTeamId!, year, month);
@@ -73,7 +100,7 @@ const useRequestShift = (activeEffect = false) => {
         async (focus: TFocus, shiftTypeId: number | null) => {
             if (!wardId) return;
 
-            setChangeStatus('loading');
+            setState('changeStatus', 'loading');
             await queryClient.cancelQueries({queryKey: requestShiftQueryKey});
 
             const {shiftNurseId, day} = focus;
@@ -112,18 +139,18 @@ const useRequestShift = (activeEffect = false) => {
 
             try {
                 await WardAPI.updateReqShift(wardId, year, month, focus.day + 1, focus.shiftNurseId, shiftTypeId);
-                setChangeStatus('success');
-                setTimeout(() => setChangeStatus('idle'), 0);
+                setState('changeStatus', 'success');
+                setTimeout(() => setState('changeStatus', 'idle'), 0);
             } catch {
                 if (oldShift) {
                     queryClient.setQueryData(requestShiftQueryKey, oldShift);
                 }
 
-                setChangeStatus('error');
-                setTimeout(() => setChangeStatus('idle'), 0);
+                setState('changeStatus', 'error');
+                setTimeout(() => setState('changeStatus', 'idle'), 0);
             }
         },
-        [queryClient, requestShiftQueryKey, wardId, wardShiftTypeMap, year, month],
+        [queryClient, requestShiftQueryKey, setState, wardId, wardShiftTypeMap, year, month],
     );
     const acceptRequest = useCallback(
         async (reqShiftId: number, isAccepted: boolean | null) => {
@@ -279,6 +306,9 @@ const useRequestShift = (activeEffect = false) => {
 
         handleToggleEditMode();
     };
+    const retry = useCallback(async () => {
+        await Promise.all([refetchShiftTeams(), refetchDutyRequestList(), refetchRequestShift()]);
+    }, [refetchDutyRequestList, refetchRequestShift, refetchShiftTeams]);
 
     useEffect(() => {
         if (activeEffect && requestShift) {
@@ -324,6 +354,8 @@ const useRequestShift = (activeEffect = false) => {
             foldedLevels,
             changeStatus,
             shiftStatus,
+            shiftTeamsStatus,
+            dutyRequestStatus,
             wardShiftTypeMap,
             readonly,
             currentShiftTeam: shiftTeams?.find((x) => x.shiftTeamId === currentShiftTeamId) as TShiftTeam | null,
@@ -336,6 +368,7 @@ const useRequestShift = (activeEffect = false) => {
             acceptRequest: (reqShiftId: number, isAccepted: boolean | null) => acceptRequest(reqShiftId, isAccepted),
             foldLevel,
             changeMonth,
+            retry,
             changeFocus: (focus: TFocus | null) => setState('focus', focus),
             changeShiftTeam: (shiftTeam: TShiftTeam) => setState('currentShiftTeamId', shiftTeam.shiftTeamId),
         },

--- a/src/features/shift/useRequestShift/store.ts
+++ b/src/features/shift/useRequestShift/store.ts
@@ -13,6 +13,7 @@ interface IState {
     oldCurrentShiftTeamId: number | null;
     wardShiftTypeMap: Map<number, TWardShiftType> | null;
     readonly: boolean;
+    changeStatus: 'idle' | 'loading' | 'success' | 'error';
 }
 
 interface IStore extends IState {
@@ -29,6 +30,7 @@ const initialState: IState = {
     foldedLevels: null,
     wardShiftTypeMap: null,
     readonly: true,
+    changeStatus: 'idle',
 };
 
 export const useRequestShiftStore = create<IStore>()(

--- a/src/pages/RequestShiftPage/index.tsx
+++ b/src/pages/RequestShiftPage/index.tsx
@@ -1,14 +1,83 @@
 import useRequestShift from '@/features/shift/useRequestShift';
+import PageState from '@/shared/ui/PageState';
+import SectionHeader from '@/shared/ui/SectionHeader';
 import RequestCalendar from './ui/RequestCalendar';
 import Toolbar from './ui/Toolbar';
 
 const RequestShiftPage = () => {
-    useRequestShift(true);
+    const {
+        state: {readonly, requestShift, shiftStatus, shiftTeams, shiftTeamsStatus},
+        actions: {retry, createNextMonthShift},
+    } = useRequestShift(true);
+    const shiftTeamCount = shiftTeams?.length ?? 0;
+    const showNoTeamsState = shiftTeamsStatus === 'success' && shiftTeamCount === 0;
+    const showLoadingState =
+        shiftTeamsStatus === 'pending' || (shiftTeamsStatus === 'success' && shiftTeamCount > 0 && shiftStatus === 'pending');
+    const showErrorState =
+        shiftTeamsStatus === 'error' || (shiftTeamsStatus === 'success' && shiftTeamCount > 0 && shiftStatus === 'error');
+    const showEmptyState = shiftTeamsStatus === 'success' && shiftTeamCount > 0 && shiftStatus === 'success' && !requestShift;
 
     return (
-        <div className="mx-auto flex h-screen w-fit min-w-418.5 flex-col">
+        <div className="flex min-h-screen w-full flex-col px-5 py-5 md:px-10 md:py-10">
             <Toolbar />
-            <RequestCalendar />
+
+            <div className="mt-3 flex flex-1 flex-col rounded-[20px] bg-white px-5 py-6 md:px-10 md:py-8">
+                {showNoTeamsState ? (
+                    <PageState
+                        tone="empty"
+                        title="아직 등록된 팀이 없어요"
+                        description="신청 근무를 작성하려면 먼저 근무 팀을 등록해 주세요."
+                        className="py-0"
+                    />
+                ) : showLoadingState ? (
+                    <PageState
+                        tone="loading"
+                        title="신청 근무표를 불러오는 중이에요"
+                        description="잠시만 기다려 주세요."
+                        className="py-0"
+                    />
+                ) : showErrorState ? (
+                    <PageState
+                        tone="error"
+                        title="신청 근무표를 불러오지 못했어요"
+                        description="네트워크 상태를 확인한 뒤 다시 시도해 주세요."
+                        action={{label: '다시 시도', onClick: () => void retry()}}
+                        className="py-0"
+                    />
+                ) : showEmptyState ? (
+                    <PageState
+                        tone="empty"
+                        title="이번 달 신청 근무표가 아직 없어요"
+                        description="다음 달 신청 근무표를 먼저 열어 작성할 수 있어요."
+                        className="py-0"
+                    >
+                        <div className="mt-1 flex justify-center">
+                            <button
+                                type="button"
+                                className="inline-flex h-11 items-center justify-center rounded-[14px] bg-main-light px-5 font-apple text-base font-semibold text-main-1 transition-colors hover:bg-main-4"
+                                onClick={createNextMonthShift}
+                            >
+                                다음 달 신청 근무 작성하기
+                            </button>
+                        </div>
+                    </PageState>
+                ) : (
+                    <>
+                        <SectionHeader
+                            title={readonly ? '신청 근무를 확인해 주세요' : '신청 근무를 확정해 주세요'}
+                            description={
+                                readonly
+                                    ? '제출된 신청 근무와 팀별 배치를 한 화면에서 검토할 수 있어요.'
+                                    : '셀을 선택한 뒤 단축키로 근무를 입력하거나 간호사 신청을 바로 반영할 수 있어요.'
+                            }
+                            className="mb-8"
+                            titleClassName="text-[28px] md:text-[32px]"
+                            descriptionClassName="text-base md:text-[20px]"
+                        />
+                        <RequestCalendar />
+                    </>
+                )}
+            </div>
         </div>
     );
 };

--- a/src/pages/RequestShiftPage/ui/RequestCalendar.tsx
+++ b/src/pages/RequestShiftPage/ui/RequestCalendar.tsx
@@ -9,11 +9,23 @@ import useRequestShift from '@/features/shift/useRequestShift';
 import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
 import {DragIcon, FoldDutyIcon, LinkedIcon, MinusIcon, PlusIcon2, UnlinkedIcon} from '@/shared/assets/svg';
 import Card from '@/shared/ui/Card';
+import PageState from '@/shared/ui/PageState';
 
 export default function ShiftCalendar() {
     const {
-        state: {readonly, year, month, requestShift, dutyRequestList, focus, foldedLevels, wardShiftTypeMap, currentShiftTeam},
-        actions: {changeFocus, foldLevel, acceptRequest},
+        state: {
+            readonly,
+            year,
+            month,
+            requestShift,
+            dutyRequestList,
+            dutyRequestStatus,
+            focus,
+            foldedLevels,
+            wardShiftTypeMap,
+            currentShiftTeam,
+        },
+        actions: {changeFocus, foldLevel, acceptRequest, retry},
     } = useRequestShift();
     const {
         state: {shiftTeams},
@@ -97,7 +109,8 @@ export default function ShiftCalendar() {
         }
     }, [focus]);
 
-    const unresolvedRequestCount = dutyRequestList?.filter((x) => x.isAccepted === null).length ?? 0;
+    const unresolvedRequestCount =
+        dutyRequestStatus === 'success' ? (dutyRequestList?.filter((x) => x.isAccepted === null).length ?? 0) : 0;
 
     return requestShift && foldedLevels && wardShiftTypeMap && currentShiftTeam ? (
         <div id="calendar" className="flex min-h-0 flex-1 flex-col gap-6 xl:flex-row">
@@ -385,7 +398,22 @@ export default function ShiftCalendar() {
                 </div>
 
                 <div className="scrollbar-hide max-h-[calc(100vh-18rem)] overflow-y-auto px-5 py-4">
-                    {dutyRequestList && dutyRequestList.length > 0 ? (
+                    {dutyRequestStatus === 'pending' ? (
+                        <PageState
+                            tone="loading"
+                            title="신청 내역을 불러오는 중이에요"
+                            description="제출된 신청 근무를 확인하고 있어요."
+                            className="px-0 py-0"
+                        />
+                    ) : dutyRequestStatus === 'error' ? (
+                        <PageState
+                            tone="error"
+                            title="신청 내역을 불러오지 못했어요"
+                            description="잠시 후 다시 시도해 주세요."
+                            action={{label: '다시 시도', onClick: () => void retry()}}
+                            className="px-0 py-0"
+                        />
+                    ) : dutyRequestList && dutyRequestList.length > 0 ? (
                         <div className="space-y-3">
                             {dutyRequestList.map((dutyRequest) => {
                                 const matchedShiftNurseId =

--- a/src/pages/RequestShiftPage/ui/RequestCalendar.tsx
+++ b/src/pages/RequestShiftPage/ui/RequestCalendar.tsx
@@ -6,9 +6,9 @@ import {events, sendEvent} from '@/analytics';
 import ShiftBadge from '@/entities/shift/ui/shift-badge';
 import {useUIConfigStore} from '@/entities/ui/useUIConfig/store';
 import useRequestShift from '@/features/shift/useRequestShift';
-import {type TFocus} from '@/features/shift/useRequestShift/type';
 import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
 import {DragIcon, FoldDutyIcon, LinkedIcon, MinusIcon, PlusIcon2, UnlinkedIcon} from '@/shared/assets/svg';
+import Card from '@/shared/ui/Card';
 
 export default function ShiftCalendar() {
     const {
@@ -97,335 +97,385 @@ export default function ShiftCalendar() {
         }
     }, [focus]);
 
+    const unresolvedRequestCount = dutyRequestList?.filter((x) => x.isAccepted === null).length ?? 0;
+
     return requestShift && foldedLevels && wardShiftTypeMap && currentShiftTeam ? (
-        <div id="calendar" className="flex">
-            <div ref={clickAwayRef} className="flex flex-col">
-                <div className="z-20 my-[.75rem] flex h-7.5 items-center gap-5 bg-[#FDFCFE] pr-4">
-                    <div className="flex gap-5">
-                        <div className="w-13.5 text-center font-apple text-[1rem] font-medium text-sub-3">{/* 구분 */}</div>
-                        <div className="w-17.5 text-center font-apple text-[1rem] font-medium text-sub-3">이름</div>
-                        <div className="w-7.5 text-center font-apple text-[1rem] font-medium text-sub-3">연동</div>
-                        <div className="flex rounded-[2.5rem] border-[.0625rem] border-sub-4 px-4 py-[.1875rem]">
-                            {requestShift.days.map((item, j) => (
-                                <p
-                                    key={j}
-                                    className={`w-9 flex-1 rounded-full text-center font-poppins text-[1rem] ${
-                                        item.dayType === 'saturday'
-                                            ? j === focus?.day
-                                                ? separateWeekendColor
-                                                    ? 'bg-blue text-white'
-                                                    : 'bg-red text-white'
-                                                : separateWeekendColor
-                                                  ? 'text-blue'
-                                                  : 'text-red'
-                                            : item.dayType === 'sunday' || item.dayType === 'holiday'
-                                              ? j === focus?.day
-                                                  ? 'bg-red text-white'
-                                                  : 'text-red'
-                                              : item.dayType === 'workday'
+        <div id="calendar" className="flex min-h-0 flex-1 flex-col gap-6 xl:flex-row">
+            <Card variant="elevated" padding="none" className="min-w-0 flex-1 overflow-hidden border-gray-6">
+                <div ref={clickAwayRef} className="flex h-full min-h-0 flex-col px-4 pb-4">
+                    <div className="z-20 my-[.75rem] flex h-7.5 min-w-max items-center gap-5 bg-white pr-4">
+                        <div className="flex gap-5">
+                            <div className="w-13.5 text-center font-apple text-[1rem] font-medium text-sub-3">{/* 구분 */}</div>
+                            <div className="w-17.5 text-center font-apple text-[1rem] font-medium text-sub-3">이름</div>
+                            <div className="w-7.5 text-center font-apple text-[1rem] font-medium text-sub-3">연동</div>
+                            <div className="flex rounded-[2.5rem] border-[.0625rem] border-sub-4 px-4 py-[.1875rem]">
+                                {requestShift.days.map((item, j) => (
+                                    <p
+                                        key={j}
+                                        className={`w-9 flex-1 rounded-full text-center font-poppins text-[1rem] ${
+                                            item.dayType === 'saturday'
                                                 ? j === focus?.day
-                                                    ? 'bg-main-1 text-white'
-                                                    : 'text-sub-2.5'
-                                                : ''
-                                    } `}
-                                >
-                                    {item.day}
-                                </p>
-                            ))}
+                                                    ? separateWeekendColor
+                                                        ? 'bg-blue text-white'
+                                                        : 'bg-red text-white'
+                                                    : separateWeekendColor
+                                                      ? 'text-blue'
+                                                      : 'text-red'
+                                                : item.dayType === 'sunday' || item.dayType === 'holiday'
+                                                  ? j === focus?.day
+                                                      ? 'bg-red text-white'
+                                                      : 'text-red'
+                                                  : item.dayType === 'workday'
+                                                    ? j === focus?.day
+                                                        ? 'bg-main-1 text-white'
+                                                        : 'text-sub-2.5'
+                                                    : ''
+                                        } `}
+                                    >
+                                        {item.day}
+                                    </p>
+                                ))}
+                            </div>
                         </div>
                     </div>
-                </div>
-                <DragDropContext onDragEnd={(d) => !readonly && onDragEnd(d)}>
-                    <div
-                        className="-mt-5 scrollbar-hide flex flex-col gap-[.3125rem] overflow-x-hidden overflow-y-scroll pt-5 pr-4 pb-8"
-                        ref={containerRef}
-                    >
-                        {requestShift.divisionShiftNurses
-                            .map((x) => x.filter((y) => y.shiftNurse.isWorker)) // 근무자만 필터링
-                            .map((rows, level) => {
-                                return rows.length ? (
-                                    requestShift && foldedLevels[level] ? (
-                                        <div
-                                            key={level}
-                                            className="ml-5 flex h-7.5 w-[calc(100%-1.25rem)] cursor-pointer items-center gap-[.125rem] rounded-[.625rem] bg-sub-4.5 px-[.625rem]"
-                                            onClick={() => {
-                                                sendEvent(events.requestPage.calendar.foldDivision);
-                                                foldLevel(level);
-                                            }}
-                                        >
-                                            <FoldDutyIcon className="h-5.5 w-5.5 rotate-180" />
-                                        </div>
-                                    ) : (
-                                        <Droppable droppableId={level.toString()} key={level.toString()}>
-                                            {(provided) => (
-                                                <div
-                                                    ref={provided.innerRef}
-                                                    key={level}
-                                                    className="flex gap-5"
-                                                    {...provided.droppableProps}
-                                                >
-                                                    <div className="relative ml-5 rounded-[1.25rem] shadow-banner">
-                                                        {!readonly && (
-                                                            <div className="absolute left-[-.9375rem] flex h-full w-7.5 items-center justify-center font-poppins font-light text-sub-2.5">
-                                                                <FoldDutyIcon
-                                                                    className="absolute top-[50%] left-[50%] z-10 h-5.5 w-5.5 translate-x-[-50%] translate-y-[-50%] cursor-pointer"
-                                                                    onClick={() => {
-                                                                        sendEvent(events.requestPage.calendar.spreadDivision);
-                                                                        foldLevel(level);
-                                                                    }}
-                                                                />
-                                                            </div>
-                                                        )}
-                                                        {rows.map((row, rowIndex) => (
-                                                            <Draggable
-                                                                draggableId={row.shiftNurse.shiftNurseId.toString()}
-                                                                index={rowIndex}
-                                                                key={row.shiftNurse.shiftNurseId}
-                                                                isDragDisabled={readonly}
-                                                            >
-                                                                {(provided) => (
-                                                                    <div
-                                                                        className={`relative flex h-10 items-center gap-5 ${
-                                                                            rowIndex === 0
-                                                                                ? rowIndex === rows.length - 1
-                                                                                    ? 'rounded-[1.25rem]'
-                                                                                    : 'rounded-t-[1.25rem]'
-                                                                                : rowIndex === rows.length - 1
-                                                                                  ? 'rounded-b-[1.25rem]'
-                                                                                  : ''
-                                                                        } ${
-                                                                            focus?.shiftNurseId === row.shiftNurse.shiftNurseId
-                                                                                ? 'bg-main-4'
-                                                                                : 'bg-white'
-                                                                        }`}
-                                                                        ref={provided.innerRef}
-                                                                        {...provided.draggableProps}
-                                                                        {...provided.dragHandleProps}
-                                                                    >
-                                                                        <div className="relative w-8.5 shrink-0">
-                                                                            {!readonly && (
-                                                                                <DragIcon className="absolute top-[50%] -right-2.5 h-6 w-6 translate-y-[-50%]" />
-                                                                            )}
-                                                                        </div>
-                                                                        <div className="w-17.5 shrink-0 truncate text-center font-apple text-[1.25rem] text-sub-1">
-                                                                            {row.shiftNurse.name}
-                                                                        </div>
-                                                                        <div className="flex w-7.5 shrink-0 items-center justify-center text-center font-apple text-[1.25rem] text-sub-1">
-                                                                            {currentShiftTeam.nurses.find(
-                                                                                (x) => x.nurseId === row.shiftNurse.nurseId,
-                                                                            )?.isConnected ? (
-                                                                                <LinkedIcon className="h-6 w-6" />
-                                                                            ) : (
-                                                                                <UnlinkedIcon className="h-6 w-6" />
-                                                                            )}
-                                                                        </div>
-                                                                        <div className="flex h-full px-4.25">
-                                                                            {row.wardReqShiftList.map((current, date) => {
-                                                                                const requestDutyRequest =
-                                                                                    dutyRequestList?.find(
-                                                                                        (x) =>
-                                                                                            x.nurseId === row.shiftNurse.nurseId &&
-                                                                                            x.date - 1 === date,
-                                                                                    ) ?? null;
-                                                                                const isSaturday =
-                                                                                    requestShift.days[date].dayType === 'saturday';
-                                                                                const isSunday =
-                                                                                    requestShift.days[date].dayType === 'sunday' ||
-                                                                                    requestShift.days[date].dayType === 'holiday';
-                                                                                const isFocused =
-                                                                                    focus?.shiftNurseId === row.shiftNurse.shiftNurseId &&
-                                                                                    focus.day === date;
+                    <DragDropContext onDragEnd={(d) => !readonly && onDragEnd(d)}>
+                        <div
+                            className="-mt-5 scrollbar-hide flex min-h-0 flex-col gap-[.3125rem] overflow-x-auto overflow-y-scroll pt-5 pr-4 pb-8"
+                            ref={containerRef}
+                        >
+                            {requestShift.divisionShiftNurses
+                                .map((x) => x.filter((y) => y.shiftNurse.isWorker)) // 근무자만 필터링
+                                .map((rows, level) => {
+                                    return rows.length ? (
+                                        requestShift && foldedLevels[level] ? (
+                                            <div
+                                                key={level}
+                                                className="ml-5 flex h-7.5 w-[calc(100%-1.25rem)] cursor-pointer items-center gap-[.125rem] rounded-[.625rem] bg-sub-4.5 px-[.625rem]"
+                                                onClick={() => {
+                                                    sendEvent(events.requestPage.calendar.foldDivision);
+                                                    foldLevel(level);
+                                                }}
+                                            >
+                                                <FoldDutyIcon className="h-5.5 w-5.5 rotate-180" />
+                                            </div>
+                                        ) : (
+                                            <Droppable droppableId={level.toString()} key={level.toString()}>
+                                                {(provided) => (
+                                                    <div
+                                                        ref={provided.innerRef}
+                                                        key={level}
+                                                        className="flex gap-5"
+                                                        {...provided.droppableProps}
+                                                    >
+                                                        <div className="relative ml-5 rounded-[1.25rem] shadow-banner">
+                                                            {!readonly && (
+                                                                <div className="absolute left-[-.9375rem] flex h-full w-7.5 items-center justify-center font-poppins font-light text-sub-2.5">
+                                                                    <FoldDutyIcon
+                                                                        className="absolute top-[50%] left-[50%] z-10 h-5.5 w-5.5 translate-x-[-50%] translate-y-[-50%] cursor-pointer"
+                                                                        onClick={() => {
+                                                                            sendEvent(events.requestPage.calendar.spreadDivision);
+                                                                            foldLevel(level);
+                                                                        }}
+                                                                    />
+                                                                </div>
+                                                            )}
+                                                            {rows.map((row, rowIndex) => (
+                                                                <Draggable
+                                                                    draggableId={row.shiftNurse.shiftNurseId.toString()}
+                                                                    index={rowIndex}
+                                                                    key={row.shiftNurse.shiftNurseId}
+                                                                    isDragDisabled={readonly}
+                                                                >
+                                                                    {(provided) => (
+                                                                        <div
+                                                                            className={`relative flex h-10 items-center gap-5 ${
+                                                                                rowIndex === 0
+                                                                                    ? rowIndex === rows.length - 1
+                                                                                        ? 'rounded-[1.25rem]'
+                                                                                        : 'rounded-t-[1.25rem]'
+                                                                                    : rowIndex === rows.length - 1
+                                                                                      ? 'rounded-b-[1.25rem]'
+                                                                                      : ''
+                                                                            } ${
+                                                                                focus?.shiftNurseId === row.shiftNurse.shiftNurseId
+                                                                                    ? 'bg-main-4'
+                                                                                    : 'bg-white'
+                                                                            }`}
+                                                                            ref={provided.innerRef}
+                                                                            {...provided.draggableProps}
+                                                                            {...provided.dragHandleProps}
+                                                                        >
+                                                                            <div className="relative w-8.5 shrink-0">
+                                                                                {!readonly && (
+                                                                                    <DragIcon className="absolute top-[50%] -right-2.5 h-6 w-6 translate-y-[-50%]" />
+                                                                                )}
+                                                                            </div>
+                                                                            <div className="w-17.5 shrink-0 truncate text-center font-apple text-[1.25rem] text-sub-1">
+                                                                                {row.shiftNurse.name}
+                                                                            </div>
+                                                                            <div className="flex w-7.5 shrink-0 items-center justify-center text-center font-apple text-[1.25rem] text-sub-1">
+                                                                                {currentShiftTeam.nurses.find(
+                                                                                    (x) => x.nurseId === row.shiftNurse.nurseId,
+                                                                                )?.isConnected ? (
+                                                                                    <LinkedIcon className="h-6 w-6" />
+                                                                                ) : (
+                                                                                    <UnlinkedIcon className="h-6 w-6" />
+                                                                                )}
+                                                                            </div>
+                                                                            <div className="flex h-full px-4.25">
+                                                                                {row.wardReqShiftList.map((current, date) => {
+                                                                                    const requestDutyRequest =
+                                                                                        dutyRequestList?.find(
+                                                                                            (x) =>
+                                                                                                x.nurseId === row.shiftNurse.nurseId &&
+                                                                                                x.date - 1 === date,
+                                                                                        ) ?? null;
+                                                                                    const isSaturday =
+                                                                                        requestShift.days[date].dayType === 'saturday';
+                                                                                    const isSunday =
+                                                                                        requestShift.days[date].dayType === 'sunday' ||
+                                                                                        requestShift.days[date].dayType === 'holiday';
+                                                                                    const isFocused =
+                                                                                        focus?.shiftNurseId ===
+                                                                                            row.shiftNurse.shiftNurseId &&
+                                                                                        focus.day === date;
 
-                                                                                return (
-                                                                                    <div
-                                                                                        key={date}
-                                                                                        className={`group relative flex h-full w-9 flex-1 items-center justify-center px-[.25rem] ${
-                                                                                            isSunday
-                                                                                                ? 'bg-[#FFE1E680]'
-                                                                                                : isSaturday
-                                                                                                  ? separateWeekendColor
-                                                                                                      ? 'bg-[#E1E5FF80]'
-                                                                                                      : 'bg-[#FFE1E680]'
-                                                                                                  : ''
-                                                                                        } ${date === focus?.day && 'bg-main-4'}`}
-                                                                                    >
-                                                                                        <ShiftBadge
-                                                                                            id={
-                                                                                                rowIndex === 0 && date === 0
-                                                                                                    ? 'cell_sample'
-                                                                                                    : undefined
-                                                                                            }
-                                                                                            onClick={() => {
-                                                                                                if (readonly) return;
+                                                                                    return (
+                                                                                        <div
+                                                                                            key={date}
+                                                                                            className={`group relative flex h-full w-9 flex-1 items-center justify-center px-[.25rem] ${
+                                                                                                isSunday
+                                                                                                    ? 'bg-[#FFE1E680]'
+                                                                                                    : isSaturday
+                                                                                                      ? separateWeekendColor
+                                                                                                          ? 'bg-[#E1E5FF80]'
+                                                                                                          : 'bg-[#FFE1E680]'
+                                                                                                      : ''
+                                                                                            } ${date === focus?.day && 'bg-main-4'}`}
+                                                                                        >
+                                                                                            <ShiftBadge
+                                                                                                id={
+                                                                                                    rowIndex === 0 && date === 0
+                                                                                                        ? 'cell_sample'
+                                                                                                        : undefined
+                                                                                                }
+                                                                                                onClick={() => {
+                                                                                                    if (readonly) return;
 
-                                                                                                changeFocus?.({
-                                                                                                    shiftNurseName: row.shiftNurse.name,
-                                                                                                    shiftNurseId:
-                                                                                                        row.shiftNurse.shiftNurseId,
-                                                                                                    day: date,
-                                                                                                });
-                                                                                                sendEvent(
-                                                                                                    events.requestPage.calendar.focusCell,
-                                                                                                );
-                                                                                            }}
-                                                                                            shiftType={
-                                                                                                current === null
-                                                                                                    ? requestDutyRequest === null
-                                                                                                        ? null
-                                                                                                        : wardShiftTypeMap.get(
-                                                                                                              requestDutyRequest.wardShiftTypeId,
-                                                                                                          )
-                                                                                                    : wardShiftTypeMap.get(current)
-                                                                                            }
-                                                                                            isOnlyRequest={
-                                                                                                current === null &&
-                                                                                                requestDutyRequest !== null
-                                                                                            }
-                                                                                            className={`z-10 ${
-                                                                                                readonly
-                                                                                                    ? 'cursor-default'
-                                                                                                    : 'cursor-pointer'
-                                                                                            } ${
-                                                                                                isFocused &&
-                                                                                                'outline-[.125rem] outline-main-1'
-                                                                                            }`}
-                                                                                            forwardRef={
-                                                                                                isFocused
-                                                                                                    ? (focusedCellRef as unknown as RefObject<HTMLParagraphElement>)
-                                                                                                    : null
-                                                                                            }
-                                                                                        />
-                                                                                    </div>
-                                                                                );
-                                                                            })}
-                                                                        </div>
-                                                                        {rowIndex !== rows.length - 1
-                                                                            ? !readonly && (
-                                                                                  <>
+                                                                                                    changeFocus?.({
+                                                                                                        shiftNurseName: row.shiftNurse.name,
+                                                                                                        shiftNurseId:
+                                                                                                            row.shiftNurse.shiftNurseId,
+                                                                                                        day: date,
+                                                                                                    });
+                                                                                                    sendEvent(
+                                                                                                        events.requestPage.calendar
+                                                                                                            .focusCell,
+                                                                                                    );
+                                                                                                }}
+                                                                                                shiftType={
+                                                                                                    current === null
+                                                                                                        ? requestDutyRequest === null
+                                                                                                            ? null
+                                                                                                            : wardShiftTypeMap.get(
+                                                                                                                  requestDutyRequest.wardShiftTypeId,
+                                                                                                              )
+                                                                                                        : wardShiftTypeMap.get(current)
+                                                                                                }
+                                                                                                isOnlyRequest={
+                                                                                                    current === null &&
+                                                                                                    requestDutyRequest !== null
+                                                                                                }
+                                                                                                className={`z-10 ${
+                                                                                                    readonly
+                                                                                                        ? 'cursor-default'
+                                                                                                        : 'cursor-pointer'
+                                                                                                } ${
+                                                                                                    isFocused &&
+                                                                                                    'outline-[.125rem] outline-main-1'
+                                                                                                }`}
+                                                                                                forwardRef={
+                                                                                                    isFocused
+                                                                                                        ? (focusedCellRef as unknown as RefObject<HTMLParagraphElement>)
+                                                                                                        : null
+                                                                                                }
+                                                                                            />
+                                                                                        </div>
+                                                                                    );
+                                                                                })}
+                                                                            </div>
+                                                                            {rowIndex !== rows.length - 1
+                                                                                ? !readonly && (
+                                                                                      <>
+                                                                                          <div
+                                                                                              className="justify-cente group peer absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-80%] translate-y-[50%] items-center"
+                                                                                              onClick={(e) => {
+                                                                                                  e.stopPropagation();
+                                                                                                  editDivision(
+                                                                                                      currentShiftTeam.shiftTeamId,
+                                                                                                      row.shiftNurse.priority,
+                                                                                                      1,
+                                                                                                      year.toString() +
+                                                                                                          '-' +
+                                                                                                          month.toString().padStart(2, '0'),
+                                                                                                  );
+                                                                                                  sendEvent(
+                                                                                                      events.makePage.calendar
+                                                                                                          .createDivision,
+                                                                                                  );
+                                                                                              }}
+                                                                                          >
+                                                                                              <PlusIcon2 className="invisible h-5 w-5 group-hover:visible" />
+                                                                                          </div>
+                                                                                          <div className="invisible absolute bottom-0 h-[.0938rem] w-full bg-sub-2.5 peer-hover:visible" />
+                                                                                      </>
+                                                                                  )
+                                                                                : level !== requestShift.divisionShiftNurses.length - 1 &&
+                                                                                  !readonly && (
                                                                                       <div
-                                                                                          className="justify-cente group peer absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-80%] translate-y-[50%] items-center"
+                                                                                          className="absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-65%] translate-y-[calc(50%+.1563rem)] items-center"
                                                                                           onClick={(e) => {
                                                                                               e.stopPropagation();
                                                                                               editDivision(
                                                                                                   currentShiftTeam.shiftTeamId,
                                                                                                   row.shiftNurse.priority,
-                                                                                                  1,
+                                                                                                  -1,
                                                                                                   year.toString() +
                                                                                                       '-' +
                                                                                                       month.toString().padStart(2, '0'),
                                                                                               );
                                                                                               sendEvent(
-                                                                                                  events.makePage.calendar.createDivision,
+                                                                                                  events.makePage.calendar.deleteDivision,
                                                                                               );
                                                                                           }}
                                                                                       >
-                                                                                          <PlusIcon2 className="invisible h-5 w-5 group-hover:visible" />
+                                                                                          <MinusIcon className="h-5 w-5 opacity-0 hover:opacity-100" />
                                                                                       </div>
-                                                                                      <div className="invisible absolute bottom-0 h-[.0938rem] w-full bg-sub-2.5 peer-hover:visible" />
-                                                                                  </>
-                                                                              )
-                                                                            : level !== requestShift.divisionShiftNurses.length - 1 &&
-                                                                              !readonly && (
-                                                                                  <div
-                                                                                      className="absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-65%] translate-y-[calc(50%+.1563rem)] items-center"
-                                                                                      onClick={(e) => {
-                                                                                          e.stopPropagation();
-                                                                                          editDivision(
-                                                                                              currentShiftTeam.shiftTeamId,
-                                                                                              row.shiftNurse.priority,
-                                                                                              -1,
-                                                                                              year.toString() +
-                                                                                                  '-' +
-                                                                                                  month.toString().padStart(2, '0'),
-                                                                                          );
-                                                                                          sendEvent(
-                                                                                              events.makePage.calendar.deleteDivision,
-                                                                                          );
-                                                                                      }}
-                                                                                  >
-                                                                                      <MinusIcon className="h-5 w-5 opacity-0 hover:opacity-100" />
-                                                                                  </div>
-                                                                              )}
-                                                                    </div>
-                                                                )}
-                                                            </Draggable>
-                                                        ))}
-                                                        {provided.placeholder}
+                                                                                  )}
+                                                                        </div>
+                                                                    )}
+                                                                </Draggable>
+                                                            ))}
+                                                            {provided.placeholder}
+                                                        </div>
                                                     </div>
-                                                </div>
-                                            )}
-                                        </Droppable>
-                                    )
-                                ) : null;
-                            })}
+                                                )}
+                                            </Droppable>
+                                        )
+                                    ) : null;
+                                })}
+                        </div>
+                    </DragDropContext>
+                </div>
+            </Card>
+
+            <Card
+                id="nurse_request_list"
+                variant="elevated"
+                padding="none"
+                className="flex w-full shrink-0 flex-col overflow-hidden border-gray-6 xl:w-[360px]"
+            >
+                <div className="border-b border-sub-4.5 px-6 py-5">
+                    <div className="flex items-center justify-between gap-3">
+                        <div>
+                            <p className="font-apple text-[1.25rem] font-semibold text-main-1">신청 내역</p>
+                            <p className="mt-1 font-apple text-sm font-medium text-gray-4">미처리 신청 {unresolvedRequestCount}건</p>
+                        </div>
                     </div>
-                </DragDropContext>
-            </div>
-            <div id="nurse_request_list" className="flex flex-1 flex-col">
-                <div className="my-[.75rem] flex items-center">
-                    <p className="font-apple text-[1.25rem] font-semibold text-main-1">신청 내역</p>
-                    <p className="ml-auto cursor-pointer font-apple text-[.875rem] font-medium text-main-2">
-                        * 미처리 신청 {dutyRequestList?.filter((x) => x.isAccepted === null).length}개
-                    </p>
                 </div>
-                <div className="scrollbar-hide max-h-[calc(100vh-9rem)] overflow-scroll rounded-[1.25rem] bg-white py-[.0625rem]">
-                    {dutyRequestList?.map((dutyRequest, i) => {
-                        const focus: TFocus = {
-                            shiftNurseName: dutyRequest.nurseName,
-                            // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-                            shiftNurseId: requestShift.divisionShiftNurses
-                                .flatMap((x) => x)
-                                .find((x) => x.shiftNurse.nurseId === dutyRequest.nurseId)?.shiftNurse.shiftNurseId!,
-                            day: dutyRequest.date - 1,
-                        };
 
-                        return (
-                            <div
-                                key={i}
-                                className="flex h-13 items-center border-b-[.0625rem] border-sub-4.5 pr-[.75rem] pl-7.5 last:border-b-0"
-                            >
-                                <p
-                                    className="mr-[.625rem] cursor-pointer font-apple text-[1rem] text-sub-1"
-                                    onClick={() => {
-                                        if (readonly) return;
+                <div className="scrollbar-hide max-h-[calc(100vh-18rem)] overflow-y-auto px-5 py-4">
+                    {dutyRequestList && dutyRequestList.length > 0 ? (
+                        <div className="space-y-3">
+                            {dutyRequestList.map((dutyRequest) => {
+                                const matchedShiftNurseId =
+                                    requestShift.divisionShiftNurses
+                                        .flatMap((x) => x)
+                                        .find((x) => x.shiftNurse.nurseId === dutyRequest.nurseId)?.shiftNurse.shiftNurseId ?? null;
+                                const requestFocus =
+                                    matchedShiftNurseId !== null
+                                        ? {
+                                              shiftNurseName: dutyRequest.nurseName,
+                                              shiftNurseId: matchedShiftNurseId,
+                                              day: dutyRequest.date - 1,
+                                          }
+                                        : null;
 
-                                        changeFocus(focus);
-                                    }}
-                                >
-                                    {dutyRequest.nurseName} / {dutyRequest.date}일
-                                </p>
-                                <ShiftBadge shiftType={wardShiftTypeMap.get(dutyRequest.wardShiftTypeId)} />
-                                <div className="ml-auto flex h-7 w-22.5 items-center justify-center gap-[.125rem] rounded-[.3125rem] border-[.0313rem] border-sub-4 bg-sub-5 p-[.125rem]">
-                                    <button
-                                        className={twMerge(
-                                            'flex h-6 flex-1 items-center justify-center rounded-[.3125rem] font-poppins text-[1rem] text-sub-2.5',
-                                            dutyRequest.isAccepted === true && 'bg-main-1 text-white',
-                                        )}
-                                        onClick={() => {
-                                            acceptRequest(dutyRequest.wardReqShiftId, true);
-                                            sendEvent(events.requestPage.acceptRequest, 'true');
-                                        }}
-                                    >
-                                        수락
-                                    </button>
-                                    <button
-                                        className={twMerge(
-                                            'flex h-6 flex-1 items-center justify-center rounded-[.3125rem] font-poppins text-[1rem] text-sub-2.5',
-                                            dutyRequest.isAccepted === false && 'bg-sub-2 text-white',
-                                        )}
-                                        onClick={() => {
-                                            acceptRequest(dutyRequest.wardReqShiftId, false);
-                                            sendEvent(events.requestPage.acceptRequest, 'false');
-                                        }}
-                                    >
-                                        거절
-                                    </button>
-                                </div>
-                            </div>
-                        );
-                    })}
+                                return (
+                                    <div key={dutyRequest.wardReqShiftId} className="rounded-[16px] border border-gray-6 px-4 py-3">
+                                        <div className="flex items-start gap-3">
+                                            <div className="min-w-0 flex-1">
+                                                <button
+                                                    type="button"
+                                                    className={twMerge(
+                                                        'truncate text-left font-apple text-base font-semibold text-sub-1',
+                                                        (!requestFocus || readonly) && 'cursor-default',
+                                                        requestFocus && !readonly && 'cursor-pointer hover:text-main-1',
+                                                    )}
+                                                    onClick={() => {
+                                                        if (readonly || !requestFocus) return;
+
+                                                        changeFocus(requestFocus);
+                                                    }}
+                                                >
+                                                    {dutyRequest.nurseName} / {dutyRequest.date}일
+                                                </button>
+                                                <div className="mt-2 flex items-center gap-2">
+                                                    <ShiftBadge shiftType={wardShiftTypeMap.get(dutyRequest.wardShiftTypeId)} />
+                                                    <p className="font-apple text-sm font-medium text-gray-4">
+                                                        {dutyRequest.isAccepted === true
+                                                            ? '수락됨'
+                                                            : dutyRequest.isAccepted === false
+                                                              ? '거절됨'
+                                                              : '확인 필요'}
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div className="mt-4 flex rounded-[12px] bg-gray-7 p-1">
+                                            <button
+                                                type="button"
+                                                className={twMerge(
+                                                    'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
+                                                    dutyRequest.isAccepted === true && 'bg-main-1 text-white',
+                                                )}
+                                                onClick={() => {
+                                                    acceptRequest(dutyRequest.wardReqShiftId, true);
+                                                    sendEvent(events.requestPage.acceptRequest, 'true');
+                                                }}
+                                            >
+                                                수락
+                                            </button>
+                                            <button
+                                                type="button"
+                                                className={twMerge(
+                                                    'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
+                                                    dutyRequest.isAccepted === false && 'bg-sub-2 text-white',
+                                                )}
+                                                onClick={() => {
+                                                    acceptRequest(dutyRequest.wardReqShiftId, false);
+                                                    sendEvent(events.requestPage.acceptRequest, 'false');
+                                                }}
+                                            >
+                                                거절
+                                            </button>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    ) : (
+                        <div className="flex min-h-[220px] items-center justify-center rounded-[16px] bg-gray-7 px-6 text-center">
+                            <p className="font-apple text-sm leading-6 font-medium text-gray-4">
+                                아직 제출된 신청 근무가 없어요.
+                                <br />
+                                신청이 들어오면 이 패널에서 바로 확인할 수 있어요.
+                            </p>
+                        </div>
+                    )}
                 </div>
-            </div>
+            </Card>
         </div>
     ) : null;
 }

--- a/src/pages/RequestShiftPage/ui/Toolbar.tsx
+++ b/src/pages/RequestShiftPage/ui/Toolbar.tsx
@@ -4,6 +4,13 @@ import {NextIcon, PenIcon, PrevIcon, SaveCompleteIcon, SavingIcon} from '@/share
 import Button from '@/shared/ui/form-controls/Button';
 import Select from '@/shared/ui/form-controls/Select';
 
+const SAVE_STATUS_LABEL: Record<'idle' | 'loading' | 'success' | 'error', string> = {
+    idle: '변경 사항 없음',
+    loading: '저장 중',
+    success: '저장 완료',
+    error: '저장 실패',
+};
+
 function Toolbar() {
     const {
         state: {month, changeStatus, currentShiftTeam, shiftTeams, readonly},
@@ -11,81 +18,92 @@ function Toolbar() {
     } = useRequestShift();
 
     return (
-        <div id="toolbar" className="sticky top-0 z-30 flex h-24.5 w-full items-center bg-[#FDFCFE] pt-7.5 pr-4 pb-[.75rem] pl-5">
-            <div className="flex gap-5">
-                <div className="w-13.5"></div>
-                <div className="w-17.5"></div>
-                <div className="w-4"></div>
-            </div>
+        <div
+            id="toolbar"
+            className="flex flex-col gap-4 rounded-[20px] bg-white px-5 py-5 md:px-8 md:py-6 xl:flex-row xl:items-center xl:justify-between"
+        >
+            <div className="flex flex-col gap-4 md:flex-row md:items-center">
+                <div className="flex items-center gap-2">
+                    <button
+                        type="button"
+                        className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1"
+                        onClick={() => {
+                            changeMonth('prev');
+                            sendEvent(events.requestPage.toolbar.changeMonth);
+                        }}
+                        aria-label="이전 달 보기"
+                    >
+                        <PrevIcon className="h-7.5 w-7.5" />
+                    </button>
+                    <p className="min-w-[6rem] text-center font-apple text-2xl font-semibold text-main-1">{month}월</p>
+                    <button
+                        type="button"
+                        className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1"
+                        onClick={() => {
+                            changeMonth('next');
+                            sendEvent(events.requestPage.toolbar.changeMonth);
+                        }}
+                        aria-label="다음 달 보기"
+                    >
+                        <NextIcon className="h-7.5 w-7.5" />
+                    </button>
+                </div>
 
-            <div className="absolute flex items-center">
-                <PrevIcon
-                    onClick={() => {
-                        changeMonth('prev');
-                        sendEvent(events.requestPage.toolbar.changeMonth);
-                    }}
-                    className="h-7.5 w-7.5 cursor-pointer"
-                />
-                <p className="mx-[.625rem] font-poppins text-2xl text-main-1">{month}월</p>
-                <NextIcon
-                    onClick={() => {
-                        changeMonth('next');
-                        sendEvent(events.requestPage.toolbar.changeMonth);
-                    }}
-                    className="h-7.5 w-7.5 cursor-pointer"
-                />
-            </div>
-
-            {!readonly && (
-                <>
-                    <div className="ml-auto flex gap-[.3125rem] font-apple text-[.875rem] text-sub-2.5">
-                        {changeStatus === 'loading' ? <SavingIcon className="h-5 w-5" /> : <SaveCompleteIcon className="h-5 w-5" />}
-                        {changeStatus === 'loading' ? '저장중' : '저장 완료'}
-                    </div>
-                </>
-            )}
-
-            <div>
-                {currentShiftTeam && (
+                {currentShiftTeam ? (
                     <Select
-                        value={currentShiftTeam?.shiftTeamId}
+                        value={currentShiftTeam.shiftTeamId}
                         options={shiftTeams?.map((shiftTeam) => ({
                             label: shiftTeam.name,
                             value: shiftTeam.shiftTeamId,
                         }))}
-                        className="ml-7.5 h-11.5 w-42 font-apple text-[1.25rem] font-semibold text-main-1"
-                        selectClassName="outline-[.0938rem] outline-main-1"
+                        className="h-11 w-full md:w-[220px]"
+                        selectClassName="rounded-[14px] border border-gray-6 bg-gray-7 px-4 font-apple text-base font-semibold text-sub-1 outline-none"
                         onChange={(e) => {
-                            changeShiftTeam(shiftTeams!.find((shiftTeam) => shiftTeam.shiftTeamId === parseInt(e.target.value))!);
+                            changeShiftTeam(shiftTeams!.find((shiftTeam) => shiftTeam.shiftTeamId === parseInt(e.target.value, 10))!);
                             sendEvent(events.requestPage.toolbar.changeShiftTeam);
                         }}
                     />
-                )}
+                ) : null}
             </div>
 
-            {readonly ? (
-                <div className="ml-auto flex gap-[10px]">
-                    <Button
-                        id="editButton"
-                        variant="default"
-                        className="flex h-10 items-center justify-center gap-[.5rem] rounded-[.625rem] bg-main-2 px-[.75rem] text-[1.25rem] font-semibold"
-                        onClick={() => toggleEditMode()}
-                    >
-                        수정하기
-                        <PenIcon className="h-6 w-6 stroke-white" />
-                    </Button>
+            <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                {!readonly ? (
+                    <div className="flex items-center gap-2 rounded-[12px] bg-gray-7 px-4 py-2 font-apple text-sm font-medium text-gray-3">
+                        {changeStatus === 'loading' ? <SavingIcon className="h-5 w-5" /> : <SaveCompleteIcon className="h-5 w-5" />}
+                        {SAVE_STATUS_LABEL[changeStatus]}
+                    </div>
+                ) : null}
+
+                <div className="flex gap-3">
+                    {readonly ? (
+                        <Button
+                            id="editButton"
+                            type="button"
+                            size="md"
+                            className="h-11 rounded-[14px] px-5 font-semibold"
+                            onClick={() => {
+                                toggleEditMode();
+                                sendEvent(events.requestPage.toolbar.changeEditMode, 'edit');
+                            }}
+                        >
+                            수정하기
+                            <PenIcon className="h-5 w-5 stroke-white" />
+                        </Button>
+                    ) : (
+                        <Button
+                            type="button"
+                            size="md"
+                            className="h-11 rounded-[14px] px-5 font-semibold"
+                            onClick={() => {
+                                toggleEditMode();
+                                sendEvent(events.requestPage.toolbar.changeEditMode, 'save');
+                            }}
+                        >
+                            저장하기
+                        </Button>
+                    )}
                 </div>
-            ) : (
-                <div className="ml-5 flex gap-[.875rem]">
-                    <Button
-                        variant="outline"
-                        className="h-10 w-18.75 rounded-[3.125rem] text-[1.25rem] font-semibold"
-                        onClick={() => toggleEditMode()}
-                    >
-                        저장
-                    </Button>
-                </div>
-            )}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-829](https://gom3.atlassian.net/browse/DUT-829)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 신청근무 페이지 상위 레이아웃을 디자인 2.0 foundation 기준으로 정리하고 로딩/에러/빈 상태를 추가했습니다.
- 툴바를 카드형 헤더 구조로 재배치하고 팀 선택, 월 이동, 편집/저장 액션, 저장 상태 표시를 일관된 패턴으로 맞췄습니다.
- 신청 근무표와 신청 내역 패널을 카드 기반 2열 레이아웃으로 정리하고, 신청 내역 empty 상태 및 연결되지 않은 간호사 요청 처리 안전장치를 추가했습니다.
- `useRequestShift`의 저장 상태를 store로 올려 툴바와 편집 동작이 같은 상태를 보도록 맞추고, 팀이 0개일 때의 예외 케이스와 retry 경로를 보강했습니다.

<br>

## To Reviewers

- 기존 드래그/셀 편집 로직은 유지하고 바깥 레이아웃과 상태 화면 위주로 정리했습니다.
- 디자인 검수는 코드 기준 정합성까지 확인했고, 실제 데이터로 보는 최종 UI QA는 아직 남아 있습니다.
- 검증: `pnpm type-check`, `npx eslint src/pages/RequestShiftPage/index.tsx src/pages/RequestShiftPage/ui/Toolbar.tsx src/pages/RequestShiftPage/ui/RequestCalendar.tsx src/features/shift/useRequestShift/index.ts src/features/shift/useRequestShift/store.ts`


[DUT-829]: https://gom3.atlassian.net/browse/DUT-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ