### PR TITLE
[DUT-852]: alert 기반 에러 피드백 공용화

### DIFF
--- a/src/features/auth/useRegister/index.ts
+++ b/src/features/auth/useRegister/index.ts
@@ -9,6 +9,7 @@ import {AccountAPI, NurseAPI, WardAPI} from '@/shared/api';
 import {type TCreateNurseDTO} from '@/shared/api/nurse/type';
 import {type TCreateWardDTO} from '@/shared/api/ward/type';
 import ROUTE from '@/shared/constant/path';
+import {showActionErrorFeedback} from '@/shared/util/feedback';
 import useAuth from '../useAuth';
 
 type TChangeAccountStatusOptions = {
@@ -40,7 +41,7 @@ const useRegister = () => {
 
                 return updatedAccount;
             } catch {
-                alert('계정 상태 변경에 실패했습니다.');
+                showActionErrorFeedback('계정 상태 변경에 실패했습니다.');
                 throw new Error('Failed to change account status.');
             }
         },

--- a/src/features/auth/useRegister/index.ts
+++ b/src/features/auth/useRegister/index.ts
@@ -40,8 +40,8 @@ const useRegister = () => {
                 }
 
                 return updatedAccount;
-            } catch {
-                showActionErrorFeedback('계정 상태 변경에 실패했습니다.');
+            } catch (error) {
+                showActionErrorFeedback(error, '계정 상태 변경에 실패했습니다.');
                 throw new Error('Failed to change account status.');
             }
         },

--- a/src/features/shift-editor/ui/complex-view/toolbar.tsx
+++ b/src/features/shift-editor/ui/complex-view/toolbar.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/shared/assets/svg';
 import Button from '@/shared/ui/form-controls/Button';
 import Select from '@/shared/ui/form-controls/Select';
+import {showValidationFeedback} from '@/shared/util/feedback';
 import SetConstraint from './editWard/set-constraint';
 import SetDesignTheme from './editWard/set-design-theme';
 import SetShiftType from './editWard/set-shift-type';
