### PR TITLE
[DUT-855]: 신청근무 RequestCalendar 책임 분리

### DIFF
--- a/src/pages/RequestShiftPage/ui/RequestCalendar.tsx
+++ b/src/pages/RequestShiftPage/ui/RequestCalendar.tsx
@@ -1,15 +1,22 @@
-import {DragDropContext, type DropResult, Droppable, Draggable} from '@hello-pangea/dnd';
-import {type RefObject, useEffect, useRef} from 'react';
+import {type DropResult, useRef} from 'react';
 import useOnclickOutside from 'react-cool-onclickoutside';
-import {twMerge} from 'tailwind-merge';
 import {events, sendEvent} from '@/analytics';
-import ShiftBadge from '@/entities/shift/ui/shift-badge';
 import {useUIConfigStore} from '@/entities/ui/useUIConfig/store';
 import useRequestShift from '@/features/shift/useRequestShift';
 import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
-import {DragIcon, FoldDutyIcon, LinkedIcon, MinusIcon, PlusIcon2, UnlinkedIcon} from '@/shared/assets/svg';
 import Card from '@/shared/ui/Card';
-import PageState from '@/shared/ui/PageState';
+import RequestCalendarGrid from './request-calendar/RequestCalendarGrid';
+import RequestCalendarHeader from './request-calendar/RequestCalendarHeader';
+import RequestDutyRequestPanel from './request-calendar/RequestDutyRequestPanel';
+import {useRequestCalendarFocusScroll} from './request-calendar/useRequestCalendarFocusScroll';
+import {
+    createConnectedNurseIdSet,
+    createDutyRequestLookup,
+    createShiftNurseIdByNurseId,
+    getMoveNurseOrderPayload,
+    getUnresolvedRequestCount,
+    getYearMonthLabel,
+} from './request-calendar/utils';
 
 export default function ShiftCalendar() {
     const {
@@ -32,7 +39,7 @@ export default function ShiftCalendar() {
         actions: {selectNurse, moveNurseOrder, editDivision},
     } = useEditShiftTeam();
     const separateWeekendColor = useUIConfigStore((state) => state.separateWeekendColor);
-    const focusedCellRef = useRef<HTMLElement>(null);
+    const focusedCellRef = useRef<HTMLParagraphElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const clickAwayRef = useOnclickOutside(() => {
         changeFocus(null);
@@ -43,467 +50,81 @@ export default function ShiftCalendar() {
 
         if (source.droppableId === destination.droppableId && destination.index === source.index) return;
 
-        const sourceDivision = parseInt(source.droppableId);
-        const destinationDivision = parseInt(destination.droppableId);
-        const dragedNurse = requestShift.divisionShiftNurses[sourceDivision].find(
-            (x) => x.shiftNurse.shiftNurseId === parseInt(draggableId),
-        )!.shiftNurse;
-        const destinationNurses = requestShift.divisionShiftNurses[destinationDivision];
+        const movePayload = getMoveNurseOrderPayload({
+            source,
+            destination,
+            draggableId,
+            requestShift,
+        });
 
-        if (
-            destination.droppableId === source.droppableId &&
-            destinationNurses.findIndex((x) => x.shiftNurse.shiftNurseId === dragedNurse.shiftNurseId) < destination.index
-        ) {
-            moveNurseOrder(
-                dragedNurse.nurseId,
-                currentShiftTeam.shiftTeamId,
-                currentShiftTeam.shiftTeamId,
-                destinationNurses[0].shiftNurse.divisionNum,
-                destination.index === 0 ? 0 : destinationNurses[destination.index].shiftNurse.priority,
-                destination.index === destinationNurses.length - 1
-                    ? destinationNurses[destination.index].shiftNurse.priority + 2024
-                    : destinationNurses[destination.index + 1].shiftNurse.priority,
-                year.toString() + '-' + month.toString().padStart(2, '0'),
-            );
-        } else {
-            moveNurseOrder(
-                dragedNurse.nurseId,
-                currentShiftTeam.shiftTeamId,
-                currentShiftTeam.shiftTeamId,
-                destinationNurses[0].shiftNurse.divisionNum,
-                destination.index === 0 ? 0 : destinationNurses[destination.index - 1].shiftNurse.priority,
-                destination.index === destinationNurses.length
-                    ? destinationNurses[destination.index - 1].shiftNurse.priority + 2024
-                    : destinationNurses[destination.index].shiftNurse.priority,
-                year.toString() + '-' + month.toString().padStart(2, '0'),
-            );
-        }
+        if (!movePayload) return;
+
+        moveNurseOrder(
+            movePayload.nurseId,
+            currentShiftTeam.shiftTeamId,
+            currentShiftTeam.shiftTeamId,
+            movePayload.destinationDivisionNum,
+            movePayload.prevPriority,
+            movePayload.nextPriority,
+            getYearMonthLabel(year, month),
+        );
 
         sendEvent(events.requestPage.calendar.moveNurse);
     };
 
-    useEffect(() => {
-        if (focus) {
-            const focusRect = focusedCellRef.current?.getBoundingClientRect();
-            const container = containerRef.current;
+    useRequestCalendarFocusScroll({focus, focusedCellRef, containerRef});
 
-            if (!focusRect || !container) return;
+    if (!requestShift || !foldedLevels || !wardShiftTypeMap || !currentShiftTeam) return null;
 
-            // 셀이 화면 오른쪽에 있을 때 오른쪽으로 충분히 화면을 이동한다.
-            if (focusRect.x + focusRect.width - container.offsetLeft > container.clientWidth)
-                container.scroll({
-                    left: focusRect.left + container.scrollLeft,
-                });
+    const unresolvedRequestCount = getUnresolvedRequestCount(dutyRequestStatus, dutyRequestList);
+    const yearMonthLabel = getYearMonthLabel(year, month);
+    const dutyRequestLookup = createDutyRequestLookup(dutyRequestList);
+    const connectedNurseIds = createConnectedNurseIdSet(currentShiftTeam);
+    const shiftNurseIdByNurseId = createShiftNurseIdByNurseId(requestShift);
 
-            // 셀이 화면 왼쪽에 있을 때 왼쪽 끝으로 화면을 이동한다.
-            if (focusRect.x - container.offsetLeft < 0) container.scroll({left: 0});
-
-            // 셀이 화면 아래에 있을 때 아래로 충분히 화면을 이동한다.
-            if (focusRect.y + focusRect.height - container.offsetTop > container.clientHeight)
-                container.scroll({
-                    top: focusRect.top + container.scrollTop,
-                });
-
-            // 셀이 화면 위에 있을 때 한칸씩 위로 화면을 이동한다.
-            if (focusRect.y - container.offsetTop < 0) container.scroll({top: focusRect.top + window.scrollY - 132});
-        }
-    }, [focus]);
-
-    const unresolvedRequestCount =
-        dutyRequestStatus === 'success' ? (dutyRequestList?.filter((x) => x.isAccepted === null).length ?? 0) : 0;
-
-    return requestShift && foldedLevels && wardShiftTypeMap && currentShiftTeam ? (
+    return (
         <div id="calendar" className="flex min-h-0 flex-1 flex-col gap-6 xl:flex-row">
             <Card variant="elevated" padding="none" className="min-w-0 flex-1 overflow-hidden border-gray-6">
                 <div ref={clickAwayRef} className="flex h-full min-h-0 flex-col px-4 pb-4">
-                    <div className="z-20 my-[.75rem] flex h-7.5 min-w-max items-center gap-5 bg-white pr-4">
-                        <div className="flex gap-5">
-                            <div className="w-13.5 text-center font-apple text-[1rem] font-medium text-sub-3">{/* 구분 */}</div>
-                            <div className="w-17.5 text-center font-apple text-[1rem] font-medium text-sub-3">이름</div>
-                            <div className="w-7.5 text-center font-apple text-[1rem] font-medium text-sub-3">연동</div>
-                            <div className="flex rounded-[2.5rem] border-[.0625rem] border-sub-4 px-4 py-[.1875rem]">
-                                {requestShift.days.map((item, j) => (
-                                    <p
-                                        key={j}
-                                        className={`w-9 flex-1 rounded-full text-center font-poppins text-[1rem] ${
-                                            item.dayType === 'saturday'
-                                                ? j === focus?.day
-                                                    ? separateWeekendColor
-                                                        ? 'bg-blue text-white'
-                                                        : 'bg-red text-white'
-                                                    : separateWeekendColor
-                                                      ? 'text-blue'
-                                                      : 'text-red'
-                                                : item.dayType === 'sunday' || item.dayType === 'holiday'
-                                                  ? j === focus?.day
-                                                      ? 'bg-red text-white'
-                                                      : 'text-red'
-                                                  : item.dayType === 'workday'
-                                                    ? j === focus?.day
-                                                        ? 'bg-main-1 text-white'
-                                                        : 'text-sub-2.5'
-                                                    : ''
-                                        } `}
-                                    >
-                                        {item.day}
-                                    </p>
-                                ))}
-                            </div>
-                        </div>
-                    </div>
-                    <DragDropContext onDragEnd={(d) => !readonly && onDragEnd(d)}>
-                        <div
-                            className="-mt-5 scrollbar-hide flex min-h-0 flex-col gap-[.3125rem] overflow-x-auto overflow-y-scroll pt-5 pr-4 pb-8"
-                            ref={containerRef}
-                        >
-                            {requestShift.divisionShiftNurses
-                                .map((x) => x.filter((y) => y.shiftNurse.isWorker)) // 근무자만 필터링
-                                .map((rows, level) => {
-                                    return rows.length ? (
-                                        requestShift && foldedLevels[level] ? (
-                                            <div
-                                                key={level}
-                                                className="ml-5 flex h-7.5 w-[calc(100%-1.25rem)] cursor-pointer items-center gap-[.125rem] rounded-[.625rem] bg-sub-4.5 px-[.625rem]"
-                                                onClick={() => {
-                                                    sendEvent(events.requestPage.calendar.foldDivision);
-                                                    foldLevel(level);
-                                                }}
-                                            >
-                                                <FoldDutyIcon className="h-5.5 w-5.5 rotate-180" />
-                                            </div>
-                                        ) : (
-                                            <Droppable droppableId={level.toString()} key={level.toString()}>
-                                                {(provided) => (
-                                                    <div
-                                                        ref={provided.innerRef}
-                                                        key={level}
-                                                        className="flex gap-5"
-                                                        {...provided.droppableProps}
-                                                    >
-                                                        <div className="relative ml-5 rounded-[1.25rem] shadow-banner">
-                                                            {!readonly && (
-                                                                <div className="absolute left-[-.9375rem] flex h-full w-7.5 items-center justify-center font-poppins font-light text-sub-2.5">
-                                                                    <FoldDutyIcon
-                                                                        className="absolute top-[50%] left-[50%] z-10 h-5.5 w-5.5 translate-x-[-50%] translate-y-[-50%] cursor-pointer"
-                                                                        onClick={() => {
-                                                                            sendEvent(events.requestPage.calendar.spreadDivision);
-                                                                            foldLevel(level);
-                                                                        }}
-                                                                    />
-                                                                </div>
-                                                            )}
-                                                            {rows.map((row, rowIndex) => (
-                                                                <Draggable
-                                                                    draggableId={row.shiftNurse.shiftNurseId.toString()}
-                                                                    index={rowIndex}
-                                                                    key={row.shiftNurse.shiftNurseId}
-                                                                    isDragDisabled={readonly}
-                                                                >
-                                                                    {(provided) => (
-                                                                        <div
-                                                                            className={`relative flex h-10 items-center gap-5 ${
-                                                                                rowIndex === 0
-                                                                                    ? rowIndex === rows.length - 1
-                                                                                        ? 'rounded-[1.25rem]'
-                                                                                        : 'rounded-t-[1.25rem]'
-                                                                                    : rowIndex === rows.length - 1
-                                                                                      ? 'rounded-b-[1.25rem]'
-                                                                                      : ''
-                                                                            } ${
-                                                                                focus?.shiftNurseId === row.shiftNurse.shiftNurseId
-                                                                                    ? 'bg-main-4'
-                                                                                    : 'bg-white'
-                                                                            }`}
-                                                                            ref={provided.innerRef}
-                                                                            {...provided.draggableProps}
-                                                                            {...provided.dragHandleProps}
-                                                                        >
-                                                                            <div className="relative w-8.5 shrink-0">
-                                                                                {!readonly && (
-                                                                                    <DragIcon className="absolute top-[50%] -right-2.5 h-6 w-6 translate-y-[-50%]" />
-                                                                                )}
-                                                                            </div>
-                                                                            <div className="w-17.5 shrink-0 truncate text-center font-apple text-[1.25rem] text-sub-1">
-                                                                                {row.shiftNurse.name}
-                                                                            </div>
-                                                                            <div className="flex w-7.5 shrink-0 items-center justify-center text-center font-apple text-[1.25rem] text-sub-1">
-                                                                                {currentShiftTeam.nurses.find(
-                                                                                    (x) => x.nurseId === row.shiftNurse.nurseId,
-                                                                                )?.isConnected ? (
-                                                                                    <LinkedIcon className="h-6 w-6" />
-                                                                                ) : (
-                                                                                    <UnlinkedIcon className="h-6 w-6" />
-                                                                                )}
-                                                                            </div>
-                                                                            <div className="flex h-full px-4.25">
-                                                                                {row.wardReqShiftList.map((current, date) => {
-                                                                                    const requestDutyRequest =
-                                                                                        dutyRequestList?.find(
-                                                                                            (x) =>
-                                                                                                x.nurseId === row.shiftNurse.nurseId &&
-                                                                                                x.date - 1 === date,
-                                                                                        ) ?? null;
-                                                                                    const isSaturday =
-                                                                                        requestShift.days[date].dayType === 'saturday';
-                                                                                    const isSunday =
-                                                                                        requestShift.days[date].dayType === 'sunday' ||
-                                                                                        requestShift.days[date].dayType === 'holiday';
-                                                                                    const isFocused =
-                                                                                        focus?.shiftNurseId ===
-                                                                                            row.shiftNurse.shiftNurseId &&
-                                                                                        focus.day === date;
-
-                                                                                    return (
-                                                                                        <div
-                                                                                            key={date}
-                                                                                            className={`group relative flex h-full w-9 flex-1 items-center justify-center px-[.25rem] ${
-                                                                                                isSunday
-                                                                                                    ? 'bg-[#FFE1E680]'
-                                                                                                    : isSaturday
-                                                                                                      ? separateWeekendColor
-                                                                                                          ? 'bg-[#E1E5FF80]'
-                                                                                                          : 'bg-[#FFE1E680]'
-                                                                                                      : ''
-                                                                                            } ${date === focus?.day && 'bg-main-4'}`}
-                                                                                        >
-                                                                                            <ShiftBadge
-                                                                                                id={
-                                                                                                    rowIndex === 0 && date === 0
-                                                                                                        ? 'cell_sample'
-                                                                                                        : undefined
-                                                                                                }
-                                                                                                onClick={() => {
-                                                                                                    if (readonly) return;
-
-                                                                                                    changeFocus?.({
-                                                                                                        shiftNurseName: row.shiftNurse.name,
-                                                                                                        shiftNurseId:
-                                                                                                            row.shiftNurse.shiftNurseId,
-                                                                                                        day: date,
-                                                                                                    });
-                                                                                                    sendEvent(
-                                                                                                        events.requestPage.calendar
-                                                                                                            .focusCell,
-                                                                                                    );
-                                                                                                }}
-                                                                                                shiftType={
-                                                                                                    current === null
-                                                                                                        ? requestDutyRequest === null
-                                                                                                            ? null
-                                                                                                            : wardShiftTypeMap.get(
-                                                                                                                  requestDutyRequest.wardShiftTypeId,
-                                                                                                              )
-                                                                                                        : wardShiftTypeMap.get(current)
-                                                                                                }
-                                                                                                isOnlyRequest={
-                                                                                                    current === null &&
-                                                                                                    requestDutyRequest !== null
-                                                                                                }
-                                                                                                className={`z-10 ${
-                                                                                                    readonly
-                                                                                                        ? 'cursor-default'
-                                                                                                        : 'cursor-pointer'
-                                                                                                } ${
-                                                                                                    isFocused &&
-                                                                                                    'outline-[.125rem] outline-main-1'
-                                                                                                }`}
-                                                                                                forwardRef={
-                                                                                                    isFocused
-                                                                                                        ? (focusedCellRef as unknown as RefObject<HTMLParagraphElement>)
-                                                                                                        : null
-                                                                                                }
-                                                                                            />
-                                                                                        </div>
-                                                                                    );
-                                                                                })}
-                                                                            </div>
-                                                                            {rowIndex !== rows.length - 1
-                                                                                ? !readonly && (
-                                                                                      <>
-                                                                                          <div
-                                                                                              className="justify-cente group peer absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-80%] translate-y-[50%] items-center"
-                                                                                              onClick={(e) => {
-                                                                                                  e.stopPropagation();
-                                                                                                  editDivision(
-                                                                                                      currentShiftTeam.shiftTeamId,
-                                                                                                      row.shiftNurse.priority,
-                                                                                                      1,
-                                                                                                      year.toString() +
-                                                                                                          '-' +
-                                                                                                          month.toString().padStart(2, '0'),
-                                                                                                  );
-                                                                                                  sendEvent(
-                                                                                                      events.makePage.calendar
-                                                                                                          .createDivision,
-                                                                                                  );
-                                                                                              }}
-                                                                                          >
-                                                                                              <PlusIcon2 className="invisible h-5 w-5 group-hover:visible" />
-                                                                                          </div>
-                                                                                          <div className="invisible absolute bottom-0 h-[.0938rem] w-full bg-sub-2.5 peer-hover:visible" />
-                                                                                      </>
-                                                                                  )
-                                                                                : level !== requestShift.divisionShiftNurses.length - 1 &&
-                                                                                  !readonly && (
-                                                                                      <div
-                                                                                          className="absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-65%] translate-y-[calc(50%+.1563rem)] items-center"
-                                                                                          onClick={(e) => {
-                                                                                              e.stopPropagation();
-                                                                                              editDivision(
-                                                                                                  currentShiftTeam.shiftTeamId,
-                                                                                                  row.shiftNurse.priority,
-                                                                                                  -1,
-                                                                                                  year.toString() +
-                                                                                                      '-' +
-                                                                                                      month.toString().padStart(2, '0'),
-                                                                                              );
-                                                                                              sendEvent(
-                                                                                                  events.makePage.calendar.deleteDivision,
-                                                                                              );
-                                                                                          }}
-                                                                                      >
-                                                                                          <MinusIcon className="h-5 w-5 opacity-0 hover:opacity-100" />
-                                                                                      </div>
-                                                                                  )}
-                                                                        </div>
-                                                                    )}
-                                                                </Draggable>
-                                                            ))}
-                                                            {provided.placeholder}
-                                                        </div>
-                                                    </div>
-                                                )}
-                                            </Droppable>
-                                        )
-                                    ) : null;
-                                })}
-                        </div>
-                    </DragDropContext>
+                    <RequestCalendarHeader days={requestShift.days} focusDay={focus?.day} separateWeekendColor={separateWeekendColor} />
+                    <RequestCalendarGrid
+                        requestShift={requestShift}
+                        foldedLevels={foldedLevels}
+                        focus={focus}
+                        readonly={readonly}
+                        separateWeekendColor={separateWeekendColor}
+                        wardShiftTypeMap={wardShiftTypeMap}
+                        currentShiftTeam={currentShiftTeam}
+                        dutyRequestLookup={dutyRequestLookup}
+                        connectedNurseIds={connectedNurseIds}
+                        focusedCellRef={focusedCellRef}
+                        containerRef={containerRef}
+                        onDragEnd={onDragEnd}
+                        changeFocus={changeFocus}
+                        foldLevel={foldLevel}
+                        editDivision={editDivision}
+                        onFoldAnalytics={(expanded) =>
+                            sendEvent(expanded ? events.requestPage.calendar.foldDivision : events.requestPage.calendar.spreadDivision)
+                        }
+                        onFocusAnalytics={() => sendEvent(events.requestPage.calendar.focusCell)}
+                        onCreateDivisionAnalytics={() => sendEvent(events.makePage.calendar.createDivision)}
+                        onDeleteDivisionAnalytics={() => sendEvent(events.makePage.calendar.deleteDivision)}
+                        yearMonthLabel={yearMonthLabel}
+                    />
                 </div>
             </Card>
-
-            <Card
-                id="nurse_request_list"
-                variant="elevated"
-                padding="none"
-                className="flex w-full shrink-0 flex-col overflow-hidden border-gray-6 xl:w-[360px]"
-            >
-                <div className="border-b border-sub-4.5 px-6 py-5">
-                    <div className="flex items-center justify-between gap-3">
-                        <div>
-                            <p className="font-apple text-[1.25rem] font-semibold text-main-1">신청 내역</p>
-                            <p className="mt-1 font-apple text-sm font-medium text-gray-4">미처리 신청 {unresolvedRequestCount}건</p>
-                        </div>
-                    </div>
-                </div>
-
-                <div className="scrollbar-hide max-h-[calc(100vh-18rem)] overflow-y-auto px-5 py-4">
-                    {dutyRequestStatus === 'pending' ? (
-                        <PageState
-                            tone="loading"
-                            title="신청 내역을 불러오는 중이에요"
-                            description="제출된 신청 근무를 확인하고 있어요."
-                            className="px-0 py-0"
-                        />
-                    ) : dutyRequestStatus === 'error' ? (
-                        <PageState
-                            tone="error"
-                            title="신청 내역을 불러오지 못했어요"
-                            description="잠시 후 다시 시도해 주세요."
-                            action={{label: '다시 시도', onClick: () => void retry()}}
-                            className="px-0 py-0"
-                        />
-                    ) : dutyRequestList && dutyRequestList.length > 0 ? (
-                        <div className="space-y-3">
-                            {dutyRequestList.map((dutyRequest) => {
-                                const matchedShiftNurseId =
-                                    requestShift.divisionShiftNurses
-                                        .flatMap((x) => x)
-                                        .find((x) => x.shiftNurse.nurseId === dutyRequest.nurseId)?.shiftNurse.shiftNurseId ?? null;
-                                const requestFocus =
-                                    matchedShiftNurseId !== null
-                                        ? {
-                                              shiftNurseName: dutyRequest.nurseName,
-                                              shiftNurseId: matchedShiftNurseId,
-                                              day: dutyRequest.date - 1,
-                                          }
-                                        : null;
-
-                                return (
-                                    <div key={dutyRequest.wardReqShiftId} className="rounded-[16px] border border-gray-6 px-4 py-3">
-                                        <div className="flex items-start gap-3">
-                                            <div className="min-w-0 flex-1">
-                                                <button
-                                                    type="button"
-                                                    className={twMerge(
-                                                        'truncate text-left font-apple text-base font-semibold text-sub-1',
-                                                        (!requestFocus || readonly) && 'cursor-default',
-                                                        requestFocus && !readonly && 'cursor-pointer hover:text-main-1',
-                                                    )}
-                                                    onClick={() => {
-                                                        if (readonly || !requestFocus) return;
-
-                                                        changeFocus(requestFocus);
-                                                    }}
-                                                >
-                                                    {dutyRequest.nurseName} / {dutyRequest.date}일
-                                                </button>
-                                                <div className="mt-2 flex items-center gap-2">
-                                                    <ShiftBadge shiftType={wardShiftTypeMap.get(dutyRequest.wardShiftTypeId)} />
-                                                    <p className="font-apple text-sm font-medium text-gray-4">
-                                                        {dutyRequest.isAccepted === true
-                                                            ? '수락됨'
-                                                            : dutyRequest.isAccepted === false
-                                                              ? '거절됨'
-                                                              : '확인 필요'}
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                        <div className="mt-4 flex rounded-[12px] bg-gray-7 p-1">
-                                            <button
-                                                type="button"
-                                                className={twMerge(
-                                                    'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
-                                                    dutyRequest.isAccepted === true && 'bg-main-1 text-white',
-                                                )}
-                                                onClick={() => {
-                                                    acceptRequest(dutyRequest.wardReqShiftId, true);
-                                                    sendEvent(events.requestPage.acceptRequest, 'true');
-                                                }}
-                                            >
-                                                수락
-                                            </button>
-                                            <button
-                                                type="button"
-                                                className={twMerge(
-                                                    'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
-                                                    dutyRequest.isAccepted === false && 'bg-sub-2 text-white',
-                                                )}
-                                                onClick={() => {
-                                                    acceptRequest(dutyRequest.wardReqShiftId, false);
-                                                    sendEvent(events.requestPage.acceptRequest, 'false');
-                                                }}
-                                            >
-                                                거절
-                                            </button>
-                                        </div>
-                                    </div>
-                                );
-                            })}
-                        </div>
-                    ) : (
-                        <div className="flex min-h-[220px] items-center justify-center rounded-[16px] bg-gray-7 px-6 text-center">
-                            <p className="font-apple text-sm leading-6 font-medium text-gray-4">
-                                아직 제출된 신청 근무가 없어요.
-                                <br />
-                                신청이 들어오면 이 패널에서 바로 확인할 수 있어요.
-                            </p>
-                        </div>
-                    )}
-                </div>
-            </Card>
+            <RequestDutyRequestPanel
+                dutyRequestList={dutyRequestList}
+                dutyRequestStatus={dutyRequestStatus}
+                wardShiftTypeMap={wardShiftTypeMap}
+                unresolvedRequestCount={unresolvedRequestCount}
+                readonly={readonly}
+                shiftNurseIdByNurseId={shiftNurseIdByNurseId}
+                changeFocus={changeFocus}
+                acceptRequest={acceptRequest}
+                retry={retry}
+                onAcceptAnalytics={(accepted) => sendEvent(events.requestPage.acceptRequest, String(accepted))}
+            />
         </div>
-    ) : null;
+    );
 }

--- a/src/pages/RequestShiftPage/ui/request-calendar/RequestCalendarGrid.tsx
+++ b/src/pages/RequestShiftPage/ui/request-calendar/RequestCalendarGrid.tsx
@@ -1,0 +1,250 @@
+import {type DropResult, DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
+import {type RefObject} from 'react';
+import {type TDutyRequest, type TRequestShift} from '@/entities/shift';
+import ShiftBadge from '@/entities/shift/ui/shift-badge';
+import {type TShiftTeam, type TWardShiftType} from '@/entities/ward';
+import {type TFocus} from '@/features/shift/useRequestShift/type';
+import {DragIcon, FoldDutyIcon, LinkedIcon, MinusIcon, PlusIcon2, UnlinkedIcon} from '@/shared/assets/svg';
+import {getDayCellClass, getDutyRequestLookupKey} from './utils';
+
+interface IRequestCalendarGridProps {
+    requestShift: TRequestShift;
+    foldedLevels: boolean[];
+    focus: TFocus | null;
+    readonly: boolean;
+    separateWeekendColor: boolean;
+    wardShiftTypeMap: Map<number, TWardShiftType>;
+    currentShiftTeam: TShiftTeam;
+    dutyRequestLookup: Map<string, TDutyRequest>;
+    connectedNurseIds: Set<number>;
+    focusedCellRef: RefObject<HTMLParagraphElement | null>;
+    containerRef: RefObject<HTMLDivElement | null>;
+    onDragEnd: (result: DropResult) => void;
+    changeFocus: (focus: TFocus | null) => void;
+    foldLevel: (level: number) => void;
+    editDivision: (shiftTeamId: number, priority: number, updateNum: number, workDate: string) => void;
+    onFoldAnalytics: (expanded: boolean) => void;
+    onFocusAnalytics: () => void;
+    onCreateDivisionAnalytics: () => void;
+    onDeleteDivisionAnalytics: () => void;
+    yearMonthLabel: string;
+}
+
+export default function RequestCalendarGrid({
+    requestShift,
+    foldedLevels,
+    focus,
+    readonly,
+    separateWeekendColor,
+    wardShiftTypeMap,
+    currentShiftTeam,
+    dutyRequestLookup,
+    connectedNurseIds,
+    focusedCellRef,
+    containerRef,
+    onDragEnd,
+    changeFocus,
+    foldLevel,
+    editDivision,
+    onFoldAnalytics,
+    onFocusAnalytics,
+    onCreateDivisionAnalytics,
+    onDeleteDivisionAnalytics,
+    yearMonthLabel,
+}: IRequestCalendarGridProps) {
+    return (
+        <DragDropContext onDragEnd={(result) => !readonly && onDragEnd(result)}>
+            <div
+                className="-mt-5 scrollbar-hide flex min-h-0 flex-col gap-[.3125rem] overflow-x-auto overflow-y-scroll pt-5 pr-4 pb-8"
+                ref={containerRef}
+            >
+                {requestShift.divisionShiftNurses
+                    .map((division) => division.filter((row) => row.shiftNurse.isWorker))
+                    .map((rows, level) => {
+                        if (rows.length === 0) return null;
+
+                        if (foldedLevels[level]) {
+                            return (
+                                <div
+                                    key={level}
+                                    className="ml-5 flex h-7.5 w-[calc(100%-1.25rem)] cursor-pointer items-center gap-[.125rem] rounded-[.625rem] bg-sub-4.5 px-[.625rem]"
+                                    onClick={() => {
+                                        onFoldAnalytics(true);
+                                        foldLevel(level);
+                                    }}
+                                >
+                                    <FoldDutyIcon className="h-5.5 w-5.5 rotate-180" />
+                                </div>
+                            );
+                        }
+
+                        return (
+                            <Droppable droppableId={level.toString()} key={level}>
+                                {(provided) => (
+                                    <div ref={provided.innerRef} className="flex gap-5" {...provided.droppableProps}>
+                                        <div className="relative ml-5 rounded-[1.25rem] shadow-banner">
+                                            {!readonly && (
+                                                <div className="absolute left-[-.9375rem] flex h-full w-7.5 items-center justify-center font-poppins font-light text-sub-2.5">
+                                                    <FoldDutyIcon
+                                                        className="absolute top-[50%] left-[50%] z-10 h-5.5 w-5.5 translate-x-[-50%] translate-y-[-50%] cursor-pointer"
+                                                        onClick={() => {
+                                                            onFoldAnalytics(false);
+                                                            foldLevel(level);
+                                                        }}
+                                                    />
+                                                </div>
+                                            )}
+                                            {rows.map((row, rowIndex) => {
+                                                const isFocusedRow = focus?.shiftNurseId === row.shiftNurse.shiftNurseId;
+                                                const isLastRow = rowIndex === rows.length - 1;
+                                                const isSingleRow = rowIndex === 0 && isLastRow;
+
+                                                return (
+                                                    <Draggable
+                                                        draggableId={row.shiftNurse.shiftNurseId.toString()}
+                                                        index={rowIndex}
+                                                        key={row.shiftNurse.shiftNurseId}
+                                                        isDragDisabled={readonly}
+                                                    >
+                                                        {(draggableProvided) => (
+                                                            <div
+                                                                className={`relative flex h-10 items-center gap-5 ${
+                                                                    isSingleRow
+                                                                        ? 'rounded-[1.25rem]'
+                                                                        : rowIndex === 0
+                                                                          ? 'rounded-t-[1.25rem]'
+                                                                          : isLastRow
+                                                                            ? 'rounded-b-[1.25rem]'
+                                                                            : ''
+                                                                } ${isFocusedRow ? 'bg-main-4' : 'bg-white'}`}
+                                                                ref={draggableProvided.innerRef}
+                                                                {...draggableProvided.draggableProps}
+                                                                {...draggableProvided.dragHandleProps}
+                                                            >
+                                                                <div className="relative w-8.5 shrink-0">
+                                                                    {!readonly && (
+                                                                        <DragIcon className="absolute top-[50%] -right-2.5 h-6 w-6 translate-y-[-50%]" />
+                                                                    )}
+                                                                </div>
+                                                                <div className="w-17.5 shrink-0 truncate text-center font-apple text-[1.25rem] text-sub-1">
+                                                                    {row.shiftNurse.name}
+                                                                </div>
+                                                                <div className="flex w-7.5 shrink-0 items-center justify-center text-center font-apple text-[1.25rem] text-sub-1">
+                                                                    {connectedNurseIds.has(row.shiftNurse.nurseId) ? (
+                                                                        <LinkedIcon className="h-6 w-6" />
+                                                                    ) : (
+                                                                        <UnlinkedIcon className="h-6 w-6" />
+                                                                    )}
+                                                                </div>
+                                                                <div className="flex h-full px-4.25">
+                                                                    {row.wardReqShiftList.map((currentShiftTypeId, date) => {
+                                                                        const requestDutyRequest =
+                                                                            dutyRequestLookup.get(
+                                                                                getDutyRequestLookupKey(row.shiftNurse.nurseId, date),
+                                                                            ) ?? null;
+                                                                        const isFocusedCell = isFocusedRow && focus?.day === date;
+
+                                                                        return (
+                                                                            <div
+                                                                                key={date}
+                                                                                className={`group relative flex h-full w-9 flex-1 items-center justify-center px-[.25rem] ${getDayCellClass(
+                                                                                    requestShift.days[date].dayType,
+                                                                                    date === focus?.day,
+                                                                                    separateWeekendColor,
+                                                                                )}`}
+                                                                            >
+                                                                                <ShiftBadge
+                                                                                    id={
+                                                                                        rowIndex === 0 && date === 0
+                                                                                            ? 'cell_sample'
+                                                                                            : undefined
+                                                                                    }
+                                                                                    onClick={() => {
+                                                                                        if (readonly) return;
+
+                                                                                        changeFocus({
+                                                                                            shiftNurseName: row.shiftNurse.name,
+                                                                                            shiftNurseId: row.shiftNurse.shiftNurseId,
+                                                                                            day: date,
+                                                                                        });
+                                                                                        onFocusAnalytics();
+                                                                                    }}
+                                                                                    shiftType={
+                                                                                        currentShiftTypeId === null
+                                                                                            ? requestDutyRequest === null
+                                                                                                ? null
+                                                                                                : wardShiftTypeMap.get(
+                                                                                                      requestDutyRequest.wardShiftTypeId,
+                                                                                                  )
+                                                                                            : wardShiftTypeMap.get(currentShiftTypeId)
+                                                                                    }
+                                                                                    isOnlyRequest={
+                                                                                        currentShiftTypeId === null &&
+                                                                                        requestDutyRequest !== null
+                                                                                    }
+                                                                                    className={`z-10 ${
+                                                                                        readonly ? 'cursor-default' : 'cursor-pointer'
+                                                                                    } ${
+                                                                                        isFocusedCell && 'outline-[.125rem] outline-main-1'
+                                                                                    }`}
+                                                                                    forwardRef={isFocusedCell ? focusedCellRef : null}
+                                                                                />
+                                                                            </div>
+                                                                        );
+                                                                    })}
+                                                                </div>
+                                                                {rowIndex !== rows.length - 1
+                                                                    ? !readonly && (
+                                                                          <>
+                                                                              <div
+                                                                                  className="justify-cente group peer absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-80%] translate-y-[50%] items-center"
+                                                                                  onClick={(event) => {
+                                                                                      event.stopPropagation();
+                                                                                      editDivision(
+                                                                                          currentShiftTeam.shiftTeamId,
+                                                                                          row.shiftNurse.priority,
+                                                                                          1,
+                                                                                          yearMonthLabel,
+                                                                                      );
+                                                                                      onCreateDivisionAnalytics();
+                                                                                  }}
+                                                                              >
+                                                                                  <PlusIcon2 className="invisible h-5 w-5 group-hover:visible" />
+                                                                              </div>
+                                                                              <div className="invisible absolute bottom-0 h-[.0938rem] w-full bg-sub-2.5 peer-hover:visible" />
+                                                                          </>
+                                                                      )
+                                                                    : level !== requestShift.divisionShiftNurses.length - 1 &&
+                                                                      !readonly && (
+                                                                          <div
+                                                                              className="absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-65%] translate-y-[calc(50%+.1563rem)] items-center"
+                                                                              onClick={(event) => {
+                                                                                  event.stopPropagation();
+                                                                                  editDivision(
+                                                                                      currentShiftTeam.shiftTeamId,
+                                                                                      row.shiftNurse.priority,
+                                                                                      -1,
+                                                                                      yearMonthLabel,
+                                                                                  );
+                                                                                  onDeleteDivisionAnalytics();
+                                                                              }}
+                                                                          >
+                                                                              <MinusIcon className="h-5 w-5 opacity-0 hover:opacity-100" />
+                                                                          </div>
+                                                                      )}
+                                                            </div>
+                                                        )}
+                                                    </Draggable>
+                                                );
+                                            })}
+                                            {provided.placeholder}
+                                        </div>
+                                    </div>
+                                )}
+                            </Droppable>
+                        );
+                    })}
+            </div>
+        </DragDropContext>
+    );
+}

--- a/src/pages/RequestShiftPage/ui/request-calendar/RequestCalendarHeader.tsx
+++ b/src/pages/RequestShiftPage/ui/request-calendar/RequestCalendarHeader.tsx
@@ -1,0 +1,34 @@
+import {type TRequestShift} from '@/entities/shift';
+import {getDayBadgeClass} from './utils';
+
+interface IRequestCalendarHeaderProps {
+    days: TRequestShift['days'];
+    focusDay: number | undefined;
+    separateWeekendColor: boolean;
+}
+
+export default function RequestCalendarHeader({days, focusDay, separateWeekendColor}: IRequestCalendarHeaderProps) {
+    return (
+        <div className="z-20 my-[.75rem] flex h-7.5 min-w-max items-center gap-5 bg-white pr-4">
+            <div className="flex gap-5">
+                <div className="w-13.5 text-center font-apple text-[1rem] font-medium text-sub-3">{/* 구분 */}</div>
+                <div className="w-17.5 text-center font-apple text-[1rem] font-medium text-sub-3">이름</div>
+                <div className="w-7.5 text-center font-apple text-[1rem] font-medium text-sub-3">연동</div>
+                <div className="flex rounded-[2.5rem] border-[.0625rem] border-sub-4 px-4 py-[.1875rem]">
+                    {days.map((day, index) => (
+                        <p
+                            key={day.day}
+                            className={`w-9 flex-1 rounded-full text-center font-poppins text-[1rem] ${getDayBadgeClass(
+                                day.dayType,
+                                index === focusDay,
+                                separateWeekendColor,
+                            )}`}
+                        >
+                            {day.day}
+                        </p>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
+++ b/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
@@ -1,0 +1,144 @@
+import {twMerge} from 'tailwind-merge';
+import {type TDutyRequest} from '@/entities/shift';
+import ShiftBadge from '@/entities/shift/ui/shift-badge';
+import {type TWardShiftType} from '@/entities/ward';
+import {type TFocus} from '@/features/shift/useRequestShift/type';
+import Card from '@/shared/ui/Card';
+import PageState from '@/shared/ui/PageState';
+import {getDutyRequestStatusLabel, getRequestFocus} from './utils';
+
+interface IRequestDutyRequestPanelProps {
+    dutyRequestList: TDutyRequest[] | undefined;
+    dutyRequestStatus: 'pending' | 'error' | 'success';
+    wardShiftTypeMap: Map<number, TWardShiftType>;
+    unresolvedRequestCount: number;
+    readonly: boolean;
+    shiftNurseIdByNurseId: Map<number, number>;
+    changeFocus: (focus: TFocus | null) => void;
+    acceptRequest: (reqShiftId: number, isAccepted: boolean | null) => void;
+    retry: () => Promise<unknown>;
+    onAcceptAnalytics: (accepted: boolean) => void;
+}
+
+export default function RequestDutyRequestPanel({
+    dutyRequestList,
+    dutyRequestStatus,
+    wardShiftTypeMap,
+    unresolvedRequestCount,
+    readonly,
+    shiftNurseIdByNurseId,
+    changeFocus,
+    acceptRequest,
+    retry,
+    onAcceptAnalytics,
+}: IRequestDutyRequestPanelProps) {
+    return (
+        <Card
+            id="nurse_request_list"
+            variant="elevated"
+            padding="none"
+            className="flex w-full shrink-0 flex-col overflow-hidden border-gray-6 xl:w-[360px]"
+        >
+            <div className="border-b border-sub-4.5 px-6 py-5">
+                <div className="flex items-center justify-between gap-3">
+                    <div>
+                        <p className="font-apple text-[1.25rem] font-semibold text-main-1">신청 내역</p>
+                        <p className="mt-1 font-apple text-sm font-medium text-gray-4">미처리 신청 {unresolvedRequestCount}건</p>
+                    </div>
+                </div>
+            </div>
+
+            <div className="scrollbar-hide max-h-[calc(100vh-18rem)] overflow-y-auto px-5 py-4">
+                {dutyRequestStatus === 'pending' ? (
+                    <PageState
+                        tone="loading"
+                        title="신청 내역을 불러오는 중이에요"
+                        description="제출된 신청 근무를 확인하고 있어요."
+                        className="px-0 py-0"
+                    />
+                ) : dutyRequestStatus === 'error' ? (
+                    <PageState
+                        tone="error"
+                        title="신청 내역을 불러오지 못했어요"
+                        description="잠시 후 다시 시도해 주세요."
+                        action={{label: '다시 시도', onClick: () => void retry()}}
+                        className="px-0 py-0"
+                    />
+                ) : dutyRequestList && dutyRequestList.length > 0 ? (
+                    <div className="space-y-3">
+                        {dutyRequestList.map((dutyRequest) => {
+                            const requestFocus = getRequestFocus(dutyRequest, shiftNurseIdByNurseId);
+
+                            return (
+                                <div key={dutyRequest.wardReqShiftId} className="rounded-[16px] border border-gray-6 px-4 py-3">
+                                    <div className="flex items-start gap-3">
+                                        <div className="min-w-0 flex-1">
+                                            <button
+                                                type="button"
+                                                className={twMerge(
+                                                    'truncate text-left font-apple text-base font-semibold text-sub-1',
+                                                    (!requestFocus || readonly) && 'cursor-default',
+                                                    requestFocus && !readonly && 'cursor-pointer hover:text-main-1',
+                                                )}
+                                                onClick={() => {
+                                                    if (readonly || !requestFocus) return;
+
+                                                    changeFocus(requestFocus);
+                                                }}
+                                            >
+                                                {dutyRequest.nurseName} / {dutyRequest.date}일
+                                            </button>
+                                            <div className="mt-2 flex items-center gap-2">
+                                                <ShiftBadge shiftType={wardShiftTypeMap.get(dutyRequest.wardShiftTypeId)} />
+                                                <p className="font-apple text-sm font-medium text-gray-4">
+                                                    {getDutyRequestStatusLabel(dutyRequest.isAccepted)}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div className="mt-4 flex rounded-[12px] bg-gray-7 p-1">
+                                        <button
+                                            type="button"
+                                            className={twMerge(
+                                                'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
+                                                dutyRequest.isAccepted === true && 'bg-main-1 text-white',
+                                            )}
+                                            onClick={() => {
+                                                acceptRequest(dutyRequest.wardReqShiftId, true);
+                                                onAcceptAnalytics(true);
+                                            }}
+                                        >
+                                            수락
+                                        </button>
+                                        <button
+                                            type="button"
+                                            className={twMerge(
+                                                'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
+                                                dutyRequest.isAccepted === false && 'bg-sub-2 text-white',
+                                            )}
+                                            onClick={() => {
+                                                acceptRequest(dutyRequest.wardReqShiftId, false);
+                                                onAcceptAnalytics(false);
+                                            }}
+                                        >
+                                            거절
+                                        </button>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                ) : (
+                    <div className="flex min-h-[220px] items-center justify-center rounded-[16px] bg-gray-7 px-6 text-center">
+                        <p className="font-apple text-sm leading-6 font-medium text-gray-4">
+                            아직 제출된 신청 근무가 없어요.
+                            <br />
+                            신청이 들어오면 이 패널에서 바로 확인할 수 있어요.
+                        </p>
+                    </div>
+                )}
+            </div>
+        </Card>
+    );
+}

--- a/src/pages/RequestShiftPage/ui/request-calendar/useRequestCalendarFocusScroll.ts
+++ b/src/pages/RequestShiftPage/ui/request-calendar/useRequestCalendarFocusScroll.ts
@@ -1,0 +1,39 @@
+import {type RefObject, useEffect} from 'react';
+import {type TFocus} from '@/features/shift/useRequestShift/type';
+
+type TUseRequestCalendarFocusScrollParams = {
+    focus: TFocus | null;
+    focusedCellRef: RefObject<HTMLElement | null>;
+    containerRef: RefObject<HTMLDivElement | null>;
+};
+
+export const useRequestCalendarFocusScroll = ({focus, focusedCellRef, containerRef}: TUseRequestCalendarFocusScrollParams) => {
+    useEffect(() => {
+        if (!focus) return;
+
+        const focusRect = focusedCellRef.current?.getBoundingClientRect();
+        const container = containerRef.current;
+
+        if (!focusRect || !container) return;
+
+        if (focusRect.x + focusRect.width - container.offsetLeft > container.clientWidth) {
+            container.scroll({
+                left: focusRect.left + container.scrollLeft,
+            });
+        }
+
+        if (focusRect.x - container.offsetLeft < 0) {
+            container.scroll({left: 0});
+        }
+
+        if (focusRect.y + focusRect.height - container.offsetTop > container.clientHeight) {
+            container.scroll({
+                top: focusRect.top + container.scrollTop,
+            });
+        }
+
+        if (focusRect.y - container.offsetTop < 0) {
+            container.scroll({top: focusRect.top + window.scrollY - 132});
+        }
+    }, [containerRef, focus, focusedCellRef]);
+};

--- a/src/pages/RequestShiftPage/ui/request-calendar/utils.test.ts
+++ b/src/pages/RequestShiftPage/ui/request-calendar/utils.test.ts
@@ -1,0 +1,153 @@
+import {describe, expect, it} from 'vitest';
+import {type TRequestShift} from '@/entities/shift';
+import {getMoveNurseOrderPayload, getRequestFocus} from './utils';
+
+const createRequestShift = (): TRequestShift =>
+    ({
+        days: [],
+        wardShiftTypes: [],
+        divisionShiftNurses: [
+            [
+                {
+                    shiftNurse: {
+                        shiftNurseId: 11,
+                        nurseId: 101,
+                        divisionNum: 1,
+                        priority: 100,
+                    },
+                    carry: 0,
+                    wardReqShiftList: [],
+                },
+                {
+                    shiftNurse: {
+                        shiftNurseId: 12,
+                        nurseId: 102,
+                        divisionNum: 1,
+                        priority: 200,
+                    },
+                    carry: 0,
+                    wardReqShiftList: [],
+                },
+                {
+                    shiftNurse: {
+                        shiftNurseId: 13,
+                        nurseId: 103,
+                        divisionNum: 1,
+                        priority: 300,
+                    },
+                    carry: 0,
+                    wardReqShiftList: [],
+                },
+            ],
+            [
+                {
+                    shiftNurse: {
+                        shiftNurseId: 21,
+                        nurseId: 201,
+                        divisionNum: 2,
+                        priority: 400,
+                    },
+                    carry: 0,
+                    wardReqShiftList: [],
+                },
+                {
+                    shiftNurse: {
+                        shiftNurseId: 22,
+                        nurseId: 202,
+                        divisionNum: 2,
+                        priority: 500,
+                    },
+                    carry: 0,
+                    wardReqShiftList: [],
+                },
+            ],
+        ],
+    }) as TRequestShift;
+
+describe('request-calendar utils', () => {
+    it('같은 division 안에서 아래로 이동할 때 다음 우선순위를 기준으로 계산한다', () => {
+        const requestShift = createRequestShift();
+        const payload = getMoveNurseOrderPayload({
+            source: {droppableId: '0', index: 0},
+            destination: {droppableId: '0', index: 2},
+            draggableId: '11',
+            requestShift,
+            type: 'DEFAULT',
+            reason: 'DROP',
+            mode: 'FLUID',
+            combine: null,
+        });
+
+        expect(payload).toEqual({
+            nurseId: 101,
+            destinationDivisionNum: 1,
+            prevPriority: 300,
+            nextPriority: 2324,
+        });
+    });
+
+    it('다른 division으로 이동할 때 이전 행 우선순위를 기준으로 계산한다', () => {
+        const requestShift = createRequestShift();
+        const payload = getMoveNurseOrderPayload({
+            source: {droppableId: '0', index: 1},
+            destination: {droppableId: '1', index: 1},
+            draggableId: '12',
+            requestShift,
+            type: 'DEFAULT',
+            reason: 'DROP',
+            mode: 'FLUID',
+            combine: null,
+        });
+
+        expect(payload).toEqual({
+            nurseId: 102,
+            destinationDivisionNum: 2,
+            prevPriority: 400,
+            nextPriority: 500,
+        });
+    });
+
+    it('신청 내역에서 포커스 가능한 간호사를 찾으면 focus 객체를 반환한다', () => {
+        const focus = getRequestFocus(
+            {
+                wardReqShiftId: 1,
+                nurseId: 101,
+                nurseName: '김간호',
+                date: 3,
+                requestDate: '2026-03-01',
+                wardShiftTypeId: 9,
+                wardShiftTypeShortName: 'D',
+                wardShiftTypeColor: '#000000',
+                isRead: false,
+                isAccepted: null,
+            },
+            new Map([[101, 11]]),
+        );
+
+        expect(focus).toEqual({
+            shiftNurseName: '김간호',
+            shiftNurseId: 11,
+            day: 2,
+        });
+    });
+
+    it('매칭되는 간호사가 없으면 focus를 만들지 않는다', () => {
+        const focus = getRequestFocus(
+            {
+                wardReqShiftId: 1,
+                nurseId: 999,
+                nurseName: '김간호',
+                date: 3,
+                requestDate: '2026-03-01',
+                wardShiftTypeId: 9,
+                wardShiftTypeShortName: 'D',
+                wardShiftTypeColor: '#000000',
+                isRead: false,
+                isAccepted: null,
+            },
+            new Map([[101, 11]]),
+        );
+
+        expect(focus).toBeNull();
+    });
+});

--- a/src/pages/RequestShiftPage/ui/request-calendar/utils.ts
+++ b/src/pages/RequestShiftPage/ui/request-calendar/utils.ts
@@ -1,0 +1,141 @@
+import {type DropResult} from '@hello-pangea/dnd';
+import {type TDutyRequest, type TRequestShift} from '@/entities/shift';
+import {type TShiftTeam} from '@/entities/ward';
+import {type TFocus} from '@/features/shift/useRequestShift/type';
+
+const PRIORITY_GAP = 2024;
+
+export const getYearMonthLabel = (year: number, month: number) => `${year}-${month.toString().padStart(2, '0')}`;
+
+export const getDutyRequestLookupKey = (nurseId: number, dateIndex: number) => `${nurseId}:${dateIndex}`;
+
+export const createDutyRequestLookup = (dutyRequestList: TDutyRequest[] | undefined) =>
+    new Map(dutyRequestList?.map((request) => [getDutyRequestLookupKey(request.nurseId, request.date - 1), request]) ?? []);
+
+export const createShiftNurseIdByNurseId = (requestShift: TRequestShift) =>
+    new Map(
+        requestShift.divisionShiftNurses
+            .flatMap((division) => division)
+            .map((row) => [row.shiftNurse.nurseId, row.shiftNurse.shiftNurseId]),
+    );
+
+export const createConnectedNurseIdSet = (currentShiftTeam: TShiftTeam) =>
+    new Set(currentShiftTeam.nurses.filter((nurse) => nurse.isConnected).map((nurse) => nurse.nurseId));
+
+export const getUnresolvedRequestCount = (dutyRequestStatus: string, dutyRequestList: TDutyRequest[] | undefined) =>
+    dutyRequestStatus === 'success' ? (dutyRequestList?.filter((request) => request.isAccepted === null).length ?? 0) : 0;
+
+export const getDutyRequestStatusLabel = (isAccepted: boolean | null) => {
+    if (isAccepted === true) return '수락됨';
+
+    if (isAccepted === false) return '거절됨';
+
+    return '확인 필요';
+};
+
+export const getRequestFocus = (dutyRequest: TDutyRequest, shiftNurseIdByNurseId: Map<number, number>): TFocus | null => {
+    const matchedShiftNurseId = shiftNurseIdByNurseId.get(dutyRequest.nurseId);
+
+    if (matchedShiftNurseId === undefined) return null;
+
+    return {
+        shiftNurseName: dutyRequest.nurseName,
+        shiftNurseId: matchedShiftNurseId,
+        day: dutyRequest.date - 1,
+    };
+};
+
+export const getDayBadgeClass = (dayType: TRequestShift['days'][number]['dayType'], isFocused: boolean, separateWeekendColor: boolean) => {
+    if (dayType === 'saturday') {
+        if (isFocused) return separateWeekendColor ? 'bg-blue text-white' : 'bg-red text-white';
+
+        return separateWeekendColor ? 'text-blue' : 'text-red';
+    }
+
+    if (dayType === 'sunday' || dayType === 'holiday') {
+        return isFocused ? 'bg-red text-white' : 'text-red';
+    }
+
+    if (dayType === 'workday') {
+        return isFocused ? 'bg-main-1 text-white' : 'text-sub-2.5';
+    }
+
+    return '';
+};
+
+export const getDayCellClass = (
+    dayType: TRequestShift['days'][number]['dayType'],
+    isFocusedDay: boolean,
+    separateWeekendColor: boolean,
+) => {
+    const classes = [];
+
+    if (dayType === 'sunday' || dayType === 'holiday') {
+        classes.push('bg-[#FFE1E680]');
+    } else if (dayType === 'saturday') {
+        classes.push(separateWeekendColor ? 'bg-[#E1E5FF80]' : 'bg-[#FFE1E680]');
+    }
+
+    if (isFocusedDay) {
+        classes.push('bg-main-4');
+    }
+
+    return classes.join(' ');
+};
+
+type TMoveNurseOrderPayload = {
+    nurseId: number;
+    destinationDivisionNum: number;
+    prevPriority: number;
+    nextPriority: number;
+};
+
+export const getMoveNurseOrderPayload = ({
+    destination,
+    draggableId,
+    requestShift,
+    source,
+}: DropResult & {
+    requestShift: TRequestShift;
+}): TMoveNurseOrderPayload | null => {
+    if (!destination) return null;
+
+    const sourceDivision = Number.parseInt(source.droppableId, 10);
+    const destinationDivision = Number.parseInt(destination.droppableId, 10);
+    const draggedNurse = requestShift.divisionShiftNurses[sourceDivision].find(
+        (row) => row.shiftNurse.shiftNurseId === Number.parseInt(draggableId, 10),
+    )?.shiftNurse;
+
+    if (!draggedNurse) return null;
+
+    const destinationNurses = requestShift.divisionShiftNurses[destinationDivision];
+    const destinationDivisionNum = destinationNurses[0]?.shiftNurse.divisionNum;
+
+    if (destinationDivisionNum === undefined) return null;
+
+    if (destination.droppableId === source.droppableId) {
+        const currentIndex = destinationNurses.findIndex((row) => row.shiftNurse.shiftNurseId === draggedNurse.shiftNurseId);
+
+        if (currentIndex !== -1 && currentIndex < destination.index) {
+            return {
+                nurseId: draggedNurse.nurseId,
+                destinationDivisionNum,
+                prevPriority: destination.index === 0 ? 0 : destinationNurses[destination.index].shiftNurse.priority,
+                nextPriority:
+                    destination.index === destinationNurses.length - 1
+                        ? destinationNurses[destination.index].shiftNurse.priority + PRIORITY_GAP
+                        : destinationNurses[destination.index + 1].shiftNurse.priority,
+            };
+        }
+    }
+
+    return {
+        nurseId: draggedNurse.nurseId,
+        destinationDivisionNum,
+        prevPriority: destination.index === 0 ? 0 : destinationNurses[destination.index - 1].shiftNurse.priority,
+        nextPriority:
+            destination.index === destinationNurses.length
+                ? destinationNurses[destination.index - 1].shiftNurse.priority + PRIORITY_GAP
+                : destinationNurses[destination.index].shiftNurse.priority,
+    };
+};


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-855](https://gom3.atlassian.net/browse/DUT-855)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `RequestCalendar`를 컨테이너 역할만 남기고 달력 헤더, 달력 그리드, 신청 내역 패널, 포커스 스크롤 훅으로 분리했습니다.
- 드래그 이동 우선순위 계산, 요청 내역 lookup, 포커스 생성, 주말/포커스 스타일 계산을 `request-calendar/utils.ts`로 옮겨 상태 계산 책임을 렌더링에서 분리했습니다.
- 기존 신청근무 동작은 유지하면서 이후 개선 작업 시 달력 본체와 신청 내역 패널을 독립적으로 수정할 수 있도록 구조를 정리했습니다.

<br>

## To Reviewers

- 드래그 앤 드롭 후 간호사 순서 변경, 셀 포커스 이동, 신청 내역 패널에서 포커스 이동/수락/거절이 기존과 동일하게 동작하는지 확인 부탁드립니다.
- 검증은 `pnpm exec tsc --noEmit`, `pnpm exec eslint src/pages/RequestShiftPage/ui/RequestCalendar.tsx src/pages/RequestShiftPage/ui/request-calendar/*.tsx src/pages/RequestShiftPage/ui/request-calendar/*.ts` 기준으로 수행했습니다.


[DUT-855]: https://gom3.atlassian.net/browse/DUT-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