### PR TITLE
[DUT-851]: 온보딩 mock 실행 경로 정리

### DIFF
--- a/src/pages/OnboardingWardCreatePage/adapter.test.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.test.ts
@@ -3,12 +3,11 @@ import {type TOnboardingWardParseApiResponse} from '@/shared/api/file/type';
 import {
     applyParsedWardData,
     buildCreateWardPayload,
-    buildMockCreateWardPayload,
     buildOnboardingParseDraftInjection,
     getOnboardingUploadFailureMessage,
     isSupportedOnboardingUploadFile,
 } from './adapter';
-import {createInitialDraft, saveSkillLevelConfig} from './model';
+import {createInitialDraft} from './model';
 
 describe('OnboardingWardCreatePage adapter', () => {
     it('builds create ward payload outside the UI draft layer', () => {
@@ -104,21 +103,6 @@ describe('OnboardingWardCreatePage adapter', () => {
         });
 
         expect(nextDraft.nurses[0]?.employmentDate).toBe(today);
-    });
-
-    it('builds a mock preview payload with parse-friendly nurse metadata', () => {
-        const draft = saveSkillLevelConfig(createInitialDraft(), {
-            levelCount: 3,
-            paletteId: 'warm',
-            autoAssign: true,
-        });
-        const payload = buildMockCreateWardPayload(draft);
-
-        expect(payload.nurses[0]).toMatchObject({
-            name: draft.nurses[0]?.name,
-            teamName: draft.teams[0]?.name,
-        });
-        expect(payload.skillLevelConfig.palette).toHaveLength(draft.skillLevelConfig.levelCount);
     });
 
     it('normalizes parse api responses into draft injection data', () => {

--- a/src/pages/OnboardingWardCreatePage/adapter.ts
+++ b/src/pages/OnboardingWardCreatePage/adapter.ts
@@ -3,28 +3,12 @@ import {type TOnboardingWardParseApiResponse} from '@/shared/api/file/type';
 import {type TCreateWardDTO} from '@/shared/api/ward/type';
 import {
     createEmptyShiftType,
-    getSkillPalette,
     type TOnboardingNurseDraft,
     type TOnboardingTeamDraft,
     type TOnboardingWardDraft,
     type TOnboardingWardShiftType,
     type TSkillLevelConfig,
 } from './model';
-
-export type TMockCreateWardPayload = TCreateWardDTO & {
-    nurses: Array<{
-        name: string;
-        memo: string;
-        isWorker: boolean;
-        employmentDate: string;
-        teamName: string;
-        level: number | null;
-        possibleShiftShortNames: string[];
-    }>;
-    skillLevelConfig: TSkillLevelConfig & {
-        palette: string[];
-    };
-};
 
 export type TOnboardingParsedShiftType = Partial<Omit<TCreateWardDTO['wardShiftTypes'][number], 'isCounted'>> & {
     name?: string;
@@ -325,28 +309,3 @@ export const buildCreateWardPayload = (draft: TOnboardingWardDraft): TCreateWard
         nurseNames: draft.nurses.filter((nurse) => nurse.teamId === team.id).map((nurse) => nurse.name),
     })),
 });
-
-export const buildMockCreateWardPayload = (draft: TOnboardingWardDraft): TMockCreateWardPayload => {
-    const teamById = new Map(draft.teams.map((team) => [team.id, team.name]));
-    const shiftTypeById = new Map(draft.shiftTypes.map((shiftType) => [shiftType.id, shiftType]));
-    const palette = getSkillPalette(draft.skillLevelConfig.paletteId);
-
-    return {
-        ...buildCreateWardPayload(draft),
-        nurses: draft.nurses.map((nurse) => ({
-            name: nurse.name,
-            memo: nurse.memo,
-            isWorker: nurse.isWorker,
-            employmentDate: nurse.employmentDate,
-            teamName: teamById.get(nurse.teamId) ?? '',
-            level: nurse.level,
-            possibleShiftShortNames: nurse.possibleShiftTypeIds
-                .map((shiftTypeId) => shiftTypeById.get(shiftTypeId)?.shortName ?? '')
-                .filter(Boolean),
-        })),
-        skillLevelConfig: {
-            ...draft.skillLevelConfig,
-            palette: palette.colors.slice(0, draft.skillLevelConfig.levelCount),
-        },
-    };
-};