@@ -352,7 +353,7 @@ function Toolbar({
                     <Button
                         variant="default"
                         className="h-10 w-33 rounded-[3.125rem] border-none bg-[rgba(171,171,180,0.80)] text-[1.25rem] font-semibold text-white"
-                        onClick={() => alert('아직 준비중인 기능입니다!')}
+                        onClick={() => showValidationFeedback('아직 준비 중인 기능입니다.')}
                     >
                         자동 채우기
                     </Button>

--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -9,6 +9,7 @@ import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import {WardAPI} from '@/shared/api';
 import {DateUtil} from '@/shared/util/date';
+import {showActionErrorFeedback, showValidationFeedback} from '@/shared/util/feedback';
 import {useRequestShiftStore} from './store';
 import {type TFocus} from './type';
 import {findNurse, keydownEventMapper, moveFocus} from './utils';
@@ -161,7 +162,7 @@ const useRequestShift = (activeEffect = false) => {
                 await queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
                 await queryClient.invalidateQueries({queryKey: dutyRequestQueryKey});
             } catch {
-                alert('신청 처리에 실패했습니다.');
+                showActionErrorFeedback('신청 처리에 실패했습니다.');
             }
         },
         [dutyRequestQueryKey, queryClient, requestShiftQueryKey, wardId],
@@ -169,7 +170,7 @@ const useRequestShift = (activeEffect = false) => {
     const changeMonth = (type: 'prev' | 'next') => {
         if (type === 'prev') {
             if (new Date(year, month, 1) <= new Date() && !readonly) {
-                alert('두달 전 신청 근무는 수정하실 수 없습니다');
+                showValidationFeedback('두 달 전 신청 근무는 수정할 수 없습니다.');
                 setState('readonly', true);
             }
 
@@ -181,7 +182,7 @@ const useRequestShift = (activeEffect = false) => {
             }
         } else if (type === 'next') {
             if (new Date(year, month - 1, 1) > new Date()) {
-                alert('두달 뒤 신청 근무는 아직 수정하실  수 없습니다.');
+                showValidationFeedback('두 달 뒤 신청 근무는 아직 수정할 수 없습니다.');
 
                 return;
             }

--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -161,8 +161,8 @@ const useRequestShift = (activeEffect = false) => {
                 await WardAPI.acceptRequestShift(wardId, reqShiftId, isAccepted);
                 await queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
                 await queryClient.invalidateQueries({queryKey: dutyRequestQueryKey});
-            } catch {
-                showActionErrorFeedback('신청 처리에 실패했습니다.');
+            } catch (error) {
+                showActionErrorFeedback(error, '신청 처리에 실패했습니다.');
             }
         },
         [dutyRequestQueryKey, queryClient, requestShiftQueryKey, wardId],

--- a/src/features/ward/CreateShiftModal/index.test.tsx
+++ b/src/features/ward/CreateShiftModal/index.test.tsx
@@ -1,0 +1,28 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen, userEvent} from '@/shared/util/test-utils';
+import CreateShiftModal from './index';
+
+describe('CreateShiftModal', () => {
+    beforeEach(() => {
+        const modalRoot = document.createElement('div');
+
+        modalRoot.id = 'modal-root';
+        document.body.appendChild(modalRoot);
+    });
+
+    afterEach(() => {
+        document.querySelector('#modal-root')?.remove();
+    });
+
+    it('shows inline validation instead of alert when required fields are missing', async () => {
+        const user = userEvent.setup();
+        const onSubmit = vi.fn();
+
+        render(<CreateShiftModal open shiftType={null} close={vi.fn()} onSubmit={onSubmit} onDelete={vi.fn()} />);
+
+        await user.click(screen.getByRole('button', {name: '저장'}));
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByRole('alert')).toHaveTextContent('근무 이름을 입력해주세요.');
+    });
+});

--- a/src/features/ward/CreateShiftModal/index.test.tsx
+++ b/src/features/ward/CreateShiftModal/index.test.tsx
@@ -25,4 +25,26 @@ describe('CreateShiftModal', () => {
         expect(onSubmit).not.toHaveBeenCalled();
         expect(screen.getByRole('alert')).toHaveTextContent('근무 이름을 입력해주세요.');
     });
+
+    it('clears work-time validation when switching to leave mode', async () => {
+        const user = userEvent.setup();
+
+        render(<CreateShiftModal open shiftType={null} close={vi.fn()} onSubmit={vi.fn()} onDelete={vi.fn()} />);
+
+        const nameInput = screen.getByPlaceholderText('근무 명을 작성하세요.');
+        const shortNameInput = screen.getAllByRole('textbox')[1];
+        const [startTimeInput, endTimeInput] = screen.getAllByDisplayValue('00:00');
+
+        await user.type(nameInput, '데이');
+        await user.type(shortNameInput, 'D');
+        await user.clear(startTimeInput);
+        await user.clear(endTimeInput);
+        await user.click(screen.getByRole('button', {name: '저장'}));
+
+        expect(screen.getByRole('alert')).toHaveTextContent('근무 시간을 입력해주세요.');
+
+        await user.click(screen.getByText('휴가'));
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
 });

--- a/src/features/ward/CreateShiftModal/index.tsx
+++ b/src/features/ward/CreateShiftModal/index.tsx
@@ -5,6 +5,7 @@ import {CancelIcon} from '@/shared/assets/svg';
 import Button from '@/shared/ui/form-controls/Button';
 import TextField from '@/shared/ui/form-controls/TextField';
 import TimeInput from '@/shared/ui/form-controls/TimeInput';
+import ValidationMessage from '@/shared/ui/ValidationMessage';
 
 interface ICreateShiftModalProps {
     open: boolean;
@@ -28,26 +29,28 @@ const initialValue: TCreateShiftTypeDTO = {
 
 function CreateShiftModal({open, shiftType, close, onSubmit, onDelete}: ICreateShiftModalProps) {
     const [writeShift, setWriteShift] = useState(initialValue);
+    const [validationMessage, setValidationMessage] = useState<string | null>(null);
     const modalRoot = document.querySelector('#modal-root');
     const handleSubmit = () => {
         if (writeShift.name === '') {
-            alert('근무 이름을 입력해주세요.');
+            setValidationMessage('근무 이름을 입력해주세요.');
 
             return;
         }
 
         if (!writeShift.isOff && (writeShift.startTime === '' || writeShift.endTime === '')) {
-            alert('근무 시간을 입력해주세요.');
+            setValidationMessage('근무 시간을 입력해주세요.');
 
             return;
         }
 
         if (writeShift.shortName === '') {
-            alert('근무 약자를 입력해주세요.');
+            setValidationMessage('근무 약자를 입력해주세요.');
 
             return;
         }
 
+        setValidationMessage(null);
         onSubmit(writeShift);
         close();
     };
@@ -55,11 +58,16 @@ function CreateShiftModal({open, shiftType, close, onSubmit, onDelete}: ICreateS
     useEffect(() => {
         if (open === false) {
             setWriteShift(initialValue);
+            setValidationMessage(null);
         }
     }, [open]);
 
     useEffect(() => {
-        if (shiftType) setWriteShift(shiftType);
+        if (shiftType) {
+            setWriteShift(shiftType);
+        }
+
+        setValidationMessage(null);
     }, [shiftType]);
 
     return open
@@ -107,7 +115,10 @@ function CreateShiftModal({open, shiftType, close, onSubmit, onDelete}: ICreateS
                               className="h-13.5 font-apple text-[1.5rem] font-medium text-sub-1"
                               placeholder={writeShift.isOff ? '휴가 명을 작성하세요.' : '근무 명을 작성하세요.'}
                               value={writeShift.name}
-                              onChange={(e) => setWriteShift({...writeShift, name: e.target.value})}
+                              onChange={(e) => {
+                                  setWriteShift({...writeShift, name: e.target.value});
+                                  setValidationMessage(null);
+                              }}
                           />
                       </div>
                       <div className="">
@@ -121,7 +132,10 @@ function CreateShiftModal({open, shiftType, close, onSubmit, onDelete}: ICreateS
                               className="h-13.5 w-13.5 px-0 text-center font-apple text-[1.5rem] font-medium text-sub-1"
                               value={writeShift.shortName}
                               readOnly={writeShift.isDefault}
-                              onChange={(e) => setWriteShift({...writeShift, shortName: e.target.value})}
+                              onChange={(e) => {
+                                  setWriteShift({...writeShift, shortName: e.target.value});
+                                  setValidationMessage(null);
+                              }}
                           />
                       </div>
                       {!writeShift.isOff && (
@@ -131,17 +145,25 @@ function CreateShiftModal({open, shiftType, close, onSubmit, onDelete}: ICreateS
                                   <TimeInput
                                       className="h-13.5 w-35 text-center text-[1.5rem]"
                                       initTime={writeShift.startTime}
-                                      onTimeChange={(time) => setWriteShift({...writeShift, startTime: time})}
+                                      onTimeChange={(time) => {
+                                          setWriteShift({...writeShift, startTime: time});
+                                          setValidationMessage(null);
+                                      }}
                                   />
                                   <p className="font-poppins text-[1.5rem] text-sub-3">~</p>
                                   <TimeInput
                                       className="h-13.5 w-35 text-center text-[1.5rem]"
                                       initTime={writeShift.endTime}
-                                      onTimeChange={(time) => setWriteShift({...writeShift, endTime: time})}
+                                      onTimeChange={(time) => {
+                                          setWriteShift({...writeShift, endTime: time});
+                                          setValidationMessage(null);
+                                      }}
                                   />
                               </div>
+                              <ValidationMessage message={validationMessage} className="mt-3" />
                           </div>
                       )}
+                      {writeShift.isOff ? <ValidationMessage message={validationMessage} className="mt-4" /> : null}
                       <div className="flex flex-col items-start">
                           <p className="mt-7.5 mb-[.625rem] font-apple text-base text-sub-3">배경 색</p>
                           <div className="flex flex-1 items-center gap-17.5">

--- a/src/features/ward/CreateShiftModal/index.tsx
+++ b/src/features/ward/CreateShiftModal/index.tsx
@@ -91,6 +91,7 @@ function CreateShiftModal({open, shiftType, close, onSubmit, onDelete}: ICreateS
                               onClick={() => {
                                   if (writeShift.isDefault) return;
 
+                                  setValidationMessage(null);
                                   setWriteShift({...writeShift, isOff: false, classification: 'OTHER_WORK'});
                               }}
                           >
@@ -103,6 +104,7 @@ function CreateShiftModal({open, shiftType, close, onSubmit, onDelete}: ICreateS
                               onClick={() => {
                                   if (writeShift.isDefault) return;
 
+                                  setValidationMessage(null);
                                   setWriteShift({...writeShift, isOff: true, classification: 'OTHER_LEAVE'});
                               }}
                           >

--- a/src/features/ward/useEditShiftTeam/index.ts
+++ b/src/features/ward/useEditShiftTeam/index.ts
@@ -52,8 +52,8 @@ const useEditShiftTeam = () => {
                     memo: '',
                 });
                 await invalidateWard();
-            } catch {
-                showActionErrorFeedback('간호사 추가에 실패했습니다.');
+            } catch (error) {
+                showActionErrorFeedback(error, '간호사 추가에 실패했습니다.');
             }
         },
         [invalidateWard, wardId],
@@ -78,8 +78,8 @@ const useEditShiftTeam = () => {
             try {
                 await NurseAPI.updateNurse(nurseId, updateNurseDTO);
                 await invalidateWardShiftAndRequest();
-            } catch {
-                showActionErrorFeedback('간호사 정보 수정에 실패했습니다.');
+            } catch (error) {
+                showActionErrorFeedback(error, '간호사 정보 수정에 실패했습니다.');
             }
         },
         [invalidateWardShiftAndRequest],

--- a/src/features/ward/useEditShiftTeam/index.ts
+++ b/src/features/ward/useEditShiftTeam/index.ts
@@ -9,6 +9,7 @@ import useRequestShift from '@/features/shift/useRequestShift';
 import {NurseAPI, WardAPI} from '@/shared/api';
 import {type TUpdateNurseDTO, type TUpdateNurseShiftTypeRequest} from '@/shared/api/nurse/type';
 import {type TUpdateShiftTeamDTO} from '@/shared/api/ward/type';
+import {showActionErrorFeedback} from '@/shared/util/feedback';
 import useEditNurseStore from './store';
 
 const useEditShiftTeam = () => {
@@ -52,7 +53,7 @@ const useEditShiftTeam = () => {
                 });
                 await invalidateWard();
             } catch {
-                alert('간호사 추가에 실패했습니다.');
+                showActionErrorFeedback('간호사 추가에 실패했습니다.');
             }
         },
         [invalidateWard, wardId],
@@ -78,7 +79,7 @@ const useEditShiftTeam = () => {
                 await NurseAPI.updateNurse(nurseId, updateNurseDTO);
                 await invalidateWardShiftAndRequest();
             } catch {
-                alert('간호사 정보 수정이 실패했습니다.');
+                showActionErrorFeedback('간호사 정보 수정에 실패했습니다.');
             }
         },
         [invalidateWardShiftAndRequest],

--- a/src/features/ward/useEditWard/index.ts
+++ b/src/features/ward/useEditWard/index.ts
@@ -5,6 +5,7 @@ import useAuth from '@/features/auth/useAuth';
 import {WardAPI} from '@/shared/api';
 import {type TCreateShiftTypeDTO} from '@/shared/api/ward/type';
 import {type TEditWardDTO} from '@/shared/api/ward/type';
+import {showActionErrorFeedback} from '@/shared/util/feedback';
 
 const useEditWard = () => {
     const {
@@ -32,7 +33,7 @@ const useEditWard = () => {
                 await WardAPI.editWard(wardId, editWardDTO);
                 await queryClient.invalidateQueries({queryKey: wardQueryKey});
             } catch {
-                alert('근무 설정 수정에 실패하였습니다.');
+                showActionErrorFeedback('근무 설정 수정에 실패했습니다.');
             }
         },
         [queryClient, wardId, wardQueryKey],

--- a/src/features/ward/useEditWard/index.ts
+++ b/src/features/ward/useEditWard/index.ts
@@ -32,8 +32,8 @@ const useEditWard = () => {
             try {
                 await WardAPI.editWard(wardId, editWardDTO);
                 await queryClient.invalidateQueries({queryKey: wardQueryKey});
-            } catch {
-                showActionErrorFeedback('근무 설정 수정에 실패했습니다.');
+            } catch (error) {
+                showActionErrorFeedback(error, '근무 설정 수정에 실패했습니다.');
             }
         },
         [queryClient, wardId, wardQueryKey],

--- a/src/pages/RegisterPage/ui/RegisterWard.test.tsx
+++ b/src/pages/RegisterPage/ui/RegisterWard.test.tsx
@@ -1,0 +1,61 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen, userEvent} from '@/shared/util/test-utils';
+import RegisterWard from './RegisterWard';
+
+const mockNavigate = vi.fn();
+const mockCreateWard = vi.fn();
+const mockGetWardShiftValidationMessage = vi.fn();
+
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
+
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+    };
+});
+
+vi.mock('@/features/auth/useRegister', () => ({
+    default: () => ({
+        state: {
+            accountMe: {
+                status: 'WARD_SELECT_PENDING',
+            },
+        },
+        actions: {
+            createWard: mockCreateWard,
+        },
+    }),
+}));
+
+vi.mock('@/features/register-ward/model/ward', async () => {
+    const actual = await vi.importActual('@/features/register-ward/model/ward');
+
+    return {
+        ...actual,
+        getWardShiftValidationMessage: (...args: unknown[]) => mockGetWardShiftValidationMessage(...args),
+    };
+});
+
+describe('RegisterWard', () => {
+    beforeEach(() => {
+        mockNavigate.mockReset();
+        mockCreateWard.mockReset();
+        mockGetWardShiftValidationMessage.mockReset();
+    });
+
+    it('renders an inline validation message and blocks submission when shift validation fails', async () => {
+        const user = userEvent.setup();
+
+        mockGetWardShiftValidationMessage.mockReturnValue('근무 이름을 입력해주세요.');
+
+        render(<RegisterWard />);
+
+        await user.type(screen.getAllByRole('textbox')[0], '듀팅병원');
+        await user.type(screen.getAllByRole('textbox')[1], '중환자실');
+        await user.click(screen.getByRole('button', {name: '저장'}));
+
+        expect(mockCreateWard).not.toHaveBeenCalled();
+        expect(screen.getByRole('alert')).toHaveTextContent('근무 이름을 입력해주세요.');
+    });
+});

--- a/src/pages/RegisterPage/ui/RegisterWard.tsx
+++ b/src/pages/RegisterPage/ui/RegisterWard.tsx
@@ -13,10 +13,12 @@ import {BackIcon, FullLogo, LogoSymbolFill} from '@/shared/assets/svg';
 import ROUTE from '@/shared/constant/path';
 import Button from '@/shared/ui/form-controls/Button';
 import TextField from '@/shared/ui/form-controls/TextField';
+import ValidationMessage from '@/shared/ui/ValidationMessage';
 
 function RegisterWard() {
     const [shiftTeams, setShiftTeams] = useState<string[][]>([[]]);
     const [wardShiftTypes, setWardShiftTypes] = useState<TCreateWardDTO['wardShiftTypes']>(DEFAULT_WARD_SHIFT_TYPES);
+    const [wardShiftError, setWardShiftError] = useState<string | null>(null);
     const {
         formState: {errors, isValid},
         register,
@@ -39,6 +41,10 @@ function RegisterWard() {
         if (accountMe?.status !== 'WARD_SELECT_PENDING') navigate(ROUTE.REGISTER);
     }, [accountMe, navigate]);
 
+    useEffect(() => {
+        setWardShiftError(null);
+    }, [wardShiftTypes]);
+
     return (
         <div className="relative mx-auto mt-30.75 flex h-[calc(100%-7.6875rem)] w-[52%] flex-col items-center bg-[#FDFCFE]">
             <div className="fixed top-7.5 left-12.5 flex cursor-pointer gap-5" onClick={() => navigate(ROUTE.ROOT)}>
@@ -50,11 +56,12 @@ function RegisterWard() {
                     const validationMessage = getWardShiftValidationMessage(wardShiftTypes);
 
                     if (validationMessage) {
-                        alert(validationMessage);
+                        setWardShiftError(validationMessage);
 
                         return;
                     }
 
+                    setWardShiftError(null);
                     createWard({
                         name: d.name,
                         hospitalName: d.hospitalName,
@@ -95,6 +102,7 @@ function RegisterWard() {
                     </div>
                 </div>
                 <RegisterWardShiftTypesSection wardShiftTypes={wardShiftTypes} setWardShiftTypes={setWardShiftTypes} />
+                <ValidationMessage message={wardShiftError} className="mt-3 self-start" />
                 <RegisterWardShiftTeamsSection shiftTeams={shiftTeams} setShiftTeams={setShiftTeams} />
                 <Button type="submit" disabled={!isValid} className="mt-10 h-15 w-30 self-end text-center text-[2rem] font-semibold">
                     저장

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
-import {toast} from 'react-hot-toast';
 import {match} from 'ts-pattern';
 import ROUTE from '@/shared/constant/path';
+import {showActionErrorFeedback} from '@/shared/util/feedback';
 
 const axiosInstance = axios.create({
     baseURL: import.meta.env.VITE_SERVER_URL,
@@ -29,7 +29,7 @@ axiosInstance.interceptors.response.use(
                 }
             })
             .with(400, 404, () => {
-                toast.error(message ?? '에러가 발생했습니다. 다시 시도해주세요.');
+                showActionErrorFeedback(message ?? '에러가 발생했습니다. 다시 시도해주세요.');
             })
             .otherwise(() => {
                 // no-op

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
+import {toast} from 'react-hot-toast';
 import {match} from 'ts-pattern';
 import ROUTE from '@/shared/constant/path';
-import {showActionErrorFeedback} from '@/shared/util/feedback';
 
 const axiosInstance = axios.create({
     baseURL: import.meta.env.VITE_SERVER_URL,
@@ -29,7 +29,7 @@ axiosInstance.interceptors.response.use(
                 }
             })
             .with(400, 404, () => {
-                showActionErrorFeedback(message ?? '에러가 발생했습니다. 다시 시도해주세요.');
+                toast.error(message ?? '에러가 발생했습니다. 다시 시도해주세요.');
             })
             .otherwise(() => {
                 // no-op

--- a/src/shared/ui/ValidationMessage/index.tsx
+++ b/src/shared/ui/ValidationMessage/index.tsx
@@ -1,0 +1,18 @@
+import {cn} from '@/shared/util/style';
+
+type TValidationMessageProps = {
+    message?: string | null;
+    className?: string;
+};
+
+function ValidationMessage({message, className}: TValidationMessageProps) {
+    if (!message) return null;
+
+    return (
+        <p role="alert" className={cn('font-apple text-[1rem] font-medium text-red', className)}>
+            {message}
+        </p>
+    );
+}
+
+export default ValidationMessage;

--- a/src/shared/util/feedback.test.ts
+++ b/src/shared/util/feedback.test.ts
@@ -1,0 +1,33 @@
+import toast from 'react-hot-toast';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {showActionErrorFeedback, showValidationFeedback} from './feedback';
+
+vi.mock('react-hot-toast', () => ({
+    default: {
+        error: vi.fn(),
+    },
+}));
+
+describe('feedback util', () => {
+    beforeEach(() => {
+        vi.mocked(toast.error).mockReset();
+    });
+
+    it('shows validation feedback with a stable toast id', () => {
+        showValidationFeedback('검증 오류');
+
+        expect(toast.error).toHaveBeenCalledWith('검증 오류', {id: 'validation-feedback'});
+    });
+
+    it('skips duplicate action feedback when the api interceptor already handled the error', () => {
+        showActionErrorFeedback({code: 400}, '액션 실패');
+
+        expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it('shows action feedback for unhandled errors', () => {
+        showActionErrorFeedback({code: 500}, '액션 실패');
+
+        expect(toast.error).toHaveBeenCalledWith('액션 실패');
+    });
+});

--- a/src/shared/util/feedback.ts
+++ b/src/shared/util/feedback.ts
@@ -1,0 +1,9 @@
+import toast from 'react-hot-toast';
+
+export function showValidationFeedback(message: string) {
+    toast.error(message, {id: 'validation-feedback'});
+}
+
+export function showActionErrorFeedback(message: string) {
+    toast.error(message);
+}

--- a/src/shared/util/feedback.ts
+++ b/src/shared/util/feedback.ts
@@ -1,9 +1,17 @@
 import toast from 'react-hot-toast';
 
+const HANDLED_API_ERROR_CODES = new Set([400, 401, 404]);
+
 export function showValidationFeedback(message: string) {
     toast.error(message, {id: 'validation-feedback'});
 }
 
-export function showActionErrorFeedback(message: string) {
+export function showActionErrorFeedback(error: unknown, message: string) {
+    const code = typeof error === 'object' && error !== null && 'code' in error ? (error as {code?: number}).code : undefined;
+
+    if (code !== undefined && HANDLED_API_ERROR_CODES.has(code)) {
+        return;
+    }
+
     toast.error(message);
 }


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-852](https://gom3.atlassian.net/browse/DUT-852)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `src/features/ward/**`, `src/features/shift/useRequestShift/**`, `src/features/auth/useRegister/**`의 직접 `alert()` 호출을 `toast` 기반 공용 피드백으로 치환했습니다.
- `CreateShiftModal`과 `RegisterWard`는 제출 차단형 검증을 `ValidationMessage` 인라인 UI로 바꿔, 폼과 모달 안에서 즉시 원인을 확인할 수 있게 했습니다.
- `src/shared/util/feedback.ts`를 추가해 사용자 액션 실패와 필드 없는 검증 실패의 공용 피드백 패턴을 맞췄고, axios 인터셉터도 같은 toast 경로를 사용하도록 정리했습니다.
- `CreateShiftModal`, `RegisterWard` 테스트를 추가해 새 검증 패턴이 회귀되지 않도록 했습니다.

<br>

## To Reviewers

- `RequestShift`의 월 이동 제한 메시지는 기존 `alert()` 대신 validation toast로 전환했습니다. 현재 UX 맥락에서 인라인 위치가 없는 동작이라 toast로 두었고, 추후 화면 구조를 바꾸면 별도 상태 UI로 확장할 수 있습니다.
- `RegisterWard` 테스트에서 `react-i18next` 인스턴스 경고가 출력되지만 테스트 자체는 통과합니다. 이번 변경 범위에서는 기능 회귀만 검증했습니다.


[DUT-852]: https://gom3.atlassian.net/browse/DUT-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