### PR TITLE
[DUT-866]: 신청근무 피드백 UX 정리

### DIFF
--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -1,6 +1,6 @@
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {produce} from 'immer';
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import {match} from 'ts-pattern';
 import {events, sendEvent} from '@/analytics';
 import {type TRequestShift} from '@/entities/shift';
@@ -25,6 +25,7 @@ const useRequestShift = (activeEffect = false) => {
         wardShiftTypeMap,
         readonly,
         changeStatus,
+        updatingRequestId,
         setState,
     } = useRequestShiftStore();
     const {
@@ -39,6 +40,27 @@ const useRequestShift = (activeEffect = false) => {
     const shiftTeamQueryKey = shiftTeamsQueryOptions.queryKey;
     const wardConstraintQueryKey = wardConstraintQueryOptions.queryKey;
     const dutyRequestQueryKey = requestListQueryOptions.queryKey;
+    const changeStatusResetTimerRef = useRef<number | null>(null);
+    const clearChangeStatusResetTimer = useCallback(() => {
+        if (changeStatusResetTimerRef.current !== null) {
+            window.clearTimeout(changeStatusResetTimerRef.current);
+            changeStatusResetTimerRef.current = null;
+        }
+    }, []);
+    const setChangeStatusWithAutoReset = useCallback(
+        (status: 'idle' | 'loading' | 'success' | 'error') => {
+            clearChangeStatusResetTimer();
+            setState('changeStatus', status);
+
+            if (status === 'loading' || status === 'idle') return;
+
+            changeStatusResetTimerRef.current = window.setTimeout(() => {
+                setState('changeStatus', 'idle');
+                changeStatusResetTimerRef.current = null;
+            }, 2400);
+        },
+        [clearChangeStatusResetTimer, setState],
+    );
     const {
         data: shiftTeams,
         status: shiftTeamsStatus,
@@ -101,7 +123,9 @@ const useRequestShift = (activeEffect = false) => {
         async (focus: TFocus, shiftTypeId: number | null) => {
             if (!wardId) return;
 
-            setState('changeStatus', 'loading');
+            if (useRequestShiftStore.getState().changeStatus === 'loading') return;
+
+            setChangeStatusWithAutoReset('loading');
             await queryClient.cancelQueries({queryKey: requestShiftQueryKey});
 
             const {shiftNurseId, day} = focus;
@@ -140,22 +164,24 @@ const useRequestShift = (activeEffect = false) => {
 
             try {
                 await WardAPI.updateReqShift(wardId, year, month, focus.day + 1, focus.shiftNurseId, shiftTypeId);
-                setState('changeStatus', 'success');
-                setTimeout(() => setState('changeStatus', 'idle'), 0);
+                setChangeStatusWithAutoReset('success');
             } catch {
                 if (oldShift) {
                     queryClient.setQueryData(requestShiftQueryKey, oldShift);
                 }
 
-                setState('changeStatus', 'error');
-                setTimeout(() => setState('changeStatus', 'idle'), 0);
+                setChangeStatusWithAutoReset('error');
             }
         },
-        [queryClient, requestShiftQueryKey, setState, wardId, wardShiftTypeMap, year, month],
+        [queryClient, requestShiftQueryKey, setChangeStatusWithAutoReset, wardId, wardShiftTypeMap, year, month],
     );
     const acceptRequest = useCallback(
         async (reqShiftId: number, isAccepted: boolean | null) => {
             if (!wardId) return;
+
+            if (useRequestShiftStore.getState().updatingRequestId !== null) return;
+
+            setState('updatingRequestId', reqShiftId);
 
             try {
                 await WardAPI.acceptRequestShift(wardId, reqShiftId, isAccepted);
@@ -163,9 +189,11 @@ const useRequestShift = (activeEffect = false) => {
                 await queryClient.invalidateQueries({queryKey: dutyRequestQueryKey});
             } catch (error) {
                 showActionErrorFeedback(error, '신청 처리에 실패했습니다.');
+            } finally {
+                setState('updatingRequestId', null);
             }
         },
-        [dutyRequestQueryKey, queryClient, requestShiftQueryKey, wardId],
+        [dutyRequestQueryKey, queryClient, requestShiftQueryKey, setState, wardId],
     );
     const changeMonth = (type: 'prev' | 'next') => {
         if (type === 'prev') {
@@ -340,6 +368,13 @@ const useRequestShift = (activeEffect = false) => {
         };
     }, [activeEffect, focus, requestShift, handleKeyDown]);
 
+    useEffect(
+        () => () => {
+            clearChangeStatusResetTimer();
+        },
+        [clearChangeStatusResetTimer],
+    );
+
     return {
         queryKey: {
             requestShiftQueryKey,
@@ -359,6 +394,7 @@ const useRequestShift = (activeEffect = false) => {
             dutyRequestStatus,
             wardShiftTypeMap,
             readonly,
+            updatingRequestId,
             currentShiftTeam: shiftTeams?.find((x) => x.shiftTeamId === currentShiftTeamId) as TShiftTeam | null,
             shiftTeams,
         },

--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -41,6 +41,8 @@ const useRequestShift = (activeEffect = false) => {
     const wardConstraintQueryKey = wardConstraintQueryOptions.queryKey;
     const dutyRequestQueryKey = requestListQueryOptions.queryKey;
     const changeStatusResetTimerRef = useRef<number | null>(null);
+    const requestShiftChangeQueueRef = useRef<Array<{focus: TFocus; shiftTypeId: number | null}>>([]);
+    const isProcessingRequestShiftQueueRef = useRef(false);
     const clearChangeStatusResetTimer = useCallback(() => {
         if (changeStatusResetTimerRef.current !== null) {
             window.clearTimeout(changeStatusResetTimerRef.current);
@@ -61,6 +63,89 @@ const useRequestShift = (activeEffect = false) => {
         },
         [clearChangeStatusResetTimer, setState],
     );
+    const applyRequestShiftChangeToCache = useCallback(
+        (focus: TFocus, shiftTypeId: number | null) => {
+            const {shiftNurseId, day} = focus;
+            const currentShift = queryClient.getQueryData<TRequestShift>(requestShiftQueryKey);
+
+            if (!currentShift) return;
+
+            const currentShiftTypeId = currentShift.divisionShiftNurses
+                .flatMap((division) => division)
+                .find((row) => row.shiftNurse.shiftNurseId === shiftNurseId)?.wardReqShiftList[focus.day];
+
+            if (currentShiftTypeId === undefined || currentShiftTypeId === shiftTypeId) return;
+
+            if (wardShiftTypeMap) {
+                const edit = {
+                    nurseName: findNurse(currentShift, focus.shiftNurseId)!.name,
+                    focus,
+                    prevShiftType: currentShiftTypeId ? (wardShiftTypeMap.get(currentShiftTypeId) as TWardShiftType) : null,
+                    nextShiftType: shiftTypeId ? (wardShiftTypeMap.get(shiftTypeId) as TWardShiftType) : null,
+                    dateString: DateUtil.getDateString(new Date(), 'yyyy-MM-dd HH:mm:ss'),
+                };
+
+                sendEvent(
+                    events.requestPage.changeShift,
+                    `${focus.shiftNurseName} / ${day + 1}일 | ` +
+                        match(edit)
+                            .with({prevShiftType: null}, () => `추가 → ${edit.nextShiftType?.shortName}`)
+                            .with({nextShiftType: null}, () => `${edit.prevShiftType?.shortName} → 삭제`)
+                            .otherwise(() => `${edit.prevShiftType?.shortName} → ${edit.nextShiftType?.shortName}`),
+                );
+            }
+
+            queryClient.setQueryData<TRequestShift>(
+                requestShiftQueryKey,
+                produce(currentShift, (draft) => {
+                    draft.divisionShiftNurses
+                        .flatMap((division) => division)
+                        .find((row) => row.shiftNurse.shiftNurseId === shiftNurseId)!.wardReqShiftList[focus.day] = shiftTypeId;
+                }),
+            );
+        },
+        [queryClient, requestShiftQueryKey, wardShiftTypeMap],
+    );
+    const flushRequestShiftChangeQueue = useCallback(async () => {
+        if (isProcessingRequestShiftQueueRef.current || !wardId) return;
+
+        isProcessingRequestShiftQueueRef.current = true;
+        setChangeStatusWithAutoReset('loading');
+
+        let hasError = false;
+
+        while (requestShiftChangeQueueRef.current.length > 0) {
+            const nextChange = requestShiftChangeQueueRef.current.shift();
+
+            if (!nextChange) continue;
+
+            try {
+                await WardAPI.updateReqShift(
+                    wardId,
+                    year,
+                    month,
+                    nextChange.focus.day + 1,
+                    nextChange.focus.shiftNurseId,
+                    nextChange.shiftTypeId,
+                );
+            } catch {
+                hasError = true;
+            }
+        }
+
+        if (hasError) {
+            await queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
+            setChangeStatusWithAutoReset('error');
+        } else {
+            setChangeStatusWithAutoReset('success');
+        }
+
+        isProcessingRequestShiftQueueRef.current = false;
+
+        if (requestShiftChangeQueueRef.current.length > 0) {
+            void flushRequestShiftChangeQueue();
+        }
+    }, [month, queryClient, requestShiftQueryKey, setChangeStatusWithAutoReset, wardId, year]);
     const {
         data: shiftTeams,
         status: shiftTeamsStatus,
@@ -123,57 +208,13 @@ const useRequestShift = (activeEffect = false) => {
         async (focus: TFocus, shiftTypeId: number | null) => {
             if (!wardId) return;
 
-            if (useRequestShiftStore.getState().changeStatus === 'loading') return;
-
-            setChangeStatusWithAutoReset('loading');
             await queryClient.cancelQueries({queryKey: requestShiftQueryKey});
+            applyRequestShiftChangeToCache(focus, shiftTypeId);
+            requestShiftChangeQueueRef.current.push({focus, shiftTypeId});
 
-            const {shiftNurseId, day} = focus;
-            const oldShift = queryClient.getQueryData<TRequestShift>(requestShiftQueryKey);
-
-            if (oldShift && wardShiftTypeMap) {
-                const oldShiftTypeId = oldShift.divisionShiftNurses
-                    .flatMap((x) => x)
-                    .find((x) => x.shiftNurse.shiftNurseId === shiftNurseId)!.wardReqShiftList[focus.day];
-                const edit = {
-                    nurseName: findNurse(oldShift, focus.shiftNurseId)!.name,
-                    focus,
-                    prevShiftType: oldShiftTypeId ? (wardShiftTypeMap.get(oldShiftTypeId) as TWardShiftType) : null,
-                    nextShiftType: shiftTypeId ? (wardShiftTypeMap.get(shiftTypeId) as TWardShiftType) : null,
-                    dateString: DateUtil.getDateString(new Date(), 'yyyy-MM-dd HH:mm:ss'),
-                };
-
-                queryClient.setQueryData<TRequestShift>(
-                    requestShiftQueryKey,
-                    produce(oldShift, (draft) => {
-                        draft.divisionShiftNurses
-                            .flatMap((x) => x)
-                            .find((x) => x.shiftNurse.shiftNurseId === focus.shiftNurseId)!.wardReqShiftList[focus.day] = shiftTypeId;
-                    }),
-                );
-
-                sendEvent(
-                    events.requestPage.changeShift,
-                    `${focus.shiftNurseName} / ${day + 1}일 | ` +
-                        match(edit)
-                            .with({prevShiftType: null}, () => `추가 → ${edit.nextShiftType?.shortName}`)
-                            .with({nextShiftType: null}, () => `${edit.prevShiftType?.shortName} → 삭제`)
-                            .otherwise(() => `${edit.prevShiftType?.shortName} → ${edit.nextShiftType?.shortName}`),
-                );
-            }
-
-            try {
-                await WardAPI.updateReqShift(wardId, year, month, focus.day + 1, focus.shiftNurseId, shiftTypeId);
-                setChangeStatusWithAutoReset('success');
-            } catch {
-                if (oldShift) {
-                    queryClient.setQueryData(requestShiftQueryKey, oldShift);
-                }
-
-                setChangeStatusWithAutoReset('error');
-            }
+            void flushRequestShiftChangeQueue();
         },
-        [queryClient, requestShiftQueryKey, setChangeStatusWithAutoReset, wardId, wardShiftTypeMap, year, month],
+        [applyRequestShiftChangeToCache, flushRequestShiftChangeQueue, queryClient, requestShiftQueryKey, wardId],
     );
     const acceptRequest = useCallback(
         async (reqShiftId: number, isAccepted: boolean | null) => {

--- a/src/features/shift/useRequestShift/store.ts
+++ b/src/features/shift/useRequestShift/store.ts
@@ -14,6 +14,7 @@ interface IState {
     wardShiftTypeMap: Map<number, TWardShiftType> | null;
     readonly: boolean;
     changeStatus: 'idle' | 'loading' | 'success' | 'error';
+    updatingRequestId: number | null;
 }
 
 interface IStore extends IState {
@@ -31,6 +32,7 @@ const initialState: IState = {
     wardShiftTypeMap: null,
     readonly: true,
     changeStatus: 'idle',
+    updatingRequestId: null,
 };
 
 export const useRequestShiftStore = create<IStore>()(

--- a/src/pages/RequestShiftPage/ui/RequestCalendar.tsx
+++ b/src/pages/RequestShiftPage/ui/RequestCalendar.tsx
@@ -1,4 +1,5 @@
-import {type DropResult, useRef} from 'react';
+import {type DropResult} from '@hello-pangea/dnd';
+import {useRef} from 'react';
 import useOnclickOutside from 'react-cool-onclickoutside';
 import {events, sendEvent} from '@/analytics';
 import {useUIConfigStore} from '@/entities/ui/useUIConfig/store';
@@ -27,6 +28,7 @@ export default function ShiftCalendar() {
             requestShift,
             dutyRequestList,
             dutyRequestStatus,
+            updatingRequestId,
             focus,
             foldedLevels,
             wardShiftTypeMap,
@@ -119,6 +121,7 @@ export default function ShiftCalendar() {
                 wardShiftTypeMap={wardShiftTypeMap}
                 unresolvedRequestCount={unresolvedRequestCount}
                 readonly={readonly}
+                updatingRequestId={updatingRequestId}
                 shiftNurseIdByNurseId={shiftNurseIdByNurseId}
                 changeFocus={changeFocus}
                 acceptRequest={acceptRequest}

--- a/src/pages/RequestShiftPage/ui/Toolbar.tsx
+++ b/src/pages/RequestShiftPage/ui/Toolbar.tsx
@@ -1,3 +1,4 @@
+import {TriangleAlert} from 'lucide-react';
 import {events, sendEvent} from '@/analytics';
 import useRequestShift from '@/features/shift/useRequestShift';
 import {NextIcon, PenIcon, PrevIcon, SaveCompleteIcon, SavingIcon} from '@/shared/assets/svg';
@@ -86,7 +87,13 @@ function Toolbar() {
                         )}
                         aria-live="polite"
                     >
-                        {isSaving ? <SavingIcon className="h-5 w-5" /> : <SaveCompleteIcon className="h-5 w-5" />}
+                        {changeStatus === 'loading' ? (
+                            <SavingIcon className="h-5 w-5" />
+                        ) : changeStatus === 'error' ? (
+                            <TriangleAlert className="h-5 w-5" strokeWidth={2.2} />
+                        ) : (
+                            <SaveCompleteIcon className="h-5 w-5" />
+                        )}
                         {SAVE_STATUS_LABEL[changeStatus]}
                     </div>
                 ) : null}

--- a/src/pages/RequestShiftPage/ui/Toolbar.tsx
+++ b/src/pages/RequestShiftPage/ui/Toolbar.tsx
@@ -3,12 +3,19 @@ import useRequestShift from '@/features/shift/useRequestShift';
 import {NextIcon, PenIcon, PrevIcon, SaveCompleteIcon, SavingIcon} from '@/shared/assets/svg';
 import Button from '@/shared/ui/form-controls/Button';
 import Select from '@/shared/ui/form-controls/Select';
+import {cn} from '@/shared/util/style';
 
 const SAVE_STATUS_LABEL: Record<'idle' | 'loading' | 'success' | 'error', string> = {
-    idle: '변경 사항 없음',
-    loading: '저장 중',
-    success: '저장 완료',
-    error: '저장 실패',
+    idle: '변경하면 자동 저장돼요',
+    loading: '변경 내용을 저장하는 중이에요',
+    success: '최근 변경을 저장했어요',
+    error: '최근 변경 저장에 실패했어요',
+};
+const SAVE_STATUS_STYLE: Record<'idle' | 'loading' | 'success' | 'error', string> = {
+    idle: 'bg-gray-7 text-gray-3',
+    loading: 'bg-main-light text-main-1',
+    success: 'bg-[#E9F8EF] text-[#237A4B]',
+    error: 'bg-[#FFF0F0] text-sub-2',
 };
 
 function Toolbar() {
@@ -16,6 +23,7 @@ function Toolbar() {
         state: {month, changeStatus, currentShiftTeam, shiftTeams, readonly},
         actions: {changeMonth, changeShiftTeam, toggleEditMode},
     } = useRequestShift();
+    const isSaving = changeStatus === 'loading';
 
     return (
         <div
@@ -26,11 +34,12 @@ function Toolbar() {
                 <div className="flex items-center gap-2">
                     <button
                         type="button"
-                        className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1"
+                        className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-5"
                         onClick={() => {
                             changeMonth('prev');
                             sendEvent(events.requestPage.toolbar.changeMonth);
                         }}
+                        disabled={isSaving}
                         aria-label="이전 달 보기"
                     >
                         <PrevIcon className="h-7.5 w-7.5" />
@@ -38,11 +47,12 @@ function Toolbar() {
                     <p className="min-w-[6rem] text-center font-apple text-2xl font-semibold text-main-1">{month}월</p>
                     <button
                         type="button"
-                        className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1"
+                        className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-5"
                         onClick={() => {
                             changeMonth('next');
                             sendEvent(events.requestPage.toolbar.changeMonth);
                         }}
+                        disabled={isSaving}
                         aria-label="다음 달 보기"
                     >
                         <NextIcon className="h-7.5 w-7.5" />
@@ -58,6 +68,7 @@ function Toolbar() {
                         }))}
                         className="h-11 w-full md:w-[220px]"
                         selectClassName="rounded-[14px] border border-gray-6 bg-gray-7 px-4 font-apple text-base font-semibold text-sub-1 outline-none"
+                        disabled={isSaving}
                         onChange={(e) => {
                             changeShiftTeam(shiftTeams!.find((shiftTeam) => shiftTeam.shiftTeamId === parseInt(e.target.value, 10))!);
                             sendEvent(events.requestPage.toolbar.changeShiftTeam);
@@ -68,8 +79,14 @@ function Toolbar() {
 
             <div className="flex flex-col gap-3 md:flex-row md:items-center">
                 {!readonly ? (
-                    <div className="flex items-center gap-2 rounded-[12px] bg-gray-7 px-4 py-2 font-apple text-sm font-medium text-gray-3">
-                        {changeStatus === 'loading' ? <SavingIcon className="h-5 w-5" /> : <SaveCompleteIcon className="h-5 w-5" />}
+                    <div
+                        className={cn(
+                            'flex items-center gap-2 rounded-[12px] px-4 py-2 font-apple text-sm font-medium transition-colors',
+                            SAVE_STATUS_STYLE[changeStatus],
+                        )}
+                        aria-live="polite"
+                    >
+                        {isSaving ? <SavingIcon className="h-5 w-5" /> : <SaveCompleteIcon className="h-5 w-5" />}
                         {SAVE_STATUS_LABEL[changeStatus]}
                     </div>
                 ) : null}
@@ -94,12 +111,13 @@ function Toolbar() {
                             type="button"
                             size="md"
                             className="h-11 rounded-[14px] px-5 font-semibold"
+                            disabled={isSaving}
                             onClick={() => {
                                 toggleEditMode();
                                 sendEvent(events.requestPage.toolbar.changeEditMode, 'save');
                             }}
                         >
-                            저장하기
+                            {isSaving ? '저장 중...' : '완료'}
                         </Button>
                     )}
                 </div>

--- a/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
+++ b/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
@@ -13,6 +13,7 @@ interface IRequestDutyRequestPanelProps {
     wardShiftTypeMap: Map<number, TWardShiftType>;
     unresolvedRequestCount: number;
     readonly: boolean;
+    updatingRequestId: number | null;
     shiftNurseIdByNurseId: Map<number, number>;
     changeFocus: (focus: TFocus | null) => void;
     acceptRequest: (reqShiftId: number, isAccepted: boolean | null) => void;
@@ -26,6 +27,7 @@ export default function RequestDutyRequestPanel({
     wardShiftTypeMap,
     unresolvedRequestCount,
     readonly,
+    updatingRequestId,
     shiftNurseIdByNurseId,
     changeFocus,
     acceptRequest,
@@ -68,6 +70,7 @@ export default function RequestDutyRequestPanel({
                     <div className="space-y-3">
                         {dutyRequestList.map((dutyRequest) => {
                             const requestFocus = getRequestFocus(dutyRequest, shiftNurseIdByNurseId);
+                            const isUpdating = updatingRequestId === dutyRequest.wardReqShiftId;
 
                             return (
                                 <div key={dutyRequest.wardReqShiftId} className="rounded-[16px] border border-gray-6 px-4 py-3">
@@ -91,7 +94,7 @@ export default function RequestDutyRequestPanel({
                                             <div className="mt-2 flex items-center gap-2">
                                                 <ShiftBadge shiftType={wardShiftTypeMap.get(dutyRequest.wardShiftTypeId)} />
                                                 <p className="font-apple text-sm font-medium text-gray-4">
-                                                    {getDutyRequestStatusLabel(dutyRequest.isAccepted)}
+                                                    {isUpdating ? '처리 중...' : getDutyRequestStatusLabel(dutyRequest.isAccepted)}
                                                 </p>
                                             </div>
                                         </div>
@@ -102,8 +105,10 @@ export default function RequestDutyRequestPanel({
                                             type="button"
                                             className={twMerge(
                                                 'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
+                                                isUpdating && 'cursor-wait opacity-60',
                                                 dutyRequest.isAccepted === true && 'bg-main-1 text-white',
                                             )}
+                                            disabled={isUpdating}
                                             onClick={() => {
                                                 acceptRequest(dutyRequest.wardReqShiftId, true);
                                                 onAcceptAnalytics(true);
@@ -115,8 +120,10 @@ export default function RequestDutyRequestPanel({
                                             type="button"
                                             className={twMerge(
                                                 'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
+                                                isUpdating && 'cursor-wait opacity-60',
                                                 dutyRequest.isAccepted === false && 'bg-sub-2 text-white',
                                             )}
+                                            disabled={isUpdating}
                                             onClick={() => {
                                                 acceptRequest(dutyRequest.wardReqShiftId, false);
                                                 onAcceptAnalytics(false);

--- a/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
+++ b/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
@@ -34,6 +34,8 @@ export default function RequestDutyRequestPanel({
     retry,
     onAcceptAnalytics,
 }: IRequestDutyRequestPanelProps) {
+    const isRequestActionLocked = updatingRequestId !== null;
+
     return (
         <Card
             id="nurse_request_list"
@@ -105,11 +107,13 @@ export default function RequestDutyRequestPanel({
                                             type="button"
                                             className={twMerge(
                                                 'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
-                                                isUpdating && 'cursor-wait opacity-60',
+                                                isRequestActionLocked && 'cursor-wait opacity-60',
                                                 dutyRequest.isAccepted === true && 'bg-main-1 text-white',
                                             )}
-                                            disabled={isUpdating}
+                                            disabled={isRequestActionLocked}
                                             onClick={() => {
+                                                if (isRequestActionLocked) return;
+
                                                 acceptRequest(dutyRequest.wardReqShiftId, true);
                                                 onAcceptAnalytics(true);
                                             }}
@@ -120,11 +124,13 @@ export default function RequestDutyRequestPanel({
                                             type="button"
                                             className={twMerge(
                                                 'flex h-9 flex-1 items-center justify-center rounded-[10px] font-apple text-sm font-semibold text-gray-3 transition-colors',
-                                                isUpdating && 'cursor-wait opacity-60',
+                                                isRequestActionLocked && 'cursor-wait opacity-60',
                                                 dutyRequest.isAccepted === false && 'bg-sub-2 text-white',
                                             )}
-                                            disabled={isUpdating}
+                                            disabled={isRequestActionLocked}
                                             onClick={() => {
+                                                if (isRequestActionLocked) return;
+
                                                 acceptRequest(dutyRequest.wardReqShiftId, false);
                                                 onAcceptAnalytics(false);
                                             }}

--- a/src/pages/RequestShiftPage/ui/request-calendar/utils.test.ts
+++ b/src/pages/RequestShiftPage/ui/request-calendar/utils.test.ts
@@ -2,82 +2,81 @@ import {describe, expect, it} from 'vitest';
 import {type TRequestShift} from '@/entities/shift';
 import {getMoveNurseOrderPayload, getRequestFocus} from './utils';
 
-const createRequestShift = (): TRequestShift =>
-    ({
-        days: [],
-        wardShiftTypes: [],
-        divisionShiftNurses: [
-            [
-                {
-                    shiftNurse: {
-                        shiftNurseId: 11,
-                        nurseId: 101,
-                        name: '간호사 1',
-                        carried: false,
-                        isWorker: true,
-                        divisionNum: 1,
-                        priority: 100,
-                    },
-                    carry: 0,
-                    wardReqShiftList: [],
+const createRequestShift = (): TRequestShift => ({
+    days: [],
+    wardShiftTypes: [],
+    divisionShiftNurses: [
+        [
+            {
+                shiftNurse: {
+                    shiftNurseId: 11,
+                    nurseId: 101,
+                    name: '간호사 1',
+                    carried: 0,
+                    isWorker: true,
+                    divisionNum: 1,
+                    priority: 100,
                 },
-                {
-                    shiftNurse: {
-                        shiftNurseId: 12,
-                        nurseId: 102,
-                        name: '간호사 2',
-                        carried: false,
-                        isWorker: true,
-                        divisionNum: 1,
-                        priority: 200,
-                    },
-                    carry: 0,
-                    wardReqShiftList: [],
+                carry: 0,
+                wardReqShiftList: [],
+            },
+            {
+                shiftNurse: {
+                    shiftNurseId: 12,
+                    nurseId: 102,
+                    name: '간호사 2',
+                    carried: 0,
+                    isWorker: true,
+                    divisionNum: 1,
+                    priority: 200,
                 },
-                {
-                    shiftNurse: {
-                        shiftNurseId: 13,
-                        nurseId: 103,
-                        name: '간호사 3',
-                        carried: false,
-                        isWorker: true,
-                        divisionNum: 1,
-                        priority: 300,
-                    },
-                    carry: 0,
-                    wardReqShiftList: [],
+                carry: 0,
+                wardReqShiftList: [],
+            },
+            {
+                shiftNurse: {
+                    shiftNurseId: 13,
+                    nurseId: 103,
+                    name: '간호사 3',
+                    carried: 0,
+                    isWorker: true,
+                    divisionNum: 1,
+                    priority: 300,
                 },
-            ],
-            [
-                {
-                    shiftNurse: {
-                        shiftNurseId: 21,
-                        nurseId: 201,
-                        name: '간호사 4',
-                        carried: false,
-                        isWorker: true,
-                        divisionNum: 2,
-                        priority: 400,
-                    },
-                    carry: 0,
-                    wardReqShiftList: [],
-                },
-                {
-                    shiftNurse: {
-                        shiftNurseId: 22,
-                        nurseId: 202,
-                        name: '간호사 5',
-                        carried: false,
-                        isWorker: true,
-                        divisionNum: 2,
-                        priority: 500,
-                    },
-                    carry: 0,
-                    wardReqShiftList: [],
-                },
-            ],
+                carry: 0,
+                wardReqShiftList: [],
+            },
         ],
-    }) as unknown as TRequestShift;
+        [
+            {
+                shiftNurse: {
+                    shiftNurseId: 21,
+                    nurseId: 201,
+                    name: '간호사 4',
+                    carried: 0,
+                    isWorker: true,
+                    divisionNum: 2,
+                    priority: 400,
+                },
+                carry: 0,
+                wardReqShiftList: [],
+            },
+            {
+                shiftNurse: {
+                    shiftNurseId: 22,
+                    nurseId: 202,
+                    name: '간호사 5',
+                    carried: 0,
+                    isWorker: true,
+                    divisionNum: 2,
+                    priority: 500,
+                },
+                carry: 0,
+                wardReqShiftList: [],
+            },
+        ],
+    ],
+});
 
 describe('request-calendar utils', () => {
     it('같은 division 안에서 아래로 이동할 때 다음 우선순위를 기준으로 계산한다', () => {

--- a/src/pages/RequestShiftPage/ui/request-calendar/utils.test.ts
+++ b/src/pages/RequestShiftPage/ui/request-calendar/utils.test.ts
@@ -12,6 +12,9 @@ const createRequestShift = (): TRequestShift =>
                     shiftNurse: {
                         shiftNurseId: 11,
                         nurseId: 101,
+                        name: '간호사 1',
+                        carried: false,
+                        isWorker: true,
                         divisionNum: 1,
                         priority: 100,
                     },
@@ -22,6 +25,9 @@ const createRequestShift = (): TRequestShift =>
                     shiftNurse: {
                         shiftNurseId: 12,
                         nurseId: 102,
+                        name: '간호사 2',
+                        carried: false,
+                        isWorker: true,
                         divisionNum: 1,
                         priority: 200,
                     },
@@ -32,6 +38,9 @@ const createRequestShift = (): TRequestShift =>
                     shiftNurse: {
                         shiftNurseId: 13,
                         nurseId: 103,
+                        name: '간호사 3',
+                        carried: false,
+                        isWorker: true,
                         divisionNum: 1,
                         priority: 300,
                     },
@@ -44,6 +53,9 @@ const createRequestShift = (): TRequestShift =>
                     shiftNurse: {
                         shiftNurseId: 21,
                         nurseId: 201,
+                        name: '간호사 4',
+                        carried: false,
+                        isWorker: true,
                         divisionNum: 2,
                         priority: 400,
                     },
@@ -54,6 +66,9 @@ const createRequestShift = (): TRequestShift =>
                     shiftNurse: {
                         shiftNurseId: 22,
                         nurseId: 202,
+                        name: '간호사 5',
+                        carried: false,
+                        isWorker: true,
                         divisionNum: 2,
                         priority: 500,
                     },
@@ -62,7 +77,7 @@ const createRequestShift = (): TRequestShift =>
                 },
             ],
         ],
-    }) as TRequestShift;
+    }) as unknown as TRequestShift;
 
 describe('request-calendar utils', () => {
     it('같은 division 안에서 아래로 이동할 때 다음 우선순위를 기준으로 계산한다', () => {

--- a/src/pages/RequestShiftPage/ui/request-calendar/utils.ts
+++ b/src/pages/RequestShiftPage/ui/request-calendar/utils.ts
@@ -95,7 +95,11 @@ export const getMoveNurseOrderPayload = ({
     draggableId,
     requestShift,
     source,
-}: DropResult & {
+}: Pick<DropResult, 'destination' | 'draggableId' | 'source'> & {
+    type?: DropResult['type'];
+    reason?: DropResult['reason'];
+    mode?: DropResult['mode'];
+    combine?: DropResult['combine'];
     requestShift: TRequestShift;
 }): TMoveNurseOrderPayload | null => {
     if (!destination) return null;

--- a/src/pages/RequestShiftPage/ui/request-calendar/utils.ts
+++ b/src/pages/RequestShiftPage/ui/request-calendar/utils.ts
@@ -96,12 +96,8 @@ export const getMoveNurseOrderPayload = ({
     requestShift,
     source,
 }: Pick<DropResult, 'destination' | 'draggableId' | 'source'> & {
-    type?: DropResult['type'];
-    reason?: DropResult['reason'];
-    mode?: DropResult['mode'];
-    combine?: DropResult['combine'];
     requestShift: TRequestShift;
-}): TMoveNurseOrderPayload | null => {
+} & Partial<Omit<DropResult, 'destination' | 'draggableId' | 'source'>>): TMoveNurseOrderPayload | null => {
     if (!destination) return null;
 
     const sourceDivision = Number.parseInt(source.droppableId, 10);


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-866](https://gom3.atlassian.net/browse/DUT-866)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 신청근무 편집 중 상태 문구를 자동 저장 흐름에 맞게 재정리하고, 저장 중에는 월 이동·팀 변경·완료 버튼을 잠가 중복 액션을 막았습니다.
- 셀 변경 저장 성공/실패 상태가 즉시 사라지지 않도록 조정해, 최근 변경 반영 여부를 툴바에서 명확히 확인할 수 있게 했습니다.
- 신청 내역 수락/거절 처리 중인 행에는 `처리 중...` 표시와 버튼 비활성화를 추가해 중복 클릭을 방지했습니다.
- 요청 캘린더 유틸 타입과 테스트 목을 현재 타입 정의에 맞게 정리했습니다.

<br>

## To Reviewers

- `저장하기` 버튼 라벨은 실제 동작에 맞춰 `완료`로 바꿨고, 셀 변경은 계속 즉시 저장됩니다.
- `pnpm eslint ...`와 `pnpm test:run src/pages/RequestShiftPage/ui/request-calendar/utils.test.ts`는 통과했습니다.
- `pnpm type-check`는 기존 `src/shared/util/event.ts` 미사용 선언 2건 때문에 실패합니다. 이번 변경 범위와는 무관합니다.


[DUT-866]: https://gom3.atlassian.net/browse/DUT-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 근무 변경 요청 중 중복 요청 방지 기능 추가
  * 요청 수락/거절 시 동시 작업 차단 기능 개선

* **개선 사항**
  * 근무 요청 처리 중 UI 상태 피드백 강화 (로딩 표시, 버튼 비활성화)
  * 상태 표시기 텍스트 및 스타일 업데이트
  * 요청 처리 중 네비게이션 버튼 및 선택 요소 비활성화
  * 요청 처리 완료 후 자동 상태 초기화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->