--- a/src/pages/OnboardingWardCreatePage/components/steps/SkillLevelModal.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/steps/SkillLevelModal.tsx
@@ -1,5 +1,6 @@
 import {Info, X} from 'lucide-react';
 import {useEffect, useState} from 'react';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/shared/ui/primitives/tooltip';
 import {cn} from '@/shared/util/style';
 import {getSkillPalette, skillPalettes, type TSkillLevelConfig} from '../../model';
@@ -14,6 +15,7 @@ interface ISkillLevelModalProps {
 }
 
 function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps) {
+    const {t} = useTypedTranslation();
     const [localConfig, setLocalConfig] = useState(config);
 
     useEffect(() => {
@@ -32,8 +34,12 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
             <div role="dialog" aria-modal="true" className="w-full max-w-[710px] rounded-[20px] bg-white px-[42px] py-10">
                 <div className="flex items-start justify-between">
                     <div>
-                        <h2 className="font-apple text-[32px] font-semibold text-text-1">숙련도 단계 설정</h2>
-                        <p className="mt-2 font-apple text-[20px] font-medium text-gray-3">기준은 자유롭게 정할 수 있어요</p>
+                        <h2 className="font-apple text-[32px] font-semibold text-text-1">
+                            {t('page.onboardingWardCreate.skillLevelModal.title')}
+                        </h2>
+                        <p className="mt-2 font-apple text-[20px] font-medium text-gray-3">
+                            {t('page.onboardingWardCreate.skillLevelModal.description')}
+                        </p>
                     </div>
                     <button type="button" onClick={onClose} className="rounded-full p-2 text-gray-4 hover:bg-gray-7">
                         <X className="h-5 w-5" />
@@ -48,7 +54,7 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
                     >
                         {[2, 3, 4, 5].map((levelCount) => (
                             <option key={levelCount} value={levelCount}>
-                                {levelCount}단계
+                                {t('page.onboardingWardCreate.skillLevelModal.levelCountOption', {levelCount})}
                             </option>
                         ))}
                     </select>
@@ -73,7 +79,9 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
                                 ))}
                             </button>
                         ))}
-                        <span className="font-apple text-[20px] font-medium text-sub-2">색상</span>
+                        <span className="font-apple text-[20px] font-medium text-sub-2">
+                            {t('page.onboardingWardCreate.skillLevelModal.colorLabel')}
+                        </span>
                     </div>
                 </div>
 
@@ -81,16 +89,16 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
                     <div className="grid grid-cols-[72px_1fr]">
                         <div className="from-gray-2 rounded-l-[10px] bg-gradient-to-b to-gray-5 px-4 py-6 text-center font-apple text-[20px] font-semibold text-white">
                             <div className="h-[176px]">
-                                <p>높음</p>
+                                <p>{t('page.onboardingWardCreate.skillLevelModal.high')}</p>
                                 <div className="flex h-full items-end justify-center">
-                                    <p className="text-text-1">낮음</p>
+                                    <p className="text-text-1">{t('page.onboardingWardCreate.skillLevelModal.low')}</p>
                                 </div>
                             </div>
                         </div>
                         <div className="space-y-5 px-8 py-6">
                             <div className="grid grid-cols-[100px_1fr] text-center font-apple text-[16px] text-gray-3">
-                                <span>숙련도</span>
-                                <span>구분</span>
+                                <span>{t('page.onboardingWardCreate.skillLevelModal.levelLabel')}</span>
+                                <span>{t('page.onboardingWardCreate.skillLevelModal.categoryLabel')}</span>
                             </div>
                             {levelItems.map((level) => (
                                 <div key={level} className="grid grid-cols-[100px_1fr] items-center">
@@ -98,7 +106,7 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
                                         <SkillBadge level={level} config={{...localConfig, paletteId: palette.id}} />
                                     </div>
                                     <div className="rounded-[5px] bg-gray-6/70 px-4 py-1.5 font-apple text-[16px] text-gray-3">
-                                        LV. {level}
+                                        {t('page.onboardingWardCreate.skillLevelModal.levelDisplay', {level})}
                                     </div>
                                 </div>
                             ))}
@@ -114,7 +122,7 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
                         onChange={(event) => setLocalConfig((prev) => ({...prev, autoAssign: event.target.checked}))}
                     />
                     <label htmlFor="skill-auto-assign" className="font-apple text-[16px] text-gray-3">
