### PR TITLE
[DUT-853]: 운영 코드 임시 로그 정리

### DIFF
--- a/src/features/account/useEditAccount.ts
+++ b/src/features/account/useEditAccount.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import {useQueryClient} from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import {type TNurse} from '@/entities/nurse';
@@ -30,7 +31,10 @@ const useEditAccount = () => {
             await queryClient.invalidateQueries({queryKey: getWardQueryKey});
             await handleGetAccountMe();
         } catch (e) {
-            console.error(e);
+            Sentry.captureException(e, {
+                tags: {feature: 'account', action: 'edit-profile'},
+                extra: {nurseId: nurse.nurseId, accountId: accountMe.accountId},
+            });
             toast.error('프로필 업데이트에 실패했습니다..');
         } finally {
             setLoading(false);
@@ -47,7 +51,10 @@ const useEditAccount = () => {
             await AccountAPI.editAccountStatus(accountMe.accountId, 'WARD_SELECT_PENDING');
             await handleGetAccountMe();
         } catch (e) {
-            console.error(e);
+            Sentry.captureException(e, {
+                tags: {feature: 'account', action: 'quit-ward'},
+                extra: {wardId: accountMe.wardId, accountId: accountMe.accountId},
+            });
             toast.error('병동 나가기에 실패했습니다..');
         } finally {
             setLoading(false);
@@ -63,7 +70,10 @@ const useEditAccount = () => {
             AccountAPI.deleteAccount(accountMe.accountId);
             handleLogout();
         } catch (e) {
-            console.error(e);
+            Sentry.captureException(e, {
+                tags: {feature: 'account', action: 'delete-account'},
+                extra: {accountId: accountMe.accountId},
+            });
             toast.error('계정 삭제에 실패했습니다..');
         } finally {
             setLoading(false);

--- a/src/features/account/useEditAccount.ts
+++ b/src/features/account/useEditAccount.ts
@@ -67,8 +67,8 @@ const useEditAccount = () => {
 
         try {
             setLoading(true);
-            AccountAPI.deleteAccount(accountMe.accountId);
-            handleLogout();
+            await AccountAPI.deleteAccount(accountMe.accountId);
+            await handleLogout();
         } catch (e) {
             Sentry.captureException(e, {
                 tags: {feature: 'account', action: 'delete-account'},

--- a/src/features/file/store.ts
+++ b/src/features/file/store.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import {AccountAPI} from '@/shared/api';
 import {createStore} from '@/shared/util/create-store';
 
@@ -36,7 +37,9 @@ export const initializeProfileImageStore = async () => {
             imageBaseUrl: match ? match[1] : DEFAULT_IMAGE_BASE_URL,
         });
     } catch (error) {
-        console.error('Failed to initialize profile image store:', error);
+        Sentry.captureException(error, {
+            tags: {feature: 'profile-image', action: 'initialize-store'},
+        });
         useProfileImageStore.setState({
             imageBaseUrl: DEFAULT_IMAGE_BASE_URL,
         });

--- a/src/features/file/useProfileImage.ts
+++ b/src/features/file/useProfileImage.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import {useState} from 'react';
 import toast from 'react-hot-toast';
 import {FileAPI} from '@/shared/api';
@@ -23,7 +24,10 @@ const useProfileImage = (initialImg?: {profileImgUrl?: string; defaultProfileImg
             await uploadImageToS3(presignedUrl, photo);
             setProfileImg({profileImgUrl: fileUrl});
         } catch (e) {
-            console.error(e);
+            Sentry.captureException(e, {
+                tags: {feature: 'profile-image', action: 'upload'},
+                extra: {extension},
+            });
             toast.error('프로필 이미지 업로드에 실패했습니다.');
         } finally {
             setIsLoading(false);

--- a/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
+++ b/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import {type DropResult} from '@hello-pangea/dnd';
 import {useEffect, useMemo, useState} from 'react';
 import toast from 'react-hot-toast';
@@ -145,11 +146,13 @@ function useOnboardingWardWizard() {
         try {
             const submission = await onboardingWardCreateExecutor(draft);
 
-            console.info('createWardPayload', submission.wardCreatePayload);
             setSubmissionStatus('success');
             toast.success(submission.successMessage);
         } catch (error) {
-            console.error('Failed to complete onboarding ward creation.', error);
+            Sentry.captureException(error, {
+                tags: {feature: 'onboarding-ward-create'},
+                extra: {step: draft.currentStep},
+            });
             setSubmissionStatus('error');
             setSubmissionError(error instanceof Error ? error.message : '병동 생성에 실패했습니다. 다시 시도해주세요.');
         }

--- a/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
+++ b/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.ts
@@ -1,5 +1,5 @@
-import * as Sentry from '@sentry/react';
 import {type DropResult} from '@hello-pangea/dnd';
+import * as Sentry from '@sentry/react';
 import {useEffect, useMemo, useState} from 'react';
 import toast from 'react-hot-toast';
 import useRegister from '@/features/auth/useRegister';

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -1,5 +1,6 @@
 import imageCompression from 'browser-image-compression';
 import {type ChangeEvent, useEffect, useRef, useState} from 'react';
+import toast from 'react-hot-toast';
 import {ProfileImage} from '@/entities/account/ui/profile-image';
 import {type TNurse} from '@/entities/nurse';
 import useEditAccount from '@/features/account/useEditAccount';
@@ -64,7 +65,7 @@ function ProfilePage() {
 
             setPhotoImage(compressedFile);
         } catch (error) {
-            console.log(error);
+            toast.error('프로필 이미지 처리에 실패했습니다.');
         }
     };
 

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -64,7 +64,7 @@ function ProfilePage() {
             const compressedFile = await imageCompression(e.target.files[0], options);
 
             setPhotoImage(compressedFile);
-        } catch (error) {
+        } catch (_error) {
             toast.error('프로필 이미지 처리에 실패했습니다.');
         }
     };

--- a/src/pages/RegisterPage/ui/RegisterNurse.tsx
+++ b/src/pages/RegisterPage/ui/RegisterNurse.tsx
@@ -79,7 +79,6 @@ function RegisterNurse() {
 
             setPhotoImage(compressedFile);
         } catch (error) {
-            console.error(error);
             toast.error('프로필 이미지 처리에 실패했습니다.');
         }
     };

--- a/src/pages/RegisterPage/ui/RegisterNurse.tsx
+++ b/src/pages/RegisterPage/ui/RegisterNurse.tsx
@@ -78,7 +78,7 @@ function RegisterNurse() {
             const compressedFile = await imageCompression(e.target.files[0], options);
 
             setPhotoImage(compressedFile);
-        } catch (error) {
+        } catch (_error) {
             toast.error('프로필 이미지 처리에 실패했습니다.');
         }
     };

--- a/src/shared/util/event.ts
+++ b/src/shared/util/event.ts
@@ -35,10 +35,3 @@ const wrapWithGAEvent =
 
         return fn(...args);
     };
-// 사용 예시
-const myFunction = (message: string) => {
-    console.log(message);
-};
-const wrappedFunction = wrapWithGAEvent(myFunction, EVENTS.LOGIN_PAGE.LOGIN);
-
-wrappedFunction('로그인 성공!');


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-853](https://gom3.atlassian.net/browse/DUT-853)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `src/pages/**`, `src/features/**`, `src/shared/util/**` 범위의 임시 `console.log`/`console.info` 출력과 예제성 디버그 코드를 제거했습니다.
- 사용자 액션 실패 시 장애 파악 가치가 있는 경로는 `console.error` 대신 `Sentry.captureException`으로 전환해 운영 관측 신호를 유지했습니다.
- 전체 `src` 검색 기준으로 남은 `console`은 `TutorialOverlay`의 누락 DOM 탐지 1건뿐이며, 이번 티켓 범위 밖의 의도된 에러 보고로 남겨두었습니다.

<br>

## To Reviewers

- `pnpm exec eslint`와 `pnpm type-check`는 worktree 환경에서 의존성 해석이 되지 않아 정상 실행되지 않았습니다. 변경 파일 diff와 `rg "console" src` 재검색으로 범위 내 정리를 확인했습니다.
- `useEditAccount`의 `deleteAccount`는 기존처럼 `await` 없이 호출되고 있어 이번 PR에서는 로그 정리 범위만 유지했습니다.


[DUT-853]: https://gom3.atlassian.net/browse/DUT-853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