### PR TITLE
[DUT-854]: MemberPage ShiftTeamList 분해

### DIFF
--- a/src/pages/MemberPage/model/shiftTeamList.ts
+++ b/src/pages/MemberPage/model/shiftTeamList.ts
@@ -27,6 +27,25 @@ const DIVISION_PRIORITY_GAP = 2024;
 export const getGroupedDivisionNurses = (nurses: TNurse[]): TGroupedDivisionNurses =>
     Object.entries(groupBy(nurses, 'divisionNum')).sort((a, b) => parseInt(a[0]) - parseInt(b[0]));
 
+const getPreviousShiftTeamNurseId = (shiftTeams: TShiftTeam[], selectedShiftTeamIndex: number) => {
+    for (let teamIndex = selectedShiftTeamIndex - 1; teamIndex >= 0; teamIndex -= 1) {
+        const previousNurseId = shiftTeams[teamIndex].nurses[shiftTeams[teamIndex].nurses.length - 1]?.nurseId;
+
+        if (previousNurseId != null) return previousNurseId;
+    }
+
+    return null;
+};
+const getNextShiftTeamNurseId = (shiftTeams: TShiftTeam[], selectedShiftTeamIndex: number) => {
+    for (let teamIndex = selectedShiftTeamIndex + 1; teamIndex < shiftTeams.length; teamIndex += 1) {
+        const nextNurseId = shiftTeams[teamIndex].nurses[0]?.nurseId;
+
+        if (nextNurseId != null) return nextNurseId;
+    }
+
+    return null;
+};
+
 export const getNextSelectedNurseId = (shiftTeams: TShiftTeam[], selectedNurse: TNurse, direction: TKeyboardDirection): number | null => {
     const selectedShiftTeamIndex = shiftTeams.findIndex((shiftTeam) =>
         shiftTeam.nurses.some((nurse) => nurse.nurseId === selectedNurse.nurseId),
@@ -55,13 +74,7 @@ export const getNextSelectedNurseId = (shiftTeams: TShiftTeam[], selectedNurse: 
             return previousGroup[previousGroup.length - 1].nurseId;
         }
 
-        if (selectedShiftTeamIndex > 0) {
-            const previousShiftTeam = shiftTeams[selectedShiftTeamIndex - 1];
-
-            return previousShiftTeam.nurses[previousShiftTeam.nurses.length - 1]?.nurseId ?? null;
-        }
-
-        return null;
+        return getPreviousShiftTeamNurseId(shiftTeams, selectedShiftTeamIndex);
     }
 
     if (selectedNurseIndex < selectedGroup.length - 1) {
@@ -72,11 +85,7 @@ export const getNextSelectedNurseId = (shiftTeams: TShiftTeam[], selectedNurse: 
         return groupedNurses[selectedGroupIndex + 1][1][0]?.nurseId ?? null;
     }
 
-    if (selectedShiftTeamIndex < shiftTeams.length - 1) {
-        return shiftTeams[selectedShiftTeamIndex + 1].nurses[0]?.nurseId ?? null;
-    }
-
-    return null;
+    return getNextShiftTeamNurseId(shiftTeams, selectedShiftTeamIndex);
 };
 
 export const createMoveNurseOrderPayload = ({

--- a/src/pages/MemberPage/model/shiftTeamList.ts
+++ b/src/pages/MemberPage/model/shiftTeamList.ts
@@ -1,0 +1,153 @@
+import {groupBy} from 'lodash-es';
+import type {TNurse} from '@/entities/nurse';
+import type {TShiftTeam} from '@/entities/ward';
+
+export type TGroupedDivisionNurses = [string, TNurse[]][];
+
+export type TEditShiftTeamState = {
+    shiftTeamId: number;
+    updateShiftTeamDTO: {
+        name: string;
+    };
+} | null;
+
+type TKeyboardDirection = 'ArrowUp' | 'ArrowDown';
+
+type TMoveNurseOrderPayload = {
+    nurseId: number;
+    sourceShiftTeamId: number;
+    destinationShiftTeamId: number;
+    divisionNum: number;
+    prevPriority: number;
+    nextPriority: number;
+};
+
+const DIVISION_PRIORITY_GAP = 2024;
+
+export const getGroupedDivisionNurses = (nurses: TNurse[]): TGroupedDivisionNurses =>
+    Object.entries(groupBy(nurses, 'divisionNum')).sort((a, b) => parseInt(a[0]) - parseInt(b[0]));
+
+export const getNextSelectedNurseId = (shiftTeams: TShiftTeam[], selectedNurse: TNurse, direction: TKeyboardDirection): number | null => {
+    const selectedShiftTeamIndex = shiftTeams.findIndex((shiftTeam) =>
+        shiftTeam.nurses.some((nurse) => nurse.nurseId === selectedNurse.nurseId),
+    );
+
+    if (selectedShiftTeamIndex === -1) return null;
+
+    const groupedNurses = getGroupedDivisionNurses(shiftTeams[selectedShiftTeamIndex].nurses);
+    const selectedGroupIndex = groupedNurses.findIndex(([, nurses]) => nurses.some((nurse) => nurse.nurseId === selectedNurse.nurseId));
+
+    if (selectedGroupIndex === -1) return null;
+
+    const selectedGroup = groupedNurses[selectedGroupIndex][1];
+    const selectedNurseIndex = selectedGroup.findIndex((nurse) => nurse.nurseId === selectedNurse.nurseId);
+
+    if (selectedNurseIndex === -1) return null;
+
+    if (direction === 'ArrowUp') {
+        if (selectedNurseIndex > 0) {
+            return selectedGroup[selectedNurseIndex - 1].nurseId;
+        }
+
+        if (selectedGroupIndex > 0) {
+            const previousGroup = groupedNurses[selectedGroupIndex - 1][1];
+
+            return previousGroup[previousGroup.length - 1].nurseId;
+        }
+
+        if (selectedShiftTeamIndex > 0) {
+            const previousShiftTeam = shiftTeams[selectedShiftTeamIndex - 1];
+
+            return previousShiftTeam.nurses[previousShiftTeam.nurses.length - 1]?.nurseId ?? null;
+        }
+
+        return null;
+    }
+
+    if (selectedNurseIndex < selectedGroup.length - 1) {
+        return selectedGroup[selectedNurseIndex + 1].nurseId;
+    }
+
+    if (selectedGroupIndex < groupedNurses.length - 1) {
+        return groupedNurses[selectedGroupIndex + 1][1][0]?.nurseId ?? null;
+    }
+
+    if (selectedShiftTeamIndex < shiftTeams.length - 1) {
+        return shiftTeams[selectedShiftTeamIndex + 1].nurses[0]?.nurseId ?? null;
+    }
+
+    return null;
+};
+
+export const createMoveNurseOrderPayload = ({
+    shiftTeams,
+    sourceDroppableId,
+    destinationDroppableId,
+    destinationIndex,
+    sourceIndex,
+    draggableId,
+}: {
+    shiftTeams: TShiftTeam[];
+    sourceDroppableId: string;
+    destinationDroppableId: string;
+    destinationIndex: number;
+    sourceIndex: number;
+    draggableId: string;
+}): TMoveNurseOrderPayload | null => {
+    if (sourceDroppableId === destinationDroppableId && destinationIndex === sourceIndex) return null;
+
+    const [sourceShiftTeamIdText] = sourceDroppableId.split(',');
+    const [destinationShiftTeamIdText, destinationDivisionText] = destinationDroppableId.split(',');
+    const sourceShiftTeamId = parseInt(sourceShiftTeamIdText);
+    const destinationShiftTeamId = parseInt(destinationShiftTeamIdText);
+    const destinationDivision = parseInt(destinationDivisionText);
+    const destinationShiftTeam = shiftTeams.find((shiftTeam) => shiftTeam.shiftTeamId === destinationShiftTeamId);
+    const sourceShiftTeam = shiftTeams.find((shiftTeam) => shiftTeam.shiftTeamId === sourceShiftTeamId);
+
+    if (!destinationShiftTeam || !sourceShiftTeam) return null;
+
+    const destinationDivisionNurses = groupBy(destinationShiftTeam.nurses, 'divisionNum')[destinationDivisionText] ?? [];
+    const draggedNurse = sourceShiftTeam.nurses.find((nurse) => nurse.nurseId === parseInt(draggableId));
+
+    if (!draggedNurse) return null;
+
+    if (
+        destinationDroppableId === sourceDroppableId &&
+        destinationDivisionNurses.findIndex((nurse) => nurse.nurseId === draggedNurse.nurseId) < destinationIndex
+    ) {
+        return {
+            nurseId: draggedNurse.nurseId,
+            sourceShiftTeamId,
+            destinationShiftTeamId,
+            divisionNum: destinationDivision,
+            prevPriority: destinationIndex === 0 ? 0 : destinationDivisionNurses[destinationIndex].priority,
+            nextPriority:
+                destinationIndex === destinationDivisionNurses.length - 1
+                    ? destinationDivisionNurses[destinationIndex].priority + DIVISION_PRIORITY_GAP
+                    : destinationDivisionNurses[destinationIndex + 1].priority,
+        };
+    }
+
+    if (destinationDivision === 0) {
+        return {
+            nurseId: draggedNurse.nurseId,
+            sourceShiftTeamId,
+            destinationShiftTeamId,
+            divisionNum: 1,
+            prevPriority: 0,
+            nextPriority: DIVISION_PRIORITY_GAP,
+        };
+    }
+
+    return {
+        nurseId: draggedNurse.nurseId,
+        sourceShiftTeamId,
+        destinationShiftTeamId,
+        divisionNum: destinationDivision,
+        prevPriority: destinationIndex === 0 ? 0 : destinationDivisionNurses[destinationIndex - 1].priority,
+        nextPriority:
+            destinationIndex === destinationDivisionNurses.length
+                ? destinationDivisionNurses[destinationIndex - 1].priority + DIVISION_PRIORITY_GAP
+                : destinationDivisionNurses[destinationIndex].priority,
+    };
+};

--- a/src/pages/MemberPage/model/useShiftTeamListController.ts
+++ b/src/pages/MemberPage/model/useShiftTeamListController.ts
@@ -1,0 +1,132 @@
+import {type DropResult} from '@hello-pangea/dnd';
+import {useCallback, useEffect, useState} from 'react';
+import useOnclickOutside from 'react-cool-onclickoutside';
+import {events, sendEvent} from '@/analytics';
+import type {TNurse} from '@/entities/nurse';
+import type {TShiftTeam} from '@/entities/ward';
+import {type TUpdateShiftTeamDTO} from '@/shared/api/ward/type';
+import {DateUtil} from '@/shared/util/date';
+import {createMoveNurseOrderPayload, type TEditShiftTeamState, getNextSelectedNurseId} from './shiftTeamList';
+
+interface IUseShiftTeamListControllerParams {
+    shiftTeams: TShiftTeam[] | undefined;
+    selectedNurse: TNurse | undefined;
+    selectNurse: (nurseId: number | null) => void;
+    moveNurseOrder: (
+        nurseId: number,
+        shiftTeamId: number,
+        nextShiftTeamId: number,
+        divisionNum: number,
+        prevPriority: number,
+        nextPriority: number,
+        patchYearMonth: string,
+    ) => void;
+    updateShiftTeam: (shiftTeamId: number, updateShiftTeamDTO: TUpdateShiftTeamDTO) => void;
+}
+
+function useShiftTeamListController({
+    shiftTeams,
+    selectedNurse,
+    selectNurse,
+    moveNurseOrder,
+    updateShiftTeam,
+}: IUseShiftTeamListControllerParams) {
+    const [openMenuShiftTeamId, setOpenMenuShiftTeamId] = useState<number | null>(null);
+    const [editShiftTeam, setEditShiftTeam] = useState<TEditShiftTeamState>(null);
+    const clickAwayListRef = useOnclickOutside(() => selectNurse(null));
+    const clickAwayMenuRef = useOnclickOutside(() => setOpenMenuShiftTeamId(null));
+    const handleUpdateShiftTeam = useCallback(() => {
+        if (!editShiftTeam) return;
+
+        setEditShiftTeam(null);
+        updateShiftTeam(editShiftTeam.shiftTeamId, editShiftTeam.updateShiftTeamDTO);
+    }, [editShiftTeam, updateShiftTeam]);
+    const clickAwayShiftTeamNameRef = useOnclickOutside(() => {
+        handleUpdateShiftTeam();
+    });
+    const startEditingShiftTeam = useCallback((shiftTeamId: number, name: string) => {
+        setEditShiftTeam({
+            shiftTeamId,
+            updateShiftTeamDTO: {name},
+        });
+    }, []);
+    const changeEditShiftTeamName = useCallback((name: string) => {
+        setEditShiftTeam((prevEditShiftTeam) =>
+            prevEditShiftTeam
+                ? {
+                      ...prevEditShiftTeam,
+                      updateShiftTeamDTO: {name},
+                  }
+                : prevEditShiftTeam,
+        );
+    }, []);
+    const handleListKeyDown = useCallback(
+        (event: KeyboardEvent) => {
+            if (!shiftTeams || !selectedNurse || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return;
+
+            const nextSelectedNurseId = getNextSelectedNurseId(shiftTeams, selectedNurse, event.key);
+
+            if (!nextSelectedNurseId) return;
+
+            selectNurse(nextSelectedNurseId);
+            sendEvent(events.memberPage.moveNurseFocus);
+        },
+        [selectedNurse, selectNurse, shiftTeams],
+    );
+    const handleDragEnd = useCallback(
+        ({source, destination, draggableId}: DropResult) => {
+            if (!destination || !shiftTeams) return null;
+
+            const moveNurseOrderPayload = createMoveNurseOrderPayload({
+                shiftTeams,
+                sourceDroppableId: source.droppableId,
+                destinationDroppableId: destination.droppableId,
+                destinationIndex: destination.index,
+                sourceIndex: source.index,
+                draggableId,
+            });
+
+            if (!moveNurseOrderPayload) return null;
+
+            moveNurseOrder(
+                moveNurseOrderPayload.nurseId,
+                moveNurseOrderPayload.sourceShiftTeamId,
+                moveNurseOrderPayload.destinationShiftTeamId,
+                moveNurseOrderPayload.divisionNum,
+                moveNurseOrderPayload.prevPriority,
+                moveNurseOrderPayload.nextPriority,
+                DateUtil.getDateString(new Date(), 'yyyy-MM'),
+            );
+
+            sendEvent(events.memberPage.moveNurse);
+        },
+        [moveNurseOrder, shiftTeams],
+    );
+
+    useEffect(() => {
+        document.addEventListener('keydown', handleListKeyDown);
+
+        return () => document.removeEventListener('keydown', handleListKeyDown);
+    }, [handleListKeyDown]);
+
+    return {
+        state: {
+            openMenuShiftTeamId,
+            editShiftTeam,
+        },
+        refs: {
+            clickAwayListRef,
+            clickAwayMenuRef,
+            clickAwayShiftTeamNameRef,
+        },
+        actions: {
+            setOpenMenuShiftTeamId,
+            handleUpdateShiftTeam,
+            startEditingShiftTeam,
+            changeEditShiftTeamName,
+            handleDragEnd,
+        },
+    };
+}
+
+export default useShiftTeamListController;

--- a/src/pages/MemberPage/model/useShiftTeamListControllerHook.ts
+++ b/src/pages/MemberPage/model/useShiftTeamListControllerHook.ts
@@ -44,6 +44,11 @@ function useShiftTeamListController({
     const clickAwayShiftTeamNameRef = useOnclickOutside(() => {
         handleUpdateShiftTeam();
     });
+    const isEditingTarget = useCallback((target: EventTarget | null) => {
+        if (!(target instanceof HTMLElement)) return false;
+
+        return target.isContentEditable || !!target.closest('input, textarea, select, [contenteditable="true"], [contenteditable=""]');
+    }, []);
     const startEditingShiftTeam = useCallback((shiftTeamId: number, name: string) => {
         setEditShiftTeam({
             shiftTeamId,
@@ -62,16 +67,19 @@ function useShiftTeamListController({
     }, []);
     const handleListKeyDown = useCallback(
         (event: KeyboardEvent) => {
+            if (event.isComposing || isEditingTarget(event.target)) return;
+
             if (!shiftTeams || !selectedNurse || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return;
 
             const nextSelectedNurseId = getNextSelectedNurseId(shiftTeams, selectedNurse, event.key);
 
             if (!nextSelectedNurseId) return;
 
+            event.preventDefault();
             selectNurse(nextSelectedNurseId);
             sendEvent(events.memberPage.moveNurseFocus);
         },
-        [selectedNurse, selectNurse, shiftTeams],
+        [isEditingTarget, selectedNurse, selectNurse, shiftTeams],
     );
     const handleDragEnd = useCallback(
         ({source, destination, draggableId}: DropResult) => {

--- a/src/pages/MemberPage/ui/ShiftTeamCard.tsx
+++ b/src/pages/MemberPage/ui/ShiftTeamCard.tsx
@@ -1,0 +1,248 @@
+import {Droppable, Draggable} from '@hello-pangea/dnd';
+import type {RefCallback} from 'react';
+import {events, sendEvent} from '@/analytics';
+import {type TShiftTeam} from '@/entities/ward';
+import {setPreferredShiftTeamId} from '@/features/shift/editDuty/model/utils/prefs';
+import {DragIcon, InfoIcon, MinusIcon, MoreIcon, PersonIcon, PlusIcon2, UnlinkedIcon} from '@/shared/assets/svg';
+import TextField from '@/shared/ui/form-controls/TextField';
+import {DateUtil} from '@/shared/util/date';
+import {getGroupedDivisionNurses, type TEditShiftTeamState} from '../model/shiftTeamList';
+
+interface IShiftTeamCardProps {
+    shiftTeam: TShiftTeam;
+    selectedNurseId: number | undefined;
+    openMenuShiftTeamId: number | null;
+    editShiftTeam: TEditShiftTeamState;
+    clickAwayMenuRef: RefCallback<HTMLDivElement>;
+    clickAwayShiftTeamNameRef: RefCallback<HTMLInputElement>;
+    selectNurse: (nurseId: number) => void;
+    addNurse: (shiftTeamId: number) => void;
+    editDivision: (shiftTeamId: number, prevPriority: number, changeValue: number, patchYearMonth: string) => void;
+    deleteShiftTeam: (shiftTeamId: number) => void;
+    onOpenMenu: (shiftTeamId: number) => void;
+    onCloseMenu: () => void;
+    onStartEditingShiftTeam: (shiftTeamId: number, name: string) => void;
+    onChangeEditShiftTeamName: (name: string) => void;
+    onSubmitEditShiftTeam: () => void;
+    onMoveToMakePage: () => void;
+}
+
+function ShiftTeamCard({
+    shiftTeam,
+    selectedNurseId,
+    openMenuShiftTeamId,
+    editShiftTeam,
+    clickAwayMenuRef,
+    clickAwayShiftTeamNameRef,
+    selectNurse,
+    addNurse,
+    editDivision,
+    deleteShiftTeam,
+    onOpenMenu,
+    onCloseMenu,
+    onStartEditingShiftTeam,
+    onChangeEditShiftTeamName,
+    onSubmitEditShiftTeam,
+    onMoveToMakePage,
+}: IShiftTeamCardProps) {
+    const groupedDivisionNurses = getGroupedDivisionNurses(shiftTeam.nurses);
+
+    return (
+        <div id="shift_team_list" className="mt-5.5 flex w-75 flex-col rounded-[.9375rem] border-[.0625rem] border-sub-4.5 shadow-banner">
+            <div className="relative flex w-full items-center justify-between rounded-t-[.9375rem] bg-sub-2 px-5 py-[.875rem]">
+                <div className="flex flex-col gap-[.3125rem]">
+                    {editShiftTeam?.shiftTeamId === shiftTeam.shiftTeamId ? (
+                        <TextField
+                            ref={clickAwayShiftTeamNameRef}
+                            value={editShiftTeam.updateShiftTeamDTO.name}
+                            onKeyDown={(event) => event.key === 'Enter' && onSubmitEditShiftTeam()}
+                            onChange={(event) => onChangeEditShiftTeamName(event.target.value)}
+                            className="ml-[-.5rem] bg-transparent px-[.5rem] font-apple text-[1.5rem] font-semibold text-sub-4 outline-main-2 focus:outline-main-2"
+                            autoFocus
+                        />
+                    ) : (
+                        <h2
+                            onClick={() => onStartEditingShiftTeam(shiftTeam.shiftTeamId, shiftTeam.name)}
+                            className="font-apple text-[1.5rem] font-semibold text-white"
+                        >
+                            {shiftTeam.name}
+                        </h2>
+                    )}
+
+                    <div className="flex items-center">
+                        <PersonIcon className="h-4 w-4" />
+                        <p className="font-poppins text-[.75rem] text-white">{shiftTeam.nurses.length}</p>
+                    </div>
+                </div>
+                <MoreIcon
+                    className="h-7.5 w-7.5 cursor-pointer"
+                    onClick={() => {
+                        onOpenMenu(shiftTeam.shiftTeamId);
+                        sendEvent(events.memberPage.openShiftTeamMenu);
+                    }}
+                />
+                {openMenuShiftTeamId === shiftTeam.shiftTeamId && (
+                    <div
+                        className="absolute top-15 right-0 z-30 flex h-56 w-57.5 flex-col rounded-[.625rem] bg-white shadow-[4px_4px_42px_0px_rgba(104,81,149,0.25)]"
+                        ref={clickAwayMenuRef}
+                    >
+                        <div
+                            className="relative flex flex-1 cursor-pointer items-center gap-[.3125rem] border-b-[.0625rem] border-main-3 px-6.25 font-apple text-[1.25rem] font-medium text-sub-2 last:border-none"
+                            onClick={() => {
+                                addNurse(shiftTeam.shiftTeamId);
+                                onCloseMenu();
+                            }}
+                        >
+                            간호사 만들기
+                            <InfoIcon className="peer h-5 w-5" />
+                            <div className="invisible absolute top-[50%] -right-86 z-30 flex w-91 translate-y-[-50%] items-center gap-[.5rem] rounded-[.3125rem] bg-white px-2 py-1 font-apple text-[.875rem] text-sub-2 shadow-shadow-2 peer-hover:visible">
+                                <div
+                                    className="absolute top-[50%] left-[-.4375rem] h-0 w-0 translate-y-[-50%]"
+                                    style={{
+                                        borderTop: '.4375rem solid transparent',
+                                        borderLeft: '.625rem solid none',
+                                        borderRight: '.625rem solid white',
+                                        borderBottom: '.4375rem solid transparent',
+                                    }}
+                                />
+                                초대하지 않아도, 가상의 간호사를 만들어 관리할 수 있어요! &nbsp; (언제든지 초대해서 연동 가능합니다.)
+                            </div>
+                        </div>
+                        <div
+                            className="flex flex-1 cursor-pointer items-center border-b-[.0625rem] border-main-3 px-6.25 font-apple text-[1.25rem] font-medium text-sub-2 last:border-none"
+                            onClick={() => {
+                                setPreferredShiftTeamId(shiftTeam.shiftTeamId);
+                                onMoveToMakePage();
+                            }}
+                        >
+                            근무표 보러가기
+                        </div>
+                        <div
+                            className="flex flex-1 cursor-pointer items-center border-b-[.0625rem] border-main-3 px-6.25 font-apple text-[1.25rem] font-medium text-sub-2 last:border-none"
+                            onClick={() => deleteShiftTeam(shiftTeam.shiftTeamId)}
+                        >
+                            팀 삭제하기
+                        </div>
+                    </div>
+                )}
+            </div>
+            {shiftTeam.nurses.length === 0 && (
+                <Droppable droppableId={shiftTeam.shiftTeamId + ',' + 0} key={shiftTeam.shiftTeamId + ',' + 0}>
+                    {(provided) => (
+                        <div
+                            ref={provided.innerRef}
+                            {...provided.droppableProps}
+                            className="flex h-14 w-full cursor-pointer items-center justify-center select-none"
+                        >
+                            <h3 className="font-apple text-[1.25rem] font-semibold text-sub-2.5">아직 간호사가 없습니다!</h3>
+                        </div>
+                    )}
+                </Droppable>
+            )}
+            {groupedDivisionNurses.map(([division, divisionNurses], divisionIndex) => (
+                <Droppable droppableId={shiftTeam.shiftTeamId + ',' + division} key={shiftTeam.shiftTeamId + ',' + division}>
+                    {(provided) => (
+                        <div
+                            ref={provided.innerRef}
+                            {...provided.droppableProps}
+                            className="border-b-[.0938rem] border-sub-2.5 last:border-none"
+                        >
+                            {divisionNurses.map((nurse, index) => (
+                                <Draggable draggableId={nurse.nurseId.toString()} index={index} key={nurse.nurseId}>
+                                    {(draggableProvided) => (
+                                        <div
+                                            id="nurse_sample"
+                                            className={`group relative flex h-14 w-full cursor-pointer items-center justify-center select-none ${
+                                                selectedNurseId === nurse.nurseId
+                                                    ? 'bg-main-4 text-main-1 underline underline-offset-2'
+                                                    : 'bg-white text-sub-1'
+                                            } ${
+                                                shiftTeam.nurses.findIndex((item) => item.nurseId === nurse.nurseId) ===
+                                                shiftTeam.nurses.length - 1
+                                                    ? 'rounded-b-[.9375rem]'
+                                                    : 'border-b-[.0313rem] border-b-sub-4.5'
+                                            }`}
+                                            ref={draggableProvided.innerRef}
+                                            onClick={() => {
+                                                selectNurse(nurse.nurseId);
+                                                sendEvent(events.memberPage.focusNurse);
+                                            }}
+                                            {...draggableProvided.draggableProps}
+                                            {...draggableProvided.dragHandleProps}
+                                        >
+                                            <DragIcon className="invisible absolute left-[.75rem] h-6 w-6 group-hover:visible" />
+                                            <div className="peer relative font-apple text-[1.25rem] font-semibold text-sub-1">
+                                                {nurse.name}
+                                                {!nurse.isConnected && (
+                                                    <div className="absolute top-0 right-[-.3125rem] h-[.3125rem] w-[.3125rem] rounded-full bg-red"></div>
+                                                )}
+                                            </div>
+                                            <div className="invisible absolute top-0 z-30 flex translate-y-[-60%] items-center gap-[.5rem] rounded-[.3125rem] bg-white px-2 py-1 font-apple text-[.875rem] whitespace-nowrap text-sub-2 shadow-shadow-2 peer-hover:visible">
+                                                <div
+                                                    className="absolute -bottom-1.5 left-[50%] h-0 w-0 translate-x-[-50%]"
+                                                    style={{
+                                                        borderTop: '.625rem solid white',
+                                                        borderLeft: '.4375rem solid transparent',
+                                                        borderRight: '.4375rem solid transparent',
+                                                        borderBottom: '.625rem solid none',
+                                                    }}
+                                                />
+                                                연동 되지 않은 가상의 간호사입니다.
+                                                <UnlinkedIcon className="h-5 w-5" />
+                                            </div>
+                                            {index !== divisionNurses.length - 1 ? (
+                                                <div
+                                                    className="absolute bottom-0 z-10 w-full"
+                                                    onClick={(event) => {
+                                                        event.stopPropagation();
+                                                        editDivision(
+                                                            shiftTeam.shiftTeamId,
+                                                            nurse.priority,
+                                                            1,
+                                                            DateUtil.getDateString(new Date(), 'yyyy-MM'),
+                                                        );
+                                                        sendEvent(events.memberPage.createDivision);
+                                                    }}
+                                                >
+                                                    <div className="peer absolute bottom-0 z-30 h-[.8rem] w-full translate-y-[50%]" />
+                                                    <div className="invisible absolute bottom-0 h-[.0938rem] w-full bg-sub-2.5 peer-hover:visible" />
+                                                    <PlusIcon2 className="invisible absolute bottom-0 left-0 h-5 w-5 -translate-x-full translate-y-[50%] peer-hover:visible" />
+                                                    <p className="invisible absolute bottom-0 left-0 translate-x-[calc(.625rem-100%)] translate-y-[-50%] font-apple text-[.75rem] text-sub-2.5 peer-hover:visible">
+                                                        구분선
+                                                    </p>
+                                                </div>
+                                            ) : (
+                                                divisionIndex !== groupedDivisionNurses.length - 1 && (
+                                                    <div
+                                                        className="absolute bottom-0 z-10 w-full"
+                                                        onClick={(event) => {
+                                                            event.stopPropagation();
+                                                            editDivision(
+                                                                shiftTeam.shiftTeamId,
+                                                                nurse.priority,
+                                                                -1,
+                                                                DateUtil.getDateString(new Date(), 'yyyy-MM'),
+                                                            );
+                                                            sendEvent(events.memberPage.deleteDivision);
+                                                        }}
+                                                    >
+                                                        <div className="peer absolute bottom-0 z-30 h-[.8rem] w-full translate-y-[50%]" />
+                                                        <div className="invisible absolute bottom-0 h-[.0938rem] w-full translate-y-full bg-red peer-hover:visible" />
+                                                        <MinusIcon className="invisible absolute bottom-0 left-0 h-5 w-5 -translate-x-full translate-y-[50%] peer-hover:visible" />
+                                                    </div>
+                                                )
+                                            )}
+                                        </div>
+                                    )}
+                                </Draggable>
+                            ))}
+                            {provided.placeholder}
+                        </div>
+                    )}
+                </Droppable>
+            ))}
+        </div>
+    );
+}
+
+export default ShiftTeamCard;

--- a/src/pages/MemberPage/ui/ShiftTeamCard.tsx
+++ b/src/pages/MemberPage/ui/ShiftTeamCard.tsx
@@ -1,9 +1,10 @@
 import {Droppable, Draggable} from '@hello-pangea/dnd';
-import type {RefCallback} from 'react';
+import type {KeyboardEvent as ReactKeyboardEvent, RefCallback} from 'react';
 import {events, sendEvent} from '@/analytics';
 import {type TShiftTeam} from '@/entities/ward';
 import {setPreferredShiftTeamId} from '@/features/shift/editDuty/model/utils/prefs';
 import {DragIcon, InfoIcon, MinusIcon, MoreIcon, PersonIcon, PlusIcon2, UnlinkedIcon} from '@/shared/assets/svg';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import TextField from '@/shared/ui/form-controls/TextField';
 import {DateUtil} from '@/shared/util/date';
 import {getGroupedDivisionNurses, type TEditShiftTeamState} from '../model/shiftTeamList';
@@ -46,6 +47,16 @@ function ShiftTeamCard({
     onMoveToMakePage,
 }: IShiftTeamCardProps) {
     const groupedDivisionNurses = getGroupedDivisionNurses(shiftTeam.nurses);
+    const {t} = useTypedTranslation();
+    const handleActionKeyDown = (event: ReactKeyboardEvent<HTMLElement>, action: () => void, options?: {preventDefault?: boolean}) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+
+        if (options?.preventDefault ?? true) {
+            event.preventDefault();
+        }
+
+        action();
+    };
 
     return (
         <div id="shift_team_list" className="mt-5.5 flex w-75 flex-col rounded-[.9375rem] border-[.0625rem] border-sub-4.5 shadow-banner">
@@ -61,12 +72,14 @@ function ShiftTeamCard({
                             autoFocus
                         />
                     ) : (
-                        <h2
+                        <button
+                            type="button"
                             onClick={() => onStartEditingShiftTeam(shiftTeam.shiftTeamId, shiftTeam.name)}
-                            className="font-apple text-[1.5rem] font-semibold text-white"
+                            className="w-fit rounded-[.3125rem] font-apple text-[1.5rem] font-semibold text-white focus-visible:outline-[.125rem] focus-visible:outline-white"
+                            aria-label={t('page.member.shiftTeamList.card.editTeamNameAria', {teamName: shiftTeam.name})}
                         >
                             {shiftTeam.name}
-                        </h2>
+                        </button>
                     )}
 
                     <div className="flex items-center">
@@ -74,26 +87,32 @@ function ShiftTeamCard({
                         <p className="font-poppins text-[.75rem] text-white">{shiftTeam.nurses.length}</p>
                     </div>
                 </div>
-                <MoreIcon
-                    className="h-7.5 w-7.5 cursor-pointer"
+                <button
+                    type="button"
+                    className="rounded-[.3125rem] focus-visible:outline-[.125rem] focus-visible:outline-white"
+                    aria-label={t('page.member.shiftTeamList.card.openMenuAria', {teamName: shiftTeam.name})}
                     onClick={() => {
                         onOpenMenu(shiftTeam.shiftTeamId);
                         sendEvent(events.memberPage.openShiftTeamMenu);
                     }}
-                />
+                >
+                    <MoreIcon className="h-7.5 w-7.5 cursor-pointer" />
+                </button>
                 {openMenuShiftTeamId === shiftTeam.shiftTeamId && (
                     <div
                         className="absolute top-15 right-0 z-30 flex h-56 w-57.5 flex-col rounded-[.625rem] bg-white shadow-[4px_4px_42px_0px_rgba(104,81,149,0.25)]"
                         ref={clickAwayMenuRef}
                     >
-                        <div
-                            className="relative flex flex-1 cursor-pointer items-center gap-[.3125rem] border-b-[.0625rem] border-main-3 px-6.25 font-apple text-[1.25rem] font-medium text-sub-2 last:border-none"
+                        <button
+                            type="button"
+                            className="relative flex flex-1 items-center gap-[.3125rem] border-b-[.0625rem] border-main-3 px-6.25 text-left font-apple text-[1.25rem] font-medium text-sub-2 last:border-none focus-visible:outline-[.125rem] focus-visible:outline-main-2"
                             onClick={() => {
                                 addNurse(shiftTeam.shiftTeamId);
                                 onCloseMenu();
                             }}
+                            aria-label={t('page.member.shiftTeamList.card.addNurse')}
                         >
-                            간호사 만들기
+                            {t('page.member.shiftTeamList.card.addNurse')}
                             <InfoIcon className="peer h-5 w-5" />
                             <div className="invisible absolute top-[50%] -right-86 z-30 flex w-91 translate-y-[-50%] items-center gap-[.5rem] rounded-[.3125rem] bg-white px-2 py-1 font-apple text-[.875rem] text-sub-2 shadow-shadow-2 peer-hover:visible">
                                 <div
@@ -105,24 +124,28 @@ function ShiftTeamCard({
                                         borderBottom: '.4375rem solid transparent',
                                     }}
                                 />
-                                초대하지 않아도, 가상의 간호사를 만들어 관리할 수 있어요! &nbsp; (언제든지 초대해서 연동 가능합니다.)
+                                {t('page.member.shiftTeamList.card.addNurseTooltip')}
                             </div>
-                        </div>
-                        <div
-                            className="flex flex-1 cursor-pointer items-center border-b-[.0625rem] border-main-3 px-6.25 font-apple text-[1.25rem] font-medium text-sub-2 last:border-none"
+                        </button>
+                        <button
+                            type="button"
+                            className="flex flex-1 items-center border-b-[.0625rem] border-main-3 px-6.25 text-left font-apple text-[1.25rem] font-medium text-sub-2 last:border-none focus-visible:outline-[.125rem] focus-visible:outline-main-2"
                             onClick={() => {
                                 setPreferredShiftTeamId(shiftTeam.shiftTeamId);
                                 onMoveToMakePage();
                             }}
+                            aria-label={t('page.member.shiftTeamList.card.viewShift')}
                         >
-                            근무표 보러가기
-                        </div>
-                        <div
-                            className="flex flex-1 cursor-pointer items-center border-b-[.0625rem] border-main-3 px-6.25 font-apple text-[1.25rem] font-medium text-sub-2 last:border-none"
+                            {t('page.member.shiftTeamList.card.viewShift')}
+                        </button>
+                        <button
+                            type="button"
+                            className="flex flex-1 items-center border-b-[.0625rem] border-main-3 px-6.25 text-left font-apple text-[1.25rem] font-medium text-sub-2 last:border-none focus-visible:outline-[.125rem] focus-visible:outline-main-2"
                             onClick={() => deleteShiftTeam(shiftTeam.shiftTeamId)}
+                            aria-label={t('page.member.shiftTeamList.card.deleteTeam')}
                         >
-                            팀 삭제하기
-                        </div>
+                            {t('page.member.shiftTeamList.card.deleteTeam')}
+                        </button>
                     </div>
                 )}
             </div>
@@ -134,7 +157,10 @@ function ShiftTeamCard({
                             {...provided.droppableProps}
                             className="flex h-14 w-full cursor-pointer items-center justify-center select-none"
                         >
-                            <h3 className="font-apple text-[1.25rem] font-semibold text-sub-2.5">아직 간호사가 없습니다!</h3>
+                            <h3 className="font-apple text-[1.25rem] font-semibold text-sub-2.5">
+                                {t('page.member.shiftTeamList.card.empty')}
+                            </h3>
+                            {provided.placeholder}
                         </div>
                     )}
                 </Droppable>
@@ -161,12 +187,21 @@ function ShiftTeamCard({
                                                 shiftTeam.nurses.length - 1
                                                     ? 'rounded-b-[.9375rem]'
                                                     : 'border-b-[.0313rem] border-b-sub-4.5'
-                                            }`}
+                                            } focus-visible:outline-[.125rem] focus-visible:outline-main-2`}
                                             ref={draggableProvided.innerRef}
                                             onClick={() => {
                                                 selectNurse(nurse.nurseId);
                                                 sendEvent(events.memberPage.focusNurse);
                                             }}
+                                            onKeyDown={(event) =>
+                                                handleActionKeyDown(event, () => {
+                                                    selectNurse(nurse.nurseId);
+                                                    sendEvent(events.memberPage.focusNurse);
+                                                })
+                                            }
+                                            tabIndex={0}
+                                            role="button"
+                                            aria-label={t('page.member.shiftTeamList.card.selectNurseAria', {nurseName: nurse.name})}
                                             {...draggableProvided.draggableProps}
                                             {...draggableProvided.dragHandleProps}
                                         >
@@ -187,12 +222,12 @@ function ShiftTeamCard({
                                                         borderBottom: '.625rem solid none',
                                                     }}
                                                 />
-                                                연동 되지 않은 가상의 간호사입니다.
+                                                {t('page.member.shiftTeamList.card.virtualNurseTooltip')}
                                                 <UnlinkedIcon className="h-5 w-5" />
                                             </div>
                                             {index !== divisionNurses.length - 1 ? (
                                                 <div
-                                                    className="absolute bottom-0 z-10 w-full"
+                                                    className="absolute bottom-0 z-10 w-full focus-visible:outline-[.125rem] focus-visible:outline-main-2"
                                                     onClick={(event) => {
                                                         event.stopPropagation();
                                                         editDivision(
@@ -203,18 +238,32 @@ function ShiftTeamCard({
                                                         );
                                                         sendEvent(events.memberPage.createDivision);
                                                     }}
+                                                    onKeyDown={(event) =>
+                                                        handleActionKeyDown(event, () => {
+                                                            editDivision(
+                                                                shiftTeam.shiftTeamId,
+                                                                nurse.priority,
+                                                                1,
+                                                                DateUtil.getDateString(new Date(), 'yyyy-MM'),
+                                                            );
+                                                            sendEvent(events.memberPage.createDivision);
+                                                        })
+                                                    }
+                                                    tabIndex={0}
+                                                    role="button"
+                                                    aria-label={t('page.member.shiftTeamList.card.addDividerAria', {nurseName: nurse.name})}
                                                 >
                                                     <div className="peer absolute bottom-0 z-30 h-[.8rem] w-full translate-y-[50%]" />
                                                     <div className="invisible absolute bottom-0 h-[.0938rem] w-full bg-sub-2.5 peer-hover:visible" />
                                                     <PlusIcon2 className="invisible absolute bottom-0 left-0 h-5 w-5 -translate-x-full translate-y-[50%] peer-hover:visible" />
                                                     <p className="invisible absolute bottom-0 left-0 translate-x-[calc(.625rem-100%)] translate-y-[-50%] font-apple text-[.75rem] text-sub-2.5 peer-hover:visible">
-                                                        구분선
+                                                        {t('page.member.shiftTeamList.card.divider')}
                                                     </p>
                                                 </div>
                                             ) : (
                                                 divisionIndex !== groupedDivisionNurses.length - 1 && (
                                                     <div
-                                                        className="absolute bottom-0 z-10 w-full"
+                                                        className="absolute bottom-0 z-10 w-full focus-visible:outline-[.125rem] focus-visible:outline-main-2"
                                                         onClick={(event) => {
                                                             event.stopPropagation();
                                                             editDivision(
@@ -225,6 +274,22 @@ function ShiftTeamCard({
                                                             );
                                                             sendEvent(events.memberPage.deleteDivision);
                                                         }}
+                                                        onKeyDown={(event) =>
+                                                            handleActionKeyDown(event, () => {
+                                                                editDivision(
+                                                                    shiftTeam.shiftTeamId,
+                                                                    nurse.priority,
+                                                                    -1,
+                                                                    DateUtil.getDateString(new Date(), 'yyyy-MM'),
+                                                                );
+                                                                sendEvent(events.memberPage.deleteDivision);
+                                                            })
+                                                        }
+                                                        tabIndex={0}
+                                                        role="button"
+                                                        aria-label={t('page.member.shiftTeamList.card.removeDividerAria', {
+                                                            nurseName: nurse.name,
+                                                        })}
                                                     >
                                                         <div className="peer absolute bottom-0 z-30 h-[.8rem] w-full translate-y-[50%]" />
                                                         <div className="invisible absolute bottom-0 h-[.0938rem] w-full translate-y-full bg-red peer-hover:visible" />

--- a/src/pages/MemberPage/ui/ShiftTeamList.tsx
+++ b/src/pages/MemberPage/ui/ShiftTeamList.tsx
@@ -6,7 +6,8 @@ import {useTutorialStore} from '@/features/ui/useTutorial/store';
 import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
 import {PlusIcon} from '@/shared/assets/svg';
 import ROUTE from '@/shared/constant/path';
-import useShiftTeamListController from '../model/useShiftTeamListController';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import useShiftTeamListController from '../model/useShiftTeamListControllerHook';
 import ShiftTeamCard from './ShiftTeamCard';
 
 function ShiftTeamList() {
@@ -16,6 +17,7 @@ function ShiftTeamList() {
     } = useEditShiftTeam();
     const showMemberTutorial = useTutorialStore((state) => state.showMemberTutorial);
     const navigate = useNavigate();
+    const {t} = useTypedTranslation();
     const {
         state: {openMenuShiftTeamId, editShiftTeam},
         refs: {clickAwayListRef, clickAwayMenuRef, clickAwayShiftTeamNameRef},
@@ -37,16 +39,18 @@ function ShiftTeamList() {
     return (
         <div>
             <div className="mt-7.5 flex items-end gap-[.625rem]">
-                <h1 className="font-apple text-[1.75rem] font-semibold text-text-1">팀</h1>
-                <p className="font-apple text-base text-sub-2.5">팀당 근무표 1개 생성 가능합니다.</p>
+                <h1 className="font-apple text-[1.75rem] font-semibold text-text-1">{t('page.member.shiftTeamList.title')}</h1>
+                <p className="font-apple text-base text-sub-2.5">{t('page.member.shiftTeamList.subtitle')}</p>
                 <button
+                    type="button"
                     className="ml-4.5 flex h-9 items-center gap-[.5rem] rounded-[.3125rem] border-[.0625rem] border-main-3 bg-white px-[.75rem] font-apple text-base text-main-2"
                     onClick={() => {
                         createShiftTeam();
                         sendEvent(events.memberPage.createShiftTeam);
                     }}
                 >
-                    <PlusIcon className="h-6 w-6 stroke-main-2" />팀 추가하기
+                    <PlusIcon className="h-6 w-6 stroke-main-2" />
+                    {t('page.member.shiftTeamList.addTeam')}
                 </button>
             </div>
             <DragDropContext onDragEnd={handleDragEnd}>

--- a/src/pages/MemberPage/ui/ShiftTeamList.tsx
+++ b/src/pages/MemberPage/ui/ShiftTeamList.tsx
@@ -1,145 +1,38 @@
-import {DragDropContext, type DropResult, Droppable, Draggable} from '@hello-pangea/dnd';
-import {groupBy} from 'lodash-es';
-import {useCallback, useEffect, useState} from 'react';
-import useOnclickOutside from 'react-cool-onclickoutside';
+import {DragDropContext} from '@hello-pangea/dnd';
+import {useEffect} from 'react';
 import {useNavigate} from 'react-router';
 import {events, sendEvent} from '@/analytics';
-import {setPreferredShiftTeamId} from '@/features/shift/editDuty/model/utils/prefs';
 import {useTutorialStore} from '@/features/ui/useTutorial/store';
 import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
-import {type TUpdateShiftTeamDTO} from '@/shared/api/ward/type';
-import {DragIcon, InfoIcon, MinusIcon, MoreIcon, PersonIcon, PlusIcon, PlusIcon2, UnlinkedIcon} from '@/shared/assets/svg';
+import {PlusIcon} from '@/shared/assets/svg';
 import ROUTE from '@/shared/constant/path';
-import TextField from '@/shared/ui/form-controls/TextField';
-import {DateUtil} from '@/shared/util/date';
+import useShiftTeamListController from '../model/useShiftTeamListController';
+import ShiftTeamCard from './ShiftTeamCard';
 
 function ShiftTeamList() {
     const {
         state: {shiftTeams, selectedNurse},
         actions: {selectNurse, createShiftTeam, moveNurseOrder, updateShiftTeam, addNurse, editDivision, deleteShiftTeam},
     } = useEditShiftTeam();
-    const [openMenu, setOpenMenu] = useState<number | null>(null);
-    const [editShiftTeam, setEditShiftTeam] = useState<{
-        shiftTeamId: number;
-        updateShiftTeamDTO: TUpdateShiftTeamDTO;
-    } | null>(null);
     const showMemberTutorial = useTutorialStore((state) => state.showMemberTutorial);
     const navigate = useNavigate();
-    const clickAwayListRef = useOnclickOutside(() => selectNurse(null));
-    const clickAwayMenuRef = useOnclickOutside(() => setOpenMenu(null));
-    const handleUpdateShiftTeam = () => {
-        setEditShiftTeam(null);
-        console.log('?');
-        console.log(editShiftTeam);
-        updateShiftTeam(editShiftTeam!.shiftTeamId, editShiftTeam!.updateShiftTeamDTO);
-    };
-    const clickAwayShiftTeamNameRef = useOnclickOutside(() => {
-        if (!editShiftTeam) return;
-
-        handleUpdateShiftTeam();
+    const {
+        state: {openMenuShiftTeamId, editShiftTeam},
+        refs: {clickAwayListRef, clickAwayMenuRef, clickAwayShiftTeamNameRef},
+        actions: {setOpenMenuShiftTeamId, handleUpdateShiftTeam, startEditingShiftTeam, changeEditShiftTeamName, handleDragEnd},
+    } = useShiftTeamListController({
+        shiftTeams,
+        selectedNurse,
+        selectNurse,
+        moveNurseOrder,
+        updateShiftTeam,
     });
-    const handleKeyDown = useCallback(
-        (e: KeyboardEvent) => {
-            if (!shiftTeams || !selectedNurse) return;
-
-            const selectedShiftTeamIndex = shiftTeams.findIndex(
-                (shiftTeam) => shiftTeam.nurses.findIndex((nurse) => nurse.nurseId === selectedNurse.nurseId) !== -1,
-            );
-            const groupNurses = Object.entries(groupBy(shiftTeams[selectedShiftTeamIndex].nurses, 'divisionNum')).sort(
-                (a, b) => parseInt(a[0]) - parseInt(b[0]),
-            );
-            const selectedGroupIndex = groupNurses.findIndex((x) => x[1].some((y) => y.nurseId === selectedNurse.nurseId));
-            const selectedGroup = groupNurses[selectedGroupIndex][1];
-            const selectedNurseIndex = selectedGroup.findIndex((nurse) => nurse.nurseId === selectedNurse.nurseId);
-
-            if (e.key === 'ArrowUp') {
-                if (selectedNurseIndex > 0) {
-                    selectNurse(selectedGroup[selectedNurseIndex - 1].nurseId);
-                } else if (selectedGroupIndex > 0) {
-                    selectNurse(groupNurses[selectedGroupIndex - 1][1][groupNurses[selectedGroupIndex - 1][1].length - 1].nurseId);
-                } else if (selectedShiftTeamIndex > 0) {
-                    selectNurse(
-                        shiftTeams[selectedShiftTeamIndex - 1].nurses[shiftTeams[selectedShiftTeamIndex - 1].nurses.length - 1].nurseId,
-                    );
-                }
-            } else if (e.key === 'ArrowDown') {
-                if (selectedNurseIndex < selectedGroup.length - 1) {
-                    selectNurse(selectedGroup[selectedNurseIndex + 1].nurseId);
-                } else if (selectedGroupIndex < groupNurses.length - 1) {
-                    selectNurse(groupNurses[selectedGroupIndex + 1][1][0].nurseId);
-                } else if (selectedShiftTeamIndex < shiftTeams.length - 1) {
-                    selectNurse(shiftTeams[selectedShiftTeamIndex + 1].nurses[0].nurseId);
-                }
-            }
-
-            sendEvent(events.memberPage.moveNurseFocus);
-        },
-        [shiftTeams, selectedNurse, selectNurse],
-    );
-    const onDragEnd = ({source, destination, draggableId}: DropResult) => {
-        if (!destination || !shiftTeams) return null;
-
-        if (source.droppableId === destination.droppableId && destination.index === source.index) return;
-
-        const [sourceShiftTeamId] = source.droppableId.split(',');
-        const [destinationShiftTeamId, destinationDivision] = destination.droppableId.split(',');
-        const divisionNurses = groupBy(shiftTeams.find((x) => x.shiftTeamId === parseInt(destinationShiftTeamId))!.nurses, 'divisionNum');
-        const destinationNurses = divisionNurses[destinationDivision];
-        const dragedNurse = shiftTeams
-            .find((x) => x.shiftTeamId === parseInt(sourceShiftTeamId))!
-            .nurses.find((x) => x.nurseId === parseInt(draggableId))!;
-
-        if (
-            destination.droppableId === source.droppableId &&
-            destinationNurses.findIndex((x) => x.nurseId === dragedNurse.nurseId) < destination.index
-        ) {
-            moveNurseOrder(
-                dragedNurse.nurseId,
-                parseInt(sourceShiftTeamId),
-                parseInt(destinationShiftTeamId),
-                parseInt(destinationDivision),
-                destination.index === 0 ? 0 : destinationNurses[destination.index].priority,
-                destination.index === destinationNurses.length - 1
-                    ? destinationNurses[destination.index].priority + 2024
-                    : destinationNurses[destination.index + 1].priority,
-                DateUtil.getDateString(new Date(), 'yyyy-MM'),
-            );
-        } else {
-            if (parseInt(destinationDivision) === 0) {
-                moveNurseOrder(
-                    dragedNurse.nurseId,
-                    parseInt(sourceShiftTeamId),
-                    parseInt(destinationShiftTeamId),
-                    1,
-                    0,
-                    2024,
-                    DateUtil.getDateString(new Date(), 'yyyy-MM'),
-                );
-            } else {
-                moveNurseOrder(
-                    dragedNurse.nurseId,
-                    parseInt(sourceShiftTeamId),
-                    parseInt(destinationShiftTeamId),
-                    parseInt(destinationDivision),
-                    destination.index === 0 ? 0 : destinationNurses[destination.index - 1].priority,
-                    destination.index === destinationNurses.length
-                        ? destinationNurses[destination.index - 1].priority + 2024
-                        : destinationNurses[destination.index].priority,
-                    DateUtil.getDateString(new Date(), 'yyyy-MM'),
-                );
-            }
-        }
-
-        sendEvent(events.memberPage.moveNurse);
-    };
 
     useEffect(() => {
-        if (shiftTeams && showMemberTutorial) window.dispatchEvent(new Event('resize'));
-
-        document.addEventListener('keydown', handleKeyDown);
-
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [shiftTeams, selectedNurse, showMemberTutorial, handleKeyDown]);
+        if (shiftTeams && showMemberTutorial) {
+            window.dispatchEvent(new Event('resize'));
+        }
+    }, [shiftTeams, showMemberTutorial]);
 
     return (
         <div>
@@ -156,227 +49,28 @@ function ShiftTeamList() {
                     <PlusIcon className="h-6 w-6 stroke-main-2" />팀 추가하기
                 </button>
             </div>
-            <DragDropContext onDragEnd={onDragEnd}>
+            <DragDropContext onDragEnd={handleDragEnd}>
                 <div className="mb-8 flex items-start gap-10" ref={clickAwayListRef}>
                     {shiftTeams?.map((shiftTeam) => (
-                        <div
-                            id="shift_team_list"
-                            className="mt-5.5 flex w-75 flex-col rounded-[.9375rem] border-[.0625rem] border-sub-4.5 shadow-banner"
+                        <ShiftTeamCard
                             key={shiftTeam.shiftTeamId}
-                        >
-                            <div className="relative flex w-full items-center justify-between rounded-t-[.9375rem] bg-sub-2 px-5 py-[.875rem]">
-                                <div className="flex flex-col gap-[.3125rem]">
-                                    {editShiftTeam?.shiftTeamId === shiftTeam.shiftTeamId ? (
-                                        <TextField
-                                            ref={clickAwayShiftTeamNameRef}
-                                            value={editShiftTeam.updateShiftTeamDTO.name}
-                                            onKeyDown={(e) => e.key === 'Enter' && handleUpdateShiftTeam()}
-                                            onChange={(e) =>
-                                                setEditShiftTeam({
-                                                    ...editShiftTeam,
-                                                    updateShiftTeamDTO: {name: e.target.value},
-                                                })
-                                            }
-                                            className="ml-[-.5rem] bg-transparent px-[.5rem] font-apple text-[1.5rem] font-semibold text-sub-4 outline-main-2 focus:outline-main-2"
-                                            autoFocus
-                                        />
-                                    ) : (
-                                        <h2
-                                            onClick={() =>
-                                                setEditShiftTeam({
-                                                    shiftTeamId: shiftTeam.shiftTeamId,
-                                                    updateShiftTeamDTO: {name: shiftTeam.name},
-                                                })
-                                            }
-                                            className="font-apple text-[1.5rem] font-semibold text-white"
-                                        >
-                                            {shiftTeam.name}
-                                        </h2>
-                                    )}
-
-                                    <div className="flex items-center">
-                                        <PersonIcon className="h-4 w-4" />
-                                        <p className="font-poppins text-[.75rem] text-white">{shiftTeam.nurses.length}</p>
-                                    </div>
-                                </div>
-                                <MoreIcon
-                                    className="h-7.5 w-7.5 cursor-pointer"
-                                    onClick={() => {
-                                        setOpenMenu(shiftTeam.shiftTeamId);
-                                        sendEvent(events.memberPage.openShiftTeamMenu);
-                                    }}
-                                />
-                                {openMenu === shiftTeam.shiftTeamId && (
-                                    <div
-                                        className="absolute top-15 right-0 z-30 flex h-56 w-57.5 flex-col rounded-[.625rem] bg-white shadow-[4px_4px_42px_0px_rgba(104,81,149,0.25)]"
-                                        ref={clickAwayMenuRef}
-                                    >
-                                        <div
-                                            className="relative flex flex-1 cursor-pointer items-center gap-[.3125rem] border-b-[.0625rem] border-main-3 px-6.25 font-apple text-[1.25rem] font-medium text-sub-2 last:border-none"
-                                            onClick={() => {
-                                                addNurse(shiftTeam.shiftTeamId);
-                                                setOpenMenu(null);
-                                            }}
-                                        >
-                                            간호사 만들기
-                                            <InfoIcon className="peer h-5 w-5" />
-                                            <div className="invisible absolute top-[50%] -right-86 z-30 flex w-91 translate-y-[-50%] items-center gap-[.5rem] rounded-[.3125rem] bg-white px-2 py-1 font-apple text-[.875rem] text-sub-2 shadow-shadow-2 peer-hover:visible">
-                                                <div
-                                                    className="absolute top-[50%] left-[-.4375rem] h-0 w-0 translate-y-[-50%]"
-                                                    style={{
-                                                        borderTop: '.4375rem solid transparent',
-                                                        borderLeft: '.625rem solid none',
-                                                        borderRight: '.625rem solid white',
-                                                        borderBottom: '.4375rem solid transparent',
-                                                    }}
-                                                />
-                                                초대하지 않아도, 가상의 간호사를 만들어 관리할 수 있어요! &nbsp; (언제든지 초대해서 연동
-                                                가능합니다.)
-                                            </div>
-                                        </div>
-                                        <div
-                                            className="flex flex-1 cursor-pointer items-center border-b-[.0625rem] border-main-3 px-6.25 font-apple text-[1.25rem] font-medium text-sub-2 last:border-none"
-                                            onClick={() => {
-                                                setPreferredShiftTeamId(shiftTeam.shiftTeamId);
-                                                navigate(ROUTE.MAKE);
-                                            }}
-                                        >
-                                            근무표 보러가기
-                                        </div>
-                                        <div
-                                            className="flex flex-1 cursor-pointer items-center border-b-[.0625rem] border-main-3 px-6.25 font-apple text-[1.25rem] font-medium text-sub-2 last:border-none"
-                                            onClick={() => deleteShiftTeam(shiftTeam.shiftTeamId)}
-                                        >
-                                            팀 삭제하기
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                            {shiftTeam.nurses.length === 0 && (
-                                <Droppable droppableId={shiftTeam.shiftTeamId + ',' + 0} key={shiftTeam.shiftTeamId + ',' + 0}>
-                                    {(provided) => (
-                                        <div
-                                            ref={provided.innerRef}
-                                            {...provided.droppableProps}
-                                            className={`flex h-14 w-full cursor-pointer items-center justify-center select-none`}
-                                        >
-                                            <h3 className="font-apple text-[1.25rem] font-semibold text-sub-2.5">
-                                                아직 간호사가 없습니다!
-                                            </h3>
-                                        </div>
-                                    )}
-                                </Droppable>
-                            )}
-                            {Object.entries(groupBy(shiftTeam.nurses, 'divisionNum'))
-                                .sort((a, b) => parseInt(a[0]) - parseInt(b[0]))
-                                .map(([division, divisionNurses], divisionIndex) => (
-                                    <Droppable
-                                        droppableId={shiftTeam.shiftTeamId + ',' + division}
-                                        key={shiftTeam.shiftTeamId + ',' + division}
-                                    >
-                                        {(provided) => (
-                                            <div
-                                                ref={provided.innerRef}
-                                                {...provided.droppableProps}
-                                                className="border-b-[.0938rem] border-sub-2.5 last:border-none"
-                                            >
-                                                {divisionNurses.map((nurse, index) => (
-                                                    <Draggable draggableId={nurse.nurseId.toString()} index={index} key={nurse.nurseId}>
-                                                        {(provided) => (
-                                                            <div
-                                                                id="nurse_sample"
-                                                                className={`group relative flex h-14 w-full cursor-pointer items-center justify-center select-none ${
-                                                                    selectedNurse?.nurseId === nurse.nurseId
-                                                                        ? 'bg-main-4 text-main-1 underline underline-offset-2'
-                                                                        : 'bg-white text-sub-1'
-                                                                } ${
-                                                                    shiftTeam.nurses.findIndex((x) => x.nurseId === nurse.nurseId) ===
-                                                                    shiftTeam.nurses.length - 1
-                                                                        ? 'rounded-b-[.9375rem]'
-                                                                        : 'border-b-[.0313rem] border-b-sub-4.5'
-                                                                }`}
-                                                                ref={provided.innerRef}
-                                                                onClick={() => {
-                                                                    selectNurse(nurse.nurseId);
-                                                                    sendEvent(events.memberPage.focusNurse);
-                                                                }}
-                                                                {...provided.draggableProps}
-                                                                {...provided.dragHandleProps}
-                                                            >
-                                                                <DragIcon className="invisible absolute left-[.75rem] h-6 w-6 group-hover:visible" />
-                                                                <div className="peer relative font-apple text-[1.25rem] font-semibold text-sub-1">
-                                                                    {nurse.name}
-                                                                    {!nurse.isConnected && (
-                                                                        <div className="absolute top-0 right-[-.3125rem] h-[.3125rem] w-[.3125rem] rounded-full bg-red"></div>
-                                                                    )}
-                                                                </div>
-                                                                <div className="invisible absolute top-0 z-30 flex translate-y-[-60%] items-center gap-[.5rem] rounded-[.3125rem] bg-white px-2 py-1 font-apple text-[.875rem] whitespace-nowrap text-sub-2 shadow-shadow-2 peer-hover:visible">
-                                                                    <div
-                                                                        className="absolute -bottom-1.5 left-[50%] h-0 w-0 translate-x-[-50%]"
-                                                                        style={{
-                                                                            borderTop: '.625rem solid white',
-                                                                            borderLeft: '.4375rem solid transparent',
-                                                                            borderRight: '.4375rem solid transparent',
-                                                                            borderBottom: '.625rem solid none',
-                                                                        }}
-                                                                    />
-                                                                    연동 되지 않은 가상의 간호사입니다.
-                                                                    <UnlinkedIcon className="h-5 w-5" />
-                                                                </div>
-                                                                {index !== divisionNurses.length - 1 ? (
-                                                                    <div
-                                                                        className="absolute bottom-0 z-10 w-full"
-                                                                        onClick={(e) => {
-                                                                            e.stopPropagation();
-                                                                            editDivision(
-                                                                                shiftTeam.shiftTeamId,
-                                                                                nurse.priority,
-                                                                                1,
-                                                                                DateUtil.getDateString(new Date(), 'yyyy-MM'),
-                                                                            );
-                                                                            sendEvent(events.memberPage.createDivision);
-                                                                        }}
-                                                                    >
-                                                                        <div className="peer absolute bottom-0 z-30 h-[.8rem] w-full translate-y-[50%]" />
-                                                                        <div className="invisible absolute bottom-0 h-[.0938rem] w-full bg-sub-2.5 peer-hover:visible" />
-                                                                        <PlusIcon2 className="invisible absolute bottom-0 left-0 h-5 w-5 -translate-x-full translate-y-[50%] peer-hover:visible" />
-                                                                        <p className="invisible absolute bottom-0 left-0 translate-x-[calc(.625rem-100%)] translate-y-[-50%] font-apple text-[.75rem] text-sub-2.5 peer-hover:visible">
-                                                                            구분선
-                                                                        </p>
-                                                                    </div>
-                                                                ) : (
-                                                                    divisionIndex !==
-                                                                        Object.entries(groupBy(shiftTeam.nurses, 'divisionNum')).length -
-                                                                            1 && (
-                                                                        <div
-                                                                            className="absolute bottom-0 z-10 w-full"
-                                                                            onClick={(e) => {
-                                                                                e.stopPropagation();
-                                                                                editDivision(
-                                                                                    shiftTeam.shiftTeamId,
-                                                                                    nurse.priority,
-                                                                                    -1,
-                                                                                    DateUtil.getDateString(new Date(), 'yyyy-MM'),
-                                                                                );
-                                                                                sendEvent(events.memberPage.deleteDivision);
-                                                                            }}
-                                                                        >
-                                                                            <div className="peer absolute bottom-0 z-30 h-[.8rem] w-full translate-y-[50%]" />
-                                                                            <div className="invisible absolute bottom-0 h-[.0938rem] w-full translate-y-full bg-red peer-hover:visible" />
-                                                                            <MinusIcon className="invisible absolute bottom-0 left-0 h-5 w-5 -translate-x-full translate-y-[50%] peer-hover:visible" />
-                                                                        </div>
-                                                                    )
-                                                                )}
-                                                            </div>
-                                                        )}
-                                                    </Draggable>
-                                                ))}
-                                                {provided.placeholder}
-                                            </div>
-                                        )}
-                                    </Droppable>
-                                ))}
-                        </div>
+                            shiftTeam={shiftTeam}
+                            selectedNurseId={selectedNurse?.nurseId}
+                            openMenuShiftTeamId={openMenuShiftTeamId}
+                            editShiftTeam={editShiftTeam}
+                            clickAwayMenuRef={clickAwayMenuRef}
+                            clickAwayShiftTeamNameRef={clickAwayShiftTeamNameRef}
+                            selectNurse={selectNurse}
+                            addNurse={addNurse}
+                            editDivision={editDivision}
+                            deleteShiftTeam={deleteShiftTeam}
+                            onOpenMenu={setOpenMenuShiftTeamId}
+                            onCloseMenu={() => setOpenMenuShiftTeamId(null)}
+                            onStartEditingShiftTeam={startEditingShiftTeam}
+                            onChangeEditShiftTeamName={changeEditShiftTeamName}
+                            onSubmitEditShiftTeam={handleUpdateShiftTeam}
+                            onMoveToMakePage={() => navigate(ROUTE.MAKE)}
+                        />
                     ))}
                 </div>
             </DragDropContext>

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -104,6 +104,28 @@ export const en: TLocale = {
         refresh: {
             loading: 'Logging in...',
         },
+        member: {
+            shiftTeamList: {
+                title: 'Team',
+                subtitle: 'You can create one duty schedule per team.',
+                addTeam: 'Add team',
+                card: {
+                    addNurse: 'Create nurse',
+                    addNurseTooltip:
+                        'You can manage a virtual nurse without sending an invite first. You can invite and connect them at any time.',
+                    viewShift: 'View duty schedule',
+                    deleteTeam: 'Delete team',
+                    empty: 'There are no nurses yet!',
+                    virtualNurseTooltip: 'This is a virtual nurse that is not connected.',
+                    divider: 'Divider',
+                    editTeamNameAria: 'Edit team name for {{teamName}}',
+                    openMenuAria: 'Open menu for {{teamName}}',
+                    selectNurseAria: 'Select nurse {{nurseName}}',
+                    addDividerAria: 'Add divider below {{nurseName}}',
+                    removeDividerAria: 'Remove divider below {{nurseName}}',
+                },
+            },
+        },
     },
     feature: {
         auth: {

--- a/src/shared/locales/ko.ts
+++ b/src/shared/locales/ko.ts
@@ -102,6 +102,27 @@ export const ko = {
         refresh: {
             loading: '로그인중입니다.',
         },
+        member: {
+            shiftTeamList: {
+                title: '팀',
+                subtitle: '팀당 근무표 1개 생성 가능합니다.',
+                addTeam: '팀 추가하기',
+                card: {
+                    addNurse: '간호사 만들기',
+                    addNurseTooltip: '초대하지 않아도, 가상의 간호사를 만들어 관리할 수 있어요! (언제든지 초대해서 연동 가능합니다.)',
+                    viewShift: '근무표 보러가기',
+                    deleteTeam: '팀 삭제하기',
+                    empty: '아직 간호사가 없습니다!',
+                    virtualNurseTooltip: '연동 되지 않은 가상의 간호사입니다.',
+                    divider: '구분선',
+                    editTeamNameAria: '{{teamName}} 팀 이름 수정',
+                    openMenuAria: '{{teamName}} 팀 메뉴 열기',
+                    selectNurseAria: '{{nurseName}} 간호사 선택',
+                    addDividerAria: '{{nurseName}} 아래에 구분선 추가',
+                    removeDividerAria: '{{nurseName}} 아래 구분선 제거',
+                },
+            },
+        },
     },
     feature: {
         auth: {


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-854](https://gom3.atlassian.net/browse/DUT-854)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `ShiftTeamList`의 키보드 이동, 드래그 이동, 팀명 수정 상태를 `useShiftTeamListController`로 분리했습니다.
- 팀 카드 렌더링을 `ShiftTeamCard`로 분리하고, 팀/간호사 목록 view 책임을 `ShiftTeamList`에서 걷어냈습니다.
- division grouping, 선택 이동, 드래그 우선순위 계산을 `shiftTeamList` helper로 분리해 이후 기능 추가 시 계산 로직 재사용이 가능하게 했습니다.

<br>

## To Reviewers

- 기존 MemberPage 동작은 유지한 채 `ShiftTeamList`만 1차 분해했습니다.
- 검증은 `pnpm exec eslint src/pages/MemberPage/ui/ShiftTeamList.tsx src/pages/MemberPage/ui/ShiftTeamCard.tsx src/pages/MemberPage/model/useShiftTeamListController.ts src/pages/MemberPage/model/shiftTeamList.ts` 와 `pnpm exec tsc --noEmit` 기준으로 확인했습니다.


[DUT-854]: https://gom3.atlassian.net/browse/DUT-854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 간호사 드래그 앤 드롭을 통한 재배치 기능 추가
  * 화살표 키를 이용한 간호사 선택 네비게이션 추가
  * 교대팀 이름 인라인 편집 기능 추가
  * 교대팀별 메뉴에서 간호사 추가, 삭제 및 페이지 이동 옵션 추가
  * 간호사 그룹 내 부서 경계 관리 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->