-                        자동 배정
+                        {t('page.onboardingWardCreate.skillLevelModal.autoAssign')}
                     </label>
                     <TooltipProvider>
                         <Tooltip>
@@ -124,7 +132,7 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
                                 </button>
                             </TooltipTrigger>
                             <TooltipContent className="max-w-[220px] bg-gray-6 text-sub-1">
-                                등록된 간호사 목록을 단계별로 분배해서 자동으로 1차 배정합니다.
+                                {t('page.onboardingWardCreate.skillLevelModal.autoAssignTooltip')}
                             </TooltipContent>
                         </Tooltip>
                     </TooltipProvider>
@@ -132,7 +140,7 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
 
                 <div className="mt-10 flex items-center justify-between">
                     <button type="button" className="font-apple text-[20px] text-gray-4 underline underline-offset-2" onClick={onClose}>
-                        취소
+                        {t('page.onboardingWardCreate.skillLevelModal.cancel')}
                     </button>
                     <WizardButton
                         onClick={() => {
@@ -140,7 +148,7 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
                             onClose();
                         }}
                     >
-                        완료
+                        {t('page.onboardingWardCreate.skillLevelModal.complete')}
                     </WizardButton>
                 </div>
             </div>

--- a/src/pages/OnboardingWardCreatePage/components/steps/SkillLevelModal.tsx
+++ b/src/pages/OnboardingWardCreatePage/components/steps/SkillLevelModal.tsx
@@ -132,7 +132,7 @@ function SkillLevelModal({open, config, onClose, onSave}: ISkillLevelModalProps)
 
                 <div className="mt-10 flex items-center justify-between">
                     <button type="button" className="font-apple text-[20px] text-gray-4 underline underline-offset-2" onClick={onClose}>
