### PR TITLE
[DUT-849]: 온보딩 엑셀 파싱 업로드 연동

### DIFF
--- a/src/pages/OnboardingWardCreatePage/adapter.test.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.test.ts
@@ -1,5 +1,13 @@
 import {describe, expect, it} from 'vitest';
-import {applyParsedWardData, buildCreateWardPayload, buildMockCreateWardPayload} from './adapter';
+import {type TOnboardingWardParseApiResponse} from '@/shared/api/file/type';
+import {
+    applyParsedWardData,
+    buildCreateWardPayload,
+    buildMockCreateWardPayload,
+    buildOnboardingParseDraftInjection,
+    getOnboardingUploadFailureMessage,
+    isSupportedOnboardingUploadFile,
+} from './adapter';
 import {createInitialDraft, saveSkillLevelConfig} from './model';
 
 describe('OnboardingWardCreatePage adapter', () => {
@@ -111,5 +119,48 @@ describe('OnboardingWardCreatePage adapter', () => {
             teamName: draft.teams[0]?.name,
         });
         expect(payload.skillLevelConfig.palette).toHaveLength(draft.skillLevelConfig.levelCount);
+    });
+
+    it('normalizes parse api responses into draft injection data', () => {
+        const response: TOnboardingWardParseApiResponse = {
+            wardName: '중환자실',
+            hospitalName: '듀팅병원',
+            wardShiftTypes: [
+                {name: '데이', shortName: 'd'},
+                {name: '오프', shortName: 'o', isOff: true},
+            ],
+            shiftTeams: [{name: 'A팀'}],
+            nurses: [
+                {
+                    name: '신규 간호사',
+                    teamName: 'A팀',
+                    possibleShiftShortNames: ['d', null],
+                },
+            ],
+            warnings: ['근속 연수가 없는 간호사는 오늘 날짜로 반영되었어요.'],
+        };
+        const {parsedWardData, warnings} = buildOnboardingParseDraftInjection(response, 'ward.xlsx');
+
+        expect(parsedWardData).toMatchObject({
+            fileName: 'ward.xlsx',
+            wardName: '중환자실',
+            hospitalName: '듀팅병원',
+        });
+        expect(parsedWardData.shiftTypes?.map((shiftType) => shiftType.shortName)).toEqual(['D', 'O']);
+        expect(parsedWardData.teams).toEqual([{name: 'A팀'}]);
+        expect(parsedWardData.nurses?.[0]?.possibleShiftShortNames).toEqual(['D']);
+        expect(warnings).toEqual(['근속 연수가 없는 간호사는 오늘 날짜로 반영되었어요.']);
+    });
+
+    it('detects supported upload file extensions', () => {
+        expect(isSupportedOnboardingUploadFile('march-duty.xlsx')).toBe(true);
+        expect(isSupportedOnboardingUploadFile('march-duty.csv')).toBe(true);
+        expect(isSupportedOnboardingUploadFile('march-duty.pdf')).toBe(false);
+    });
+
+    it('maps network upload failures to a user guidance message', () => {
+        expect(getOnboardingUploadFailureMessage(new Error('Network Error'))).toBe(
+            '파싱 서버에 연결하지 못했어요. 잠시 후 다시 시도해 주세요.',
+        );
     });
 });

--- a/src/pages/OnboardingWardCreatePage/adapter.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.ts
@@ -1,4 +1,5 @@
 import {v4 as uuidv4} from 'uuid';
+import {type TOnboardingWardParseApiResponse} from '@/shared/api/file/type';
 import {type TCreateWardDTO} from '@/shared/api/ward/type';
 import {
     createEmptyShiftType,
@@ -49,13 +50,24 @@ export type TOnboardingParsedWardData = {
     skillLevelConfig?: Partial<TSkillLevelConfig>;
 };
 
+export type TOnboardingParseDraftInjection = {
+    parsedWardData: TOnboardingParsedWardData;
+    warnings: string[];
+};
+
 const SHIFT_TIME_RANGES: Record<string, {startTime: string; endTime: string}> = {
     D: {startTime: '07:00', endTime: '15:00'},
     E: {startTime: '15:00', endTime: '23:00'},
     N: {startTime: '23:00', endTime: '07:00'},
 };
+const SUPPORTED_ONBOARDING_UPLOAD_EXTENSIONS = ['xlsx', 'xls', 'csv'] as const;
 const createLocalId = (prefix: string) => `${prefix}-${uuidv4()}`;
 const getTodayDate = () => new Date().toISOString().slice(0, 10);
+const trimToUndefined = (value?: string | null) => {
+    const trimmed = value?.trim();
+
+    return trimmed ?? undefined;
+};
 const requireFirstTeamId = (teams: TOnboardingTeamDraft[]) => {
     const firstTeamId = teams[0]?.id;
 
@@ -191,6 +203,98 @@ const buildParsedNurses = (
         };
     });
 };
+const collectWarnings = (response: TOnboardingWardParseApiResponse) =>
+    [
+        ...(response.warnings ?? []),
+        ...(response.failedSheets ?? []).map((sheetName) => `시트 "${sheetName}" 데이터를 불러오지 못했어요.`),
+        ...(response.failedRows ?? []).map((rowLabel) => `일부 행(${rowLabel})을 해석하지 못해 제외했어요.`),
+    ].filter((warning): warning is string => Boolean(warning?.trim()));
+const normalizeParsedShiftTypes = (response: TOnboardingWardParseApiResponse): TOnboardingParsedShiftType[] | undefined => {
+    const rawShiftTypes = response.shiftTypes ?? response.wardShiftTypes;
+
+    if (!rawShiftTypes) {
+        return undefined;
+    }
+
+    return rawShiftTypes
+        .map((shiftType) => ({
+            name: trimToUndefined(shiftType.name),
+            shortName: trimToUndefined(shiftType.shortName)?.toUpperCase(),
+            startTime: trimToUndefined(shiftType.startTime),
+            endTime: trimToUndefined(shiftType.endTime),
+            color: trimToUndefined(shiftType.color),
+            isDefault: shiftType.isDefault ?? undefined,
+            isOff: shiftType.isOff ?? undefined,
+            classification: shiftType.classification ?? undefined,
+        }))
+        .filter((shiftType) => Boolean(shiftType.name ?? shiftType.shortName));
+};
+const normalizeParsedTeams = (response: TOnboardingWardParseApiResponse): TOnboardingParsedTeam[] | undefined => {
+    const rawTeams = response.teams ?? response.shiftTeams;
+
+    if (!rawTeams) {
+        return undefined;
+    }
+
+    return rawTeams.map((team) => ({name: trimToUndefined(team.name) ?? ''})).filter((team) => Boolean(team.name));
+};
+const normalizeParsedNurses = (response: TOnboardingWardParseApiResponse): TOnboardingParsedNurse[] | undefined => {
+    if (!response.nurses) {
+        return undefined;
+    }
+
+    return response.nurses
+        .map((nurse) => ({
+            name: trimToUndefined(nurse.name),
+            memo: nurse.memo ?? undefined,
+            isWorker: nurse.isWorker ?? undefined,
+            employmentDate: trimToUndefined(nurse.employmentDate),
+            level: nurse.level ?? undefined,
+            teamName: trimToUndefined(nurse.teamName),
+            possibleShiftShortNames:
+                nurse.possibleShiftShortNames
+                    ?.map((shortName) => trimToUndefined(shortName)?.toUpperCase())
+                    .filter((shortName): shortName is string => Boolean(shortName)) ?? undefined,
+        }))
+        .filter((nurse) => Boolean(nurse.name ?? nurse.teamName));
+};
+
+export const getOnboardingUploadExtension = (fileName: string) => fileName.split('.').pop()?.toLowerCase() ?? '';
+
+export const isSupportedOnboardingUploadFile = (fileName: string) =>
+    SUPPORTED_ONBOARDING_UPLOAD_EXTENSIONS.includes(
+        getOnboardingUploadExtension(fileName) as (typeof SUPPORTED_ONBOARDING_UPLOAD_EXTENSIONS)[number],
+    );
+
+export const getOnboardingUploadFailureMessage = (error: unknown) => {
+    const defaultMessage = '파일을 해석하지 못했어요. 엑셀 양식을 확인한 뒤 다시 업로드해 주세요.';
+    const message = error instanceof Error ? error.message.trim() : '';
+
+    if (!message) {
+        return defaultMessage;
+    }
+
+    if (message.includes('Network Error')) {
+        return '파싱 서버에 연결하지 못했어요. 잠시 후 다시 시도해 주세요.';
+    }
+
+    return message;
+};
+
+export const buildOnboardingParseDraftInjection = (
+    response: TOnboardingWardParseApiResponse,
+    uploadedFileName: string,
+): TOnboardingParseDraftInjection => ({
+    parsedWardData: {
+        fileName: trimToUndefined(response.fileName) ?? uploadedFileName,
+        wardName: trimToUndefined(response.wardName),
+        hospitalName: trimToUndefined(response.hospitalName),
+        shiftTypes: normalizeParsedShiftTypes(response),
+        teams: normalizeParsedTeams(response),
+        nurses: normalizeParsedNurses(response),
+    },
+    warnings: collectWarnings(response),
+});
 
 export const applyParsedWardData = (draft: TOnboardingWardDraft, parsed: TOnboardingParsedWardData): TOnboardingWardDraft => {
     const nextShiftTypes = parsed.shiftTypes

--- a/src/pages/OnboardingWardCreatePage/components/steps/UploadStep.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/steps/UploadStep.tsx
@@ -7,9 +7,12 @@ import type {TOnboardingWardDraft} from '../../model';
 interface IUploadStepProps {
     draft: TOnboardingWardDraft;
     onUpload: (file: File) => void;
+    isUploading: boolean;
+    uploadError: string | null;
+    uploadWarnings: string[];
 }
 
-function UploadStep({draft, onUpload}: IUploadStepProps) {
+function UploadStep({draft, onUpload, isUploading, uploadError, uploadWarnings}: IUploadStepProps) {
     const inputRef = useRef<HTMLInputElement>(null);
 
     return (
@@ -35,12 +38,13 @@ function UploadStep({draft, onUpload}: IUploadStepProps) {
                     data-testid="upload-input"
                     hidden
                     type="file"
-                    accept=".xlsx,.xls,.csv,.png,.jpg,.jpeg,.pdf"
+                    accept=".xlsx,.xls,.csv"
                     onChange={(event) => {
                         const file = event.target.files?.[0];
 
                         if (file) {
                             onUpload(file);
+                            event.target.value = '';
                         }
                     }}
                 />
@@ -49,15 +53,40 @@ function UploadStep({draft, onUpload}: IUploadStepProps) {
                     variant="secondary"
                     size="md"
                     className="mt-5 h-10 rounded-[10px] border-gray-4 px-4 text-[20px] font-medium"
+                    disabled={isUploading}
                     onClick={() => inputRef.current?.click()}
                 >
-                    파일 업로드
+                    {isUploading ? '파일 해석 중...' : '파일 업로드'}
                     <Upload className="h-5 w-5" />
                 </Button>
             </Card>
             {draft.uploadedFileName ? (
                 <Card variant="success" padding="none" className="rounded-[10px] px-5 py-4 font-apple text-[18px]">
                     업로드됨: {draft.uploadedFileName}
+                </Card>
+            ) : null}
+            {uploadWarnings.length > 0 ? (
+                <Card
+                    data-testid="upload-warning"
+                    padding="none"
+                    className="rounded-[10px] border border-[#FFE0A3] bg-[#FFF9EA] px-5 py-4 font-apple text-[16px] text-[#A56600]"
+                >
+                    <p className="text-[18px] font-semibold">일부 데이터만 반영했어요</p>
+                    <ul className="mt-2 list-disc space-y-1 pl-5">
+                        {uploadWarnings.map((warning) => (
+                            <li key={warning}>{warning}</li>
+                        ))}
+                    </ul>
+                </Card>
+            ) : null}
+            {uploadError ? (
+                <Card
+                    data-testid="upload-error"
+                    padding="none"
+                    className="rounded-[10px] border border-[#F3C6C6] bg-[#FFF5F5] px-5 py-4 font-apple text-[16px] text-[#7A4F4F]"
+                >
+                    <p className="text-[18px] font-semibold text-[#C55252]">파일 업로드에 실패했어요</p>
+                    <p className="mt-2">{uploadError}</p>
                 </Card>
             ) : null}
         </div>

--- a/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
+++ b/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
@@ -2,7 +2,13 @@ import {type DropResult} from '@hello-pangea/dnd';
 import {useEffect, useMemo, useState} from 'react';
 import toast from 'react-hot-toast';
 import useRegister from '@/features/auth/useRegister';
-import {applyParsedWardData} from '../adapter';
+import {FileAPI} from '@/shared/api';
+import {
+    applyParsedWardData,
+    buildOnboardingParseDraftInjection,
+    getOnboardingUploadFailureMessage,
+    isSupportedOnboardingUploadFile,
+} from '../adapter';
 import {
     addNurseDraft,
     addShiftTypeDraft,
@@ -28,6 +34,7 @@ import type {TSortMode} from '../types';
 const MAX_STEP = 4;
 
 type TSubmissionStatus = 'idle' | 'submitting' | 'success' | 'error';
+type TUploadStatus = 'idle' | 'uploading' | 'success' | 'warning' | 'error';
 
 function useOnboardingWardWizard() {
     const {
@@ -39,6 +46,9 @@ function useOnboardingWardWizard() {
     const [showSkillModal, setShowSkillModal] = useState(false);
     const [submissionStatus, setSubmissionStatus] = useState<TSubmissionStatus>('idle');
     const [submissionError, setSubmissionError] = useState<string | null>(null);
+    const [uploadStatus, setUploadStatus] = useState<TUploadStatus>('idle');
+    const [uploadError, setUploadError] = useState<string | null>(null);
+    const [uploadWarnings, setUploadWarnings] = useState<string[]>([]);
     const onboardingWardCreateExecutor = useMemo(() => createOnboardingWardCreateExecutor(createWard), [createWard]);
 
     useEffect(() => {
@@ -83,8 +93,43 @@ function useOnboardingWardWizard() {
 
         setDraft((prev) => reorderNursesWithinTeam(prev, activeTeamId, {destination, source}));
     };
-    const applyUploadedFile = (fileName: string) => {
-        setDraft((prev) => applyParsedWardData(prev, {fileName}));
+    const applyUploadedFile = async (file: File) => {
+        if (!isSupportedOnboardingUploadFile(file.name)) {
+            const message = '엑셀 파일(.xlsx, .xls, .csv)만 업로드할 수 있어요.';
+
+            setUploadStatus('error');
+            setUploadError(message);
+            setUploadWarnings([]);
+            toast.error(message);
+
+            return;
+        }
+
+        setUploadStatus('uploading');
+        setUploadError(null);
+        setUploadWarnings([]);
+
+        try {
+            const response = await FileAPI.parseOnboardingWardExcel(file);
+            const {parsedWardData, warnings} = buildOnboardingParseDraftInjection(response, file.name);
+
+            setDraft((prev) => applyParsedWardData(prev, parsedWardData));
+            setUploadWarnings(warnings);
+            setUploadStatus(warnings.length > 0 ? 'warning' : 'success');
+
+            if (warnings.length > 0) {
+                toast.error('일부 데이터만 반영했어요. 누락된 항목을 확인해 주세요.');
+            } else {
+                toast.success('엑셀 데이터를 불러왔어요.');
+            }
+        } catch (error) {
+            const message = getOnboardingUploadFailureMessage(error);
+
+            setUploadStatus('error');
+            setUploadError(message);
+            setUploadWarnings([]);
+            toast.error(message);
+        }
     };
     const saveSkillConfig = (config: TSkillLevelConfig) => {
         setDraft((prev) => saveSkillLevelConfig(prev, config));
@@ -138,6 +183,9 @@ function useOnboardingWardWizard() {
         updateNurse,
         handleNurseDragEnd,
         applyUploadedFile,
+        uploadStatus,
+        uploadError,
+        uploadWarnings,
         saveSkillConfig,
         complete,
         submissionStatus,

--- a/src/pages/OnboardingWardCreatePage/index.test.tsx
+++ b/src/pages/OnboardingWardCreatePage/index.test.tsx
@@ -1,15 +1,19 @@
 import {screen, waitFor, within} from '@testing-library/react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type * as SharedApiModule from '@/shared/api';
 import {render, userEvent} from '@/shared/util/test-utils';
 import OnboardingWardCreatePage from './index';
 
 const toastSuccess = vi.fn();
+const toastError = vi.fn();
 const mockCreateWard = vi.fn();
 const mockNavigate = vi.fn();
+const mockParseOnboardingWardExcel = vi.fn();
 
 vi.mock('react-hot-toast', () => ({
     default: {
         success: (...args: unknown[]) => toastSuccess(...args),
+        error: (...args: unknown[]) => toastError(...args),
     },
 }));
 
@@ -30,6 +34,18 @@ vi.mock('@/features/auth/useRegister', () => ({
     }),
 }));
 
+vi.mock('@/shared/api', async () => {
+    const actual = (await vi.importActual('@/shared/api')) as typeof SharedApiModule;
+
+    return {
+        ...actual,
+        FileAPI: {
+            ...actual.FileAPI,
+            parseOnboardingWardExcel: (...args: unknown[]) => mockParseOnboardingWardExcel(...args),
+        },
+    };
+});
+
 const prepareValidFinalStep = async (user: ReturnType<typeof userEvent.setup>) => {
     await user.click(screen.getByRole('button', {name: '건너뛰기'}));
     await user.click(screen.getByRole('button', {name: '다음'}));
@@ -47,24 +63,89 @@ describe('OnboardingWardCreatePage', () => {
         mockCreateWard.mockReset();
         mockNavigate.mockReset();
         toastSuccess.mockReset();
+        toastError.mockReset();
+        mockParseOnboardingWardExcel.mockReset();
     });
 
-    it('uploads a mock file and moves through onboarding steps', async () => {
+    it('uploads a file, injects parsed data, and moves through onboarding steps', async () => {
         const user = userEvent.setup();
         const {container} = render(<OnboardingWardCreatePage />);
         const uploadInput = container.querySelector('input[type="file"]') as HTMLInputElement;
 
+        mockParseOnboardingWardExcel.mockResolvedValue({
+            wardName: '중환자실',
+            hospitalName: '듀팅병원',
+            shiftTypes: [
+                {name: '데이', shortName: 'D'},
+                {name: '오프', shortName: 'O', isOff: true},
+            ],
+            teams: [{name: 'A팀'}],
+            nurses: [
+                {
+                    name: '신규 간호사',
+                    teamName: 'A팀',
+                    possibleShiftShortNames: ['D'],
+                    employmentDate: '2025-01-01',
+                },
+            ],
+        });
+
         await user.upload(uploadInput, new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}));
 
-        expect(screen.getByText('업로드됨: march-duty.xlsx')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText('업로드됨: march-duty.xlsx')).toBeInTheDocument();
+        });
+
+        expect(mockParseOnboardingWardExcel).toHaveBeenCalledTimes(1);
+        expect(toastSuccess).toHaveBeenCalledWith('엑셀 데이터를 불러왔어요.');
 
         await user.click(screen.getByRole('button', {name: '다음'}));
 
         expect(screen.getByText('근무 유형')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('데이')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('오프')).toBeInTheDocument();
 
         await user.click(screen.getByRole('button', {name: '다음'}));
 
         expect(screen.getAllByText('간호사 추가하기')[0]).toBeInTheDocument();
+        expect(screen.getByDisplayValue('신규 간호사')).toBeInTheDocument();
+    });
+
+    it('shows upload warnings when the parse api partially succeeds', async () => {
+        const user = userEvent.setup();
+        const {container} = render(<OnboardingWardCreatePage />);
+        const uploadInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+        mockParseOnboardingWardExcel.mockResolvedValue({
+            nurses: [{name: '신규 간호사', teamName: 'A팀'}],
+            warnings: ['2행 데이터를 해석하지 못했어요.'],
+        });
+
+        await user.upload(uploadInput, new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('upload-warning')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('2행 데이터를 해석하지 못했어요.')).toBeInTheDocument();
+        expect(toastError).toHaveBeenCalledWith('일부 데이터만 반영했어요. 누락된 항목을 확인해 주세요.');
+    });
+
+    it('shows upload error guidance when the parse api fails', async () => {
+        const user = userEvent.setup();
+        const {container} = render(<OnboardingWardCreatePage />);
+        const uploadInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+        mockParseOnboardingWardExcel.mockRejectedValue(new Error('업로드한 파일 형식이 올바르지 않습니다.'));
+
+        await user.upload(uploadInput, new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('upload-error')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('업로드한 파일 형식이 올바르지 않습니다.')).toBeInTheDocument();
+        expect(toastError).toHaveBeenCalledWith('업로드한 파일 형식이 올바르지 않습니다.');
     });
 
     it('disables next in step 2 when a shift type is invalid', async () => {

--- a/src/pages/OnboardingWardCreatePage/index.tsx
+++ b/src/pages/OnboardingWardCreatePage/index.tsx
@@ -32,6 +32,9 @@ function OnboardingWardCreatePage() {
         updateNurse,
         handleNurseDragEnd,
         applyUploadedFile,
+        uploadStatus,
+        uploadError,
+        uploadWarnings,
         saveSkillConfig,
         complete,
         canGoNext,
@@ -44,7 +47,15 @@ function OnboardingWardCreatePage() {
     const stepContent = (() => {
         switch (draft.currentStep) {
             case 1:
-                return <UploadStep draft={draft} onUpload={(file) => applyUploadedFile(file.name)} />;
+                return (
+                    <UploadStep
+                        draft={draft}
+                        onUpload={(file) => void applyUploadedFile(file)}
+                        isUploading={uploadStatus === 'uploading'}
+                        uploadError={uploadError}
+                        uploadWarnings={uploadWarnings}
+                    />
+                );
             case 2:
                 return (
                     <ShiftTypeStep

--- a/src/shared/api/file/index.ts
+++ b/src/shared/api/file/index.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '../client';
-import {type IFileAPI, type IPresignedUrlResponse, type TPresignedUrlRequest} from './type';
+import {type IFileAPI, type IPresignedUrlResponse, type TOnboardingWardParseApiResponse, type TPresignedUrlRequest} from './type';
 
 class FileAPI implements IFileAPI {
     public async getPresignedUrl(fileType: TPresignedUrlRequest, fileExtension: string) {
@@ -7,6 +7,20 @@ class FileAPI implements IFileAPI {
             await axiosInstance.post<IPresignedUrlResponse>(`/files/presigned-url`, {
                 fileType,
                 fileExtension,
+            })
+        ).data;
+    }
+
+    public async parseOnboardingWardExcel(file: File) {
+        const formData = new FormData();
+
+        formData.append('file', file);
+
+        return (
+            await axiosInstance.post<TOnboardingWardParseApiResponse>(`/files/wards/onboarding/parse`, formData, {
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                },
             })
         ).data;
     }

--- a/src/shared/api/file/type.ts
+++ b/src/shared/api/file/type.ts
@@ -6,6 +6,46 @@ export const FILE_TYPE = {
 
 export type TPresignedUrlRequest = TValues<typeof FILE_TYPE>;
 
+export type TOnboardingWardParseApiShiftType = {
+    name?: string | null;
+    shortName?: string | null;
+    startTime?: string | null;
+    endTime?: string | null;
+    color?: string | null;
+    isDefault?: boolean | null;
+    isOff?: boolean | null;
+    classification?: 'DAY' | 'EVENING' | 'NIGHT' | 'OTHER_WORK' | 'OFF' | 'OTHER_LEAVE' | null;
+};
+
+export type TOnboardingWardParseApiTeam = {
+    name?: string | null;
+};
+
+export type TOnboardingWardParseApiNurse = {
+    name?: string | null;
+    memo?: string | null;
+    isWorker?: boolean | null;
+    employmentDate?: string | null;
+    level?: number | null;
+    teamName?: string | null;
+    possibleShiftShortNames?: Array<string | null> | null;
+};
+
+export type TOnboardingWardParseApiResponse = {
+    fileName?: string | null;
+    wardName?: string | null;
+    hospitalName?: string | null;
+    shiftTypes?: TOnboardingWardParseApiShiftType[] | null;
+    wardShiftTypes?: TOnboardingWardParseApiShiftType[] | null;
+    teams?: TOnboardingWardParseApiTeam[] | null;
+    shiftTeams?: TOnboardingWardParseApiTeam[] | null;
+    nurses?: TOnboardingWardParseApiNurse[] | null;
+    warnings?: string[] | null;
+    failedRows?: string[] | null;
+    failedSheets?: string[] | null;
+    message?: string | null;
+};
+
 export interface IPresignedUrlResponse {
     presignedUrl: string;
     fileUrl: string;
@@ -16,4 +56,5 @@ export interface IPresignedUrlResponse {
 export interface IFileAPI {
     // POST
     getPresignedUrl: (fileType: TPresignedUrlRequest, fileExtension: string) => Promise<IPresignedUrlResponse>;
+    parseOnboardingWardExcel: (file: File) => Promise<TOnboardingWardParseApiResponse>;
 }


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-849](https://gom3.atlassian.net/browse/DUT-849)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 온보딩 업로드 step에서 실제 파싱 API를 호출하고, 업로드 중/성공/실패/부분 성공 상태를 표시하도록 연결했습니다.
- 파싱 응답을 draft 주입용 데이터로 정규화하는 어댑터를 추가해 간호사, 근무유형, 병동 기본 정보 반영 규칙을 코드로 명시했습니다.
- 부분 실패 warning, 업로드 실패 메시지, 지원하지 않는 파일 확장자 안내를 추가하고 관련 테스트를 보강했습니다.

<br>

## To Reviewers

- 실제 백엔드 파싱 endpoint와 응답 필드명이 프론트 가정(`/files/wards/onboarding/parse`)과 일치하는지 QA 또는 Swagger에서 한 번 확인 부탁드립니다.
- DUT-832 하위 작업은 이 티켓만 남아 있었고, 코드/테스트 기준으론 닫을 수 있는 상태지만 실제 서버 연동 확인 후 부모 종료 판단이 더 안전합니다.


[DUT-849]: https://gom3.atlassian.net/browse/DUT-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file upload functionality for importing ward onboarding data with support for .xlsx, .xls, and .csv files
  * Added upload progress indication and loading state during file processing
  * Added error and warning notifications to inform users of import results and any partial data issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->