-                        임시 저장
+                        취소
                     </button>
                     <WizardButton
                         onClick={() => {

--- a/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
+++ b/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
@@ -145,7 +145,6 @@ function useOnboardingWardWizard() {
         try {
             const submission = await onboardingWardCreateExecutor(draft);
 
-            console.info('createWardPayload', submission.wardCreatePayload);
             setSubmissionStatus('success');
             toast.success(submission.successMessage);
         } catch (error) {

--- a/src/pages/OnboardingWardCreatePage/index.test.tsx
+++ b/src/pages/OnboardingWardCreatePage/index.test.tsx
@@ -9,6 +9,19 @@ const toastError = vi.fn();
 const mockCreateWard = vi.fn();
 const mockNavigate = vi.fn();
 const mockParseOnboardingWardExcel = vi.fn();
+const typedTranslations = {
+    'page.onboardingWardCreate.skillLevelModal.title': '숙련도 단계 설정',
+    'page.onboardingWardCreate.skillLevelModal.description': '기준은 자유롭게 정할 수 있어요',
+    'page.onboardingWardCreate.skillLevelModal.colorLabel': '색상',
+    'page.onboardingWardCreate.skillLevelModal.high': '높음',
+    'page.onboardingWardCreate.skillLevelModal.low': '낮음',
+    'page.onboardingWardCreate.skillLevelModal.levelLabel': '숙련도',
+    'page.onboardingWardCreate.skillLevelModal.categoryLabel': '구분',
+    'page.onboardingWardCreate.skillLevelModal.autoAssign': '자동 배정',
+    'page.onboardingWardCreate.skillLevelModal.autoAssignTooltip': '등록된 간호사 목록을 단계별로 분배해서 자동으로 1차 배정합니다.',
+    'page.onboardingWardCreate.skillLevelModal.cancel': '취소',
+    'page.onboardingWardCreate.skillLevelModal.complete': '완료',
+} as const;
 
 vi.mock('react-hot-toast', () => ({
     default: {
@@ -30,6 +43,22 @@ vi.mock('@/features/auth/useRegister', () => ({
     default: () => ({
         actions: {
             createWard: mockCreateWard,
+        },
+    }),
+}));
+
+vi.mock('@/shared/hook/use-typed-translation', () => ({
+    useTypedTranslation: () => ({
+        t: (key: string, values?: Record<string, string | number>) => {
+            if (key === 'page.onboardingWardCreate.skillLevelModal.levelCountOption') {
+                return `${values?.levelCount ?? ''}단계`;
+            }
+
+            if (key === 'page.onboardingWardCreate.skillLevelModal.levelDisplay') {
+                return `LV. ${values?.level ?? ''}`;
+            }
+
+            return typedTranslations[key as keyof typeof typedTranslations] ?? key;
         },
     }),
 }));

--- a/src/pages/OnboardingWardCreatePage/submission.ts
+++ b/src/pages/OnboardingWardCreatePage/submission.ts
@@ -1,11 +1,9 @@
 import type {TCreateWardDTO} from '@/shared/api/ward/type';
-import {buildCreateWardPayload, buildMockCreateWardPayload, type TMockCreateWardPayload} from './adapter';
+import {buildCreateWardPayload} from './adapter';
 import type {TOnboardingWardDraft} from './model';
 
 export type TOnboardingWardCreateSubmission = {
     mode: 'created';
-    wardCreatePayload: TCreateWardDTO;
-    previewPayload: TMockCreateWardPayload;
     successMessage: string;
 };
 
@@ -27,8 +25,6 @@ export const createOnboardingWardCreateExecutor =
 
         return {
             mode: 'created',
-            wardCreatePayload,
-            previewPayload: buildMockCreateWardPayload(draft),
             successMessage: '병동 생성을 완료했어요.',
         };
     };

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -152,6 +152,23 @@ export const en: TLocale = {
         refresh: {
             loading: 'Logging in...',
         },
+        onboardingWardCreate: {
+            skillLevelModal: {
+                title: 'Set skill levels',
+                description: 'You can define the criteria freely.',
+                levelCountOption: '{{levelCount}} levels',
+                colorLabel: 'Color',
+                high: 'High',
+                low: 'Low',
+                levelLabel: 'Level',
+                categoryLabel: 'Category',
+                levelDisplay: 'LV. {{level}}',
+                autoAssign: 'Auto assign',
+                autoAssignTooltip: 'Automatically distributes registered nurses across levels for an initial assignment.',
+                cancel: 'Cancel',
+                complete: 'Complete',
+            },
+        },
     },
     feature: {
         auth: {

--- a/src/shared/locales/ko.ts
+++ b/src/shared/locales/ko.ts
@@ -150,6 +150,23 @@ export const ko = {
         refresh: {
             loading: '로그인중입니다.',
         },
+        onboardingWardCreate: {
+            skillLevelModal: {
+                title: '숙련도 단계 설정',
+                description: '기준은 자유롭게 정할 수 있어요',
+                levelCountOption: '{{levelCount}}단계',
+                colorLabel: '색상',
+                high: '높음',
+                low: '낮음',
+                levelLabel: '숙련도',
+                categoryLabel: '구분',
+                levelDisplay: 'LV. {{level}}',
+                autoAssign: '자동 배정',
+                autoAssignTooltip: '등록된 간호사 목록을 단계별로 분배해서 자동으로 1차 배정합니다.',
+                cancel: '취소',
+                complete: '완료',
+            },
+        },
     },
     feature: {
         auth: {


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-851](https://gom3.atlassian.net/browse/DUT-851)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 온보딩 병동 생성 제출 경로에서 사용되지 않던 mock preview payload 생성 및 관련 타입/테스트를 제거했습니다.
- 병동 생성 완료 시 남아 있던 `createWardPayload` 콘솔 로그를 제거해 운영 경로의 디버그 흔적을 정리했습니다.
- 숙련도 설정 모달의 `임시 저장` 문구를 실제 동작과 맞는 `취소`로 정리했습니다.

<br>

## To Reviewers

- 전체 `pnpm type-check`는 기존 `src/pages/RequestShiftPage/**` 타입 오류로 실패했고, 이번 티켓 변경 파일과는 무관해 수정하지 않았습니다.
- 온보딩 범위 검증으로 `adapter/index` 테스트와 변경 파일 대상 ESLint를 실행했습니다.


[DUT-851]: https://gom3.atlassian.net/browse/DUT-851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 기술 레벨 모달의 하단 좌측 버튼 레이블을 "취소"로 변경했습니다.

* **정리**
  * 내부 모의 데이터 생성 기능을 제거하고 제출 데이터 구조를 간소화했습니다.
  * 디버그 로깅을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->