### PR TITLE
[DUT-869]: 간호사 추가 수정 UX 정리

### DIFF
--- a/src/features/ward/useEditShiftTeam/index.ts
+++ b/src/features/ward/useEditShiftTeam/index.ts
@@ -1,6 +1,7 @@
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {produce} from 'immer';
 import {useCallback} from 'react';
+import toast from 'react-hot-toast';
 import {type TRequestShift, type TShift} from '@/entities/shift';
 import {type TWard} from '@/entities/ward';
 import {wardQueryKeys, wardQueryOptions} from '@/entities/ward/model/queries';
@@ -13,7 +14,8 @@ import {showActionErrorFeedback} from '@/shared/util/feedback';
 import useEditNurseStore from './store';
 
 const useEditShiftTeam = () => {
-    const {selectedNurseId, setState} = useEditNurseStore();
+    const {selectedNurseId, selectedNurseDrawerMode, isNurseDraftDirty, nurseSaveStatus, isAddingNurse, isDeletingNurse, patch} =
+        useEditNurseStore();
     const {
         state: {wardId},
     } = useAuth();
@@ -40,8 +42,12 @@ const useEditShiftTeam = () => {
         async (shiftTeamId: number) => {
             if (!wardId) return;
 
+            patch({
+                isAddingNurse: true,
+            });
+
             try {
-                await WardAPI.addNurseIntoShiftTeam(wardId, shiftTeamId, {
+                const nurse = await WardAPI.addNurseIntoShiftTeam(wardId, shiftTeamId, {
                     name: `간호사${Math.floor(Math.random() * 10000)}`,
                     phoneNum: '01012345678',
                     gender: '여',
@@ -51,38 +57,104 @@ const useEditShiftTeam = () => {
                     isWardManager: false,
                     memo: '',
                 });
+
+                patch({
+                    selectedNurseId: nurse.nurseId,
+                    selectedNurseDrawerMode: 'create',
+                    isNurseDraftDirty: false,
+                    nurseSaveStatus: 'idle',
+                });
+
+                toast.success('새 간호사를 추가했어요. 이름과 연락처를 확인한 뒤 저장해 주세요.');
                 await invalidateWard();
             } catch (error) {
                 showActionErrorFeedback(error, '간호사 추가에 실패했습니다.');
+            } finally {
+                patch({
+                    isAddingNurse: false,
+                });
             }
         },
-        [invalidateWard, wardId],
+        [invalidateWard, patch, wardId],
     );
     const deleteNurse = useCallback(
         async (shiftTeamId: number, nurseId: number) => {
             if (!wardId) return;
 
-            await WardAPI.removeNurseFromShiftTeam(wardId, shiftTeamId, nurseId);
-            await invalidateWard();
+            patch({
+                isDeletingNurse: true,
+            });
+
+            try {
+                await WardAPI.removeNurseFromShiftTeam(wardId, shiftTeamId, nurseId);
+                patch({
+                    selectedNurseId: null,
+                    selectedNurseDrawerMode: 'edit',
+                    isNurseDraftDirty: false,
+                    nurseSaveStatus: 'idle',
+                });
+                toast.success('간호사를 삭제했어요.');
+                await invalidateWard();
+            } catch (error) {
+                showActionErrorFeedback(error, '간호사 삭제에 실패했습니다.');
+            } finally {
+                patch({
+                    isDeletingNurse: false,
+                });
+            }
         },
-        [invalidateWard, wardId],
+        [invalidateWard, patch, wardId],
     );
     const selectNurse = useCallback(
-        (nurseId: number | null) => {
-            setState('selectedNurseId', nurseId);
+        (nurseId: number | null, mode: 'create' | 'edit' = 'edit') => {
+            const isChangingSelection = selectedNurseId !== nurseId;
+            const isClosingDrawer = nurseId === null;
+
+            if ((isChangingSelection || isClosingDrawer) && selectedNurseId !== null && isNurseDraftDirty) {
+                const isConfirmed = window.confirm('저장되지 않은 변경 사항이 있습니다. 저장하지 않고 닫을까요?');
+
+                if (!isConfirmed) return false;
+            }
+
+            patch({
+                selectedNurseId: nurseId,
+                selectedNurseDrawerMode: nurseId === null ? 'edit' : mode,
+                isNurseDraftDirty: false,
+                nurseSaveStatus: 'idle',
+            });
+
+            return true;
         },
-        [setState],
+        [isNurseDraftDirty, patch, selectedNurseId],
     );
     const updateNurse = useCallback(
         async (nurseId: number, updateNurseDTO: TUpdateNurseDTO) => {
+            patch({
+                nurseSaveStatus: 'saving',
+            });
+
             try {
                 await NurseAPI.updateNurse(nurseId, updateNurseDTO);
+                patch({
+                    isNurseDraftDirty: false,
+                    nurseSaveStatus: 'success',
+                    selectedNurseDrawerMode: 'edit',
+                });
+
                 await invalidateWardShiftAndRequest();
+
+                return true;
             } catch (error) {
+                patch({
+                    nurseSaveStatus: 'error',
+                });
+
                 showActionErrorFeedback(error, '간호사 정보 수정에 실패했습니다.');
+
+                return false;
             }
         },
-        [invalidateWardShiftAndRequest],
+        [invalidateWardShiftAndRequest, patch],
     );
     const updateNurseShift = useCallback(
         async (nurseId: number, nurseShiftTypeId: number, change: TUpdateNurseShiftTypeRequest) => {
@@ -269,12 +341,26 @@ const useEditShiftTeam = () => {
         },
         [invalidateWard, queryClient, wardId, wardQueryKey],
     );
+    const setNurseDraftDirty = useCallback(
+        (isDirty: boolean) => {
+            patch({
+                isNurseDraftDirty: isDirty,
+                nurseSaveStatus: isDirty ? 'idle' : nurseSaveStatus,
+            });
+        },
+        [nurseSaveStatus, patch],
+    );
 
     return {
         state: {
             ward,
             selectedNurse: ward?.shiftTeams?.flatMap((x) => x.nurses).find((nurse) => nurse.nurseId === selectedNurseId),
             shiftTeams: ward?.shiftTeams,
+            selectedNurseDrawerMode,
+            isNurseDraftDirty,
+            nurseSaveStatus,
+            isAddingNurse,
+            isDeletingNurse,
         },
         actions: {
             addNurse,
@@ -287,6 +373,7 @@ const useEditShiftTeam = () => {
             editDivision,
             moveNurseOrder,
             updateShiftTeam,
+            setNurseDraftDirty,
         },
     };
 };

--- a/src/features/ward/useEditShiftTeam/index.ts
+++ b/src/features/ward/useEditShiftTeam/index.ts
@@ -107,6 +107,10 @@ const useEditShiftTeam = () => {
     );
     const selectNurse = useCallback(
         (nurseId: number | null, mode: 'create' | 'edit' = 'edit') => {
+            if (selectedNurseId === nurseId) {
+                return true;
+            }
+
             const isChangingSelection = selectedNurseId !== nurseId;
             const isClosingDrawer = nurseId === null;
 
@@ -343,12 +347,18 @@ const useEditShiftTeam = () => {
     );
     const setNurseDraftDirty = useCallback(
         (isDirty: boolean) => {
-            patch({
-                isNurseDraftDirty: isDirty,
-                nurseSaveStatus: isDirty ? 'idle' : nurseSaveStatus,
+            patch((prev) => {
+                if (prev.isNurseDraftDirty === isDirty) {
+                    return {};
+                }
+
+                return {
+                    isNurseDraftDirty: isDirty,
+                    nurseSaveStatus: isDirty && prev.nurseSaveStatus !== 'saving' ? 'idle' : prev.nurseSaveStatus,
+                };
             });
         },
-        [nurseSaveStatus, patch],
+        [patch],
     );
 
     return {

--- a/src/features/ward/useEditShiftTeam/store.ts
+++ b/src/features/ward/useEditShiftTeam/store.ts
@@ -1,7 +1,15 @@
 import {createStore} from '@/shared/util/create-store';
 
+export type TNurseDrawerMode = 'create' | 'edit';
+export type TNurseSaveStatus = 'idle' | 'saving' | 'success' | 'error';
+
 const initialState = {
     selectedNurseId: null as number | null,
+    selectedNurseDrawerMode: 'edit' as TNurseDrawerMode,
+    isNurseDraftDirty: false,
+    nurseSaveStatus: 'idle' as TNurseSaveStatus,
+    isAddingNurse: false,
+    isDeletingNurse: false,
 };
 const useEditNurseStore = createStore(initialState, {
     name: 'useEditNurseStore',

--- a/src/pages/MemberPage/model/nurseEdit.test.ts
+++ b/src/pages/MemberPage/model/nurseEdit.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, it} from 'vitest';
+import {type TNurse} from '@/entities/nurse';
+import {getNurseDrawerFeedback, hasNurseChanges} from './nurseEdit';
+
+const createNurse = (): TNurse => ({
+    nurseId: 1,
+    accountId: null,
+    shiftTeamId: 10,
+    wardId: 20,
+    name: '김간호',
+    phoneNum: '01012345678',
+    isConnected: false,
+    nurseShiftTypes: [
+        {
+            nurseShiftTypeId: 1,
+            name: 'Day',
+            shortName: 'D',
+            isPossible: true,
+            isPreferred: false,
+        },
+        {
+            nurseShiftTypeId: 2,
+            name: 'Evening',
+            shortName: 'E',
+            isPossible: false,
+            isPreferred: false,
+        },
+    ],
+    isWorker: true,
+    isDutyManager: false,
+    isWardManager: false,
+    gender: '여',
+    employmentDate: '2021-08-01',
+    memo: '',
+    isDeleted: false,
+    divisionNum: 0,
+    priority: 1,
+});
+
+describe('hasNurseChanges', () => {
+    it('returns false when editable fields are unchanged', () => {
+        const nurse = createNurse();
+
+        expect(hasNurseChanges(nurse, {...nurse})).toBe(false);
+    });
+
+    it('detects shift type availability changes', () => {
+        const nurse = createNurse();
+        const draft = {
+            ...nurse,
+            nurseShiftTypes: nurse.nurseShiftTypes.map((shiftType, index) => (index === 1 ? {...shiftType, isPossible: true} : shiftType)),
+        };
+
+        expect(hasNurseChanges(nurse, draft)).toBe(true);
+    });
+});
+
+describe('getNurseDrawerFeedback', () => {
+    it('returns create guidance before the first save', () => {
+        expect(
+            getNurseDrawerFeedback({
+                mode: 'create',
+                saveStatus: 'idle',
+                isDirty: false,
+            }).title,
+        ).toBe('새 간호사를 추가했어요');
+    });
+
+    it('prioritizes error feedback over draft state', () => {
+        expect(
+            getNurseDrawerFeedback({
+                mode: 'edit',
+                saveStatus: 'error',
+                isDirty: true,
+            }).title,
+        ).toBe('저장하지 못했어요');
+    });
+});

--- a/src/pages/MemberPage/model/nurseEdit.ts
+++ b/src/pages/MemberPage/model/nurseEdit.ts
@@ -1,0 +1,72 @@
+import {type TNurse} from '@/entities/nurse';
+import {type TNurseDrawerMode, type TNurseSaveStatus} from '@/features/ward/useEditShiftTeam/store';
+
+const nurseEditableKeys = ['name', 'gender', 'employmentDate', 'phoneNum', 'isWorker', 'isDutyManager', 'memo'] as const;
+
+export function hasNurseChanges(original: TNurse | null | undefined, draft: TNurse | null | undefined) {
+    if (!original || !draft) return false;
+
+    const hasPrimitiveChanges = nurseEditableKeys.some((key) => original[key] !== draft[key]);
+
+    if (hasPrimitiveChanges) return true;
+
+    if (original.nurseShiftTypes.length !== draft.nurseShiftTypes.length) return true;
+
+    return original.nurseShiftTypes.some((shiftType, index) => {
+        const draftShiftType = draft.nurseShiftTypes[index];
+
+        if (!draftShiftType) return true;
+
+        return shiftType.nurseShiftTypeId !== draftShiftType.nurseShiftTypeId || shiftType.isPossible !== draftShiftType.isPossible;
+    });
+}
+
+export function getNurseDrawerFeedback(params: {mode: TNurseDrawerMode; saveStatus: TNurseSaveStatus; isDirty: boolean}) {
+    const {mode, saveStatus, isDirty} = params;
+
+    if (saveStatus === 'saving') {
+        return {
+            title: '저장 중이에요',
+            description: '입력한 내용을 반영하고 있어요. 저장이 끝날 때까지 잠시만 기다려 주세요.',
+            toneClassName: 'border-main-3 bg-main-light text-main-1',
+        };
+    }
+
+    if (saveStatus === 'error') {
+        return {
+            title: '저장하지 못했어요',
+            description: '입력한 내용은 그대로 남아 있어요. 내용을 확인한 뒤 다시 저장해 주세요.',
+            toneClassName: 'border-red/30 bg-red/5 text-red',
+        };
+    }
+
+    if (saveStatus === 'success' && !isDirty) {
+        return {
+            title: '저장이 완료되었어요',
+            description: '간호사 정보가 반영되었습니다. 더 수정할 내용이 없다면 닫아도 괜찮아요.',
+            toneClassName: 'border-main-2/20 bg-main-4 text-main-1',
+        };
+    }
+
+    if (mode === 'create') {
+        return {
+            title: '새 간호사를 추가했어요',
+            description: '기본 정보가 먼저 입력된 상태예요. 이름과 연락처를 확인한 뒤 저장해 주세요.',
+            toneClassName: 'border-main-3/60 bg-sub-5 text-sub-1',
+        };
+    }
+
+    if (isDirty) {
+        return {
+            title: '변경 사항이 있어요',
+            description: '저장하지 않고 닫으면 수정한 내용이 사라집니다.',
+            toneClassName: 'border-sub-4 bg-main-bg text-sub-1',
+        };
+    }
+
+    return {
+        title: '수정할 항목을 확인해 주세요',
+        description: '변경된 내용이 생기면 저장 버튼이 활성화됩니다.',
+        toneClassName: 'border-sub-4 bg-main-bg text-sub-2',
+    };
+}

--- a/src/pages/MemberPage/model/useShiftTeamListControllerHook.ts
+++ b/src/pages/MemberPage/model/useShiftTeamListControllerHook.ts
@@ -11,7 +11,7 @@ import {createMoveNurseOrderPayload, type TEditShiftTeamState, getNextSelectedNu
 interface IUseShiftTeamListControllerParams {
     shiftTeams: TShiftTeam[] | undefined;
     selectedNurse: TNurse | undefined;
-    selectNurse: (nurseId: number | null) => void;
+    selectNurse: (nurseId: number | null, mode?: 'create' | 'edit') => boolean;
     moveNurseOrder: (
         nurseId: number,
         shiftTeamId: number,
@@ -33,7 +33,9 @@ function useShiftTeamListController({
 }: IUseShiftTeamListControllerParams) {
     const [openMenuShiftTeamId, setOpenMenuShiftTeamId] = useState<number | null>(null);
     const [editShiftTeam, setEditShiftTeam] = useState<TEditShiftTeamState>(null);
-    const clickAwayListRef = useOnclickOutside(() => selectNurse(null));
+    const clickAwayListRef = useOnclickOutside(() => {
+        selectNurse(null);
+    });
     const clickAwayMenuRef = useOnclickOutside(() => setOpenMenuShiftTeamId(null));
     const handleUpdateShiftTeam = useCallback(() => {
         if (!editShiftTeam) return;

--- a/src/pages/MemberPage/ui/NurseEditDrawer.tsx
+++ b/src/pages/MemberPage/ui/NurseEditDrawer.tsx
@@ -84,8 +84,12 @@ function NurseEditDrawer() {
                     value={writeNurse?.name ?? ''}
                 />
                 <div
-                    className="ml-auto flex h-5 w-7 cursor-pointer items-center justify-center rounded-[.3125rem] bg-sub-5 font-apple text-[.875rem] text-[#A2A6F5]"
+                    className={`ml-auto flex h-5 w-7 items-center justify-center rounded-[.3125rem] bg-sub-5 font-apple text-[.875rem] text-[#A2A6F5] ${
+                        isBusy ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
+                    }`}
                     onClick={() => {
+                        if (isBusy) return;
+
                         handleChange('gender', writeNurse?.gender === '남' ? '여' : '남');
                         sendEvent(events.memberPage.editNurseDrawer.changeNurseGender);
                     }}

--- a/src/pages/MemberPage/ui/NurseEditDrawer.tsx
+++ b/src/pages/MemberPage/ui/NurseEditDrawer.tsx
@@ -6,14 +6,22 @@ import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
 import {CheckedIcon, FoldIcon, UncheckedIcon2} from '@/shared/assets/svg';
 import Button from '@/shared/ui/form-controls/Button';
 import TextField from '@/shared/ui/form-controls/TextField';
+import {getNurseDrawerFeedback, hasNurseChanges} from '../model/nurseEdit';
 
 function NurseEditDrawer() {
     const {
-        state: {shiftTeams, selectedNurse},
-        actions: {selectNurse, updateNurse, deleteNurse},
+        state: {shiftTeams, selectedNurse, selectedNurseDrawerMode, nurseSaveStatus, isDeletingNurse},
+        actions: {selectNurse, updateNurse, deleteNurse, setNurseDraftDirty},
     } = useEditShiftTeam();
     const [writeNurse, setWriteNurse] = useState<TNurse | null>(null);
     const textInputRef = useRef<HTMLInputElement>(null);
+    const isDirty = hasNurseChanges(selectedNurse, writeNurse);
+    const isBusy = nurseSaveStatus === 'saving' || isDeletingNurse;
+    const feedback = getNurseDrawerFeedback({
+        mode: selectedNurseDrawerMode,
+        saveStatus: nurseSaveStatus,
+        isDirty,
+    });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handleChange = (key: keyof TNurse, value: any) => {
         if (!writeNurse) return;
@@ -21,17 +29,20 @@ function NurseEditDrawer() {
         setWriteNurse({...writeNurse, [key]: value});
     };
     const save = useCallback(() => {
-        if (writeNurse) {
+        if (writeNurse && !isBusy && isDirty) {
             updateNurse(writeNurse.nurseId, writeNurse);
         }
-    }, [writeNurse, updateNurse]);
+    }, [isBusy, isDirty, writeNurse, updateNurse]);
+    const closeDrawer = useCallback(() => {
+        selectNurse(null);
+    }, [selectNurse]);
     const handleKeyDown = useCallback(
         (event: KeyboardEvent) => {
-            if (event.key === 'Enter') {
+            if (event.key === 'Enter' && !isBusy && isDirty) {
                 save();
             }
         },
-        [save],
+        [isBusy, isDirty, save],
     );
 
     useEffect(() => {
@@ -39,6 +50,10 @@ function NurseEditDrawer() {
 
         if (textInputRef) textInputRef.current?.focus();
     }, [selectedNurse]);
+
+    useEffect(() => {
+        setNurseDraftDirty(isDirty);
+    }, [isDirty, setNurseDraftDirty]);
 
     useEffect(() => {
         document.addEventListener('keydown', handleKeyDown);
@@ -54,15 +69,13 @@ function NurseEditDrawer() {
                 selectedNurse ? 'translate-x-0' : 'translate-x-full'
             }`}
         >
-            <FoldIcon
-                className="absolute top-[.8125rem] left-5 h-7.5 w-7.5 scale-x-[-1] cursor-pointer text-sub-3"
-                onClick={() => selectNurse(null)}
-            />
+            <FoldIcon className="absolute top-[.8125rem] left-5 h-7.5 w-7.5 scale-x-[-1] cursor-pointer text-sub-3" onClick={closeDrawer} />
             <div className="mt-15 mb-5 flex h-10.5 w-full items-center px-10">
                 <div className="h-10.5 w-10.5 rounded-full bg-gray-400" />
                 <TextField
                     ref={textInputRef}
                     autoFocus
+                    disabled={isBusy}
                     className="ml-5 h-10.5 w-40.5 px-3 text-[1.875rem] font-semibold text-text-1"
                     onChange={(e) => {
                         handleChange('name', e.target.value);
@@ -81,6 +94,10 @@ function NurseEditDrawer() {
                 </div>
             </div>
             <div className="h-[.3125rem] w-full bg-sub-5" />
+            <div className={`mx-10 mt-5 rounded-[.625rem] border px-4 py-3 ${feedback.toneClassName}`} aria-live="polite">
+                <p className="font-apple text-[.9375rem] font-semibold">{feedback.title}</p>
+                <p className="mt-1 font-apple text-[.8125rem]">{feedback.description}</p>
+            </div>
             <div className="flex h-29 w-full flex-col items-stretch justify-between border-b-[.0313rem] border-sub-4 px-10 pt-[.625rem] pb-7.5">
                 <div className="flex items-center justify-between">
                     <p className="shrink-0 font-apple text-base font-medium text-sub-2">입사 년도</p>
@@ -90,6 +107,7 @@ function NurseEditDrawer() {
                 </div>
                 <TextField
                     type="date"
+                    disabled={isBusy}
                     className="h-10 font-poppins text-[1.25rem] text-sub-3"
                     placeholder="YYYY-MM-DD"
                     onChange={(e) => {
@@ -106,6 +124,7 @@ function NurseEditDrawer() {
                 </div>
                 <TextField
                     type="tel"
+                    disabled={isBusy}
                     className="h-10 font-poppins text-[1.25rem] text-sub-3"
                     onChange={(e) => {
                         handleChange('phoneNum', e.target.value);
@@ -123,8 +142,10 @@ function NurseEditDrawer() {
                     {writeNurse?.nurseShiftTypes.slice(0, 3).map(({nurseShiftTypeId, isPossible, name}) => (
                         <div
                             key={nurseShiftTypeId}
-                            className={`flex h-10 flex-1 cursor-pointer items-center justify-center rounded-[.3125rem] border-[.0625rem] font-apple text-[1.25rem] ${isPossible ? 'border-main-1 text-main-1' : 'border-sub-4 text-sub-3'} `}
+                            className={`flex h-10 flex-1 items-center justify-center rounded-[.3125rem] border-[.0625rem] font-apple text-[1.25rem] ${isBusy ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'} ${isPossible ? 'border-main-1 text-main-1' : 'border-sub-4 text-sub-3'} `}
                             onClick={() => {
+                                if (isBusy) return;
+
                                 handleChange(
                                     'nurseShiftTypes',
                                     produce(writeNurse.nurseShiftTypes, (draft: TNurse['nurseShiftTypes']) => {
@@ -145,9 +166,11 @@ function NurseEditDrawer() {
                     <div className="ml-auto flex items-center gap-[.625rem]">
                         <p className="font-apple text-[.75rem] text-sub-3">해당 됨</p>
                         <CheckedIcon
-                            className="h-5 w-5 cursor-pointer"
+                            className={`h-5 w-5 ${isBusy ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
                             fill="#B08BFF"
                             onClick={() => {
+                                if (isBusy) return;
+
                                 handleChange('isWorker', false);
                                 sendEvent(events.memberPage.editNurseDrawer.changeNurseIsWorker);
                             }}
@@ -157,8 +180,10 @@ function NurseEditDrawer() {
                     <div className="ml-auto flex items-center gap-[.625rem]">
                         <p className="font-apple text-[.75rem] text-sub-3">해당 안됨</p>
                         <UncheckedIcon2
-                            className="h-5 w-5 cursor-pointer"
+                            className={`h-5 w-5 ${isBusy ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
                             onClick={() => {
+                                if (isBusy) return;
+
                                 handleChange('isWorker', true);
                                 sendEvent(events.memberPage.editNurseDrawer.changeNurseIsWorker);
                             }}
@@ -172,9 +197,11 @@ function NurseEditDrawer() {
                     <div className="ml-auto flex items-center gap-[.625rem]">
                         <p className="font-apple text-[.75rem] text-sub-3">해당 됨</p>
                         <CheckedIcon
-                            className="h-5 w-5 cursor-pointer"
+                            className={`h-5 w-5 ${isBusy ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
                             fill="#B08BFF"
                             onClick={() => {
+                                if (isBusy) return;
+
                                 handleChange('isDutyManager', false);
                                 sendEvent(events.memberPage.editNurseDrawer.changeNurseIsManager);
                             }}
@@ -184,8 +211,10 @@ function NurseEditDrawer() {
                     <div className="ml-auto flex items-center gap-[.625rem]">
                         <p className="font-apple text-[.75rem] text-sub-3">해당 안됨</p>
                         <UncheckedIcon2
-                            className="h-5 w-5 cursor-pointer"
+                            className={`h-5 w-5 ${isBusy ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
                             onClick={() => {
+                                if (isBusy) return;
+
                                 handleChange('isDutyManager', true);
                                 sendEvent(events.memberPage.editNurseDrawer.changeNurseIsManager);
                             }}
@@ -197,6 +226,7 @@ function NurseEditDrawer() {
             <p className="mt-7.5 ml-10 font-apple text-base font-medium text-sub-2.5">메모</p>
             <textarea
                 value={writeNurse?.memo}
+                disabled={isBusy}
                 className="mx-10 mt-[.9375rem] h-43.25 resize-none rounded-[.3125rem] border-[.0313rem] border-sub-4.5 bg-main-bg p-2 font-apple text-sm text-sub-1"
                 onChange={(e) => {
                     handleChange('memo', e.target.value);
@@ -206,33 +236,41 @@ function NurseEditDrawer() {
 
             <div className="mt-6.25 mr-10 ml-auto flex h-9 gap-4">
                 <button
-                    className="flex h-9 items-center justify-center rounded-[3.125rem] bg-sub-3 px-5 py-[.5rem] font-apple text-base font-medium text-white"
-                    onClick={() =>
-                        selectedNurse &&
-                        shiftTeams &&
+                    className="flex h-9 items-center justify-center rounded-[3.125rem] bg-sub-3 px-5 py-[.5rem] font-apple text-base font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={isBusy}
+                    onClick={() => {
+                        if (!selectedNurse || !shiftTeams) return;
+
+                        const shouldDelete = window.confirm(`${selectedNurse.name} 간호사를 삭제할까요? 이 작업은 되돌릴 수 없습니다.`);
+
+                        if (!shouldDelete) return;
+
                         deleteNurse(
                             shiftTeams.find((x) => x.nurses.some((y) => y.nurseId === selectedNurse.nurseId))!.shiftTeamId,
                             selectedNurse.nurseId,
-                        )
-                    }
+                        );
+                    }}
                 >
-                    간호사 삭제
+                    {isDeletingNurse ? '삭제 중...' : '간호사 삭제'}
                 </button>
                 <Button
+                    type="button"
+                    variant="outline"
+                    size="md"
+                    className="flex h-9 items-center justify-center rounded-[3.125rem] px-5 py-[.5rem] font-apple text-base font-medium"
+                    disabled={nurseSaveStatus === 'saving'}
+                    onClick={closeDrawer}
+                >
+                    {isDirty ? '취소' : '닫기'}
+                </Button>
+                <Button
                     id="nurse_edit_drawer"
+                    type="button"
                     className="flex h-9 items-center justify-center rounded-[3.125rem] bg-main-1 px-5 py-[.5rem] font-apple text-base font-medium text-white"
-                    disabled={
-                        selectedNurse?.name === writeNurse?.name &&
-                        selectedNurse?.employmentDate === writeNurse?.employmentDate &&
-                        selectedNurse?.phoneNum === writeNurse?.phoneNum &&
-                        selectedNurse?.isWorker === writeNurse?.isWorker &&
-                        selectedNurse?.isDutyManager === writeNurse?.isDutyManager &&
-                        selectedNurse?.memo === writeNurse?.memo &&
-                        selectedNurse?.nurseShiftTypes.length === writeNurse?.nurseShiftTypes.length
-                    }
+                    disabled={!isDirty || nurseSaveStatus === 'saving'}
                     onClick={() => save()}
                 >
-                    저장
+                    {nurseSaveStatus === 'saving' ? '저장 중...' : '저장'}
                 </Button>
             </div>
         </div>

--- a/src/pages/MemberPage/ui/ShiftTeamCard.tsx
+++ b/src/pages/MemberPage/ui/ShiftTeamCard.tsx
@@ -16,8 +16,9 @@ interface IShiftTeamCardProps {
     editShiftTeam: TEditShiftTeamState;
     clickAwayMenuRef: RefCallback<HTMLDivElement>;
     clickAwayShiftTeamNameRef: RefCallback<HTMLInputElement>;
-    selectNurse: (nurseId: number) => void;
+    selectNurse: (nurseId: number, mode?: 'create' | 'edit') => boolean;
     addNurse: (shiftTeamId: number) => void;
+    isAddingNurse: boolean;
     editDivision: (shiftTeamId: number, prevPriority: number, changeValue: number, patchYearMonth: string) => void;
     deleteShiftTeam: (shiftTeamId: number) => void;
     onOpenMenu: (shiftTeamId: number) => void;
@@ -37,6 +38,7 @@ function ShiftTeamCard({
     clickAwayShiftTeamNameRef,
     selectNurse,
     addNurse,
+    isAddingNurse,
     editDivision,
     deleteShiftTeam,
     onOpenMenu,
@@ -105,14 +107,15 @@ function ShiftTeamCard({
                     >
                         <button
                             type="button"
-                            className="relative flex flex-1 items-center gap-[.3125rem] border-b-[.0625rem] border-main-3 px-6.25 text-left font-apple text-[1.25rem] font-medium text-sub-2 last:border-none focus-visible:outline-[.125rem] focus-visible:outline-main-2"
+                            className="relative flex flex-1 items-center gap-[.3125rem] border-b-[.0625rem] border-main-3 px-6.25 text-left font-apple text-[1.25rem] font-medium text-sub-2 last:border-none focus-visible:outline-[.125rem] focus-visible:outline-main-2 disabled:cursor-not-allowed disabled:opacity-60"
+                            disabled={isAddingNurse}
                             onClick={() => {
                                 addNurse(shiftTeam.shiftTeamId);
                                 onCloseMenu();
                             }}
                             aria-label={t('page.member.shiftTeamList.card.addNurse')}
                         >
-                            {t('page.member.shiftTeamList.card.addNurse')}
+                            {isAddingNurse ? '간호사 추가 중...' : t('page.member.shiftTeamList.card.addNurse')}
                             <InfoIcon className="peer h-5 w-5" />
                             <div className="invisible absolute top-[50%] -right-86 z-30 flex w-91 translate-y-[-50%] items-center gap-[.5rem] rounded-[.3125rem] bg-white px-2 py-1 font-apple text-[.875rem] text-sub-2 shadow-shadow-2 peer-hover:visible">
                                 <div

--- a/src/pages/MemberPage/ui/ShiftTeamList.tsx
+++ b/src/pages/MemberPage/ui/ShiftTeamList.tsx
@@ -12,7 +12,7 @@ import ShiftTeamCard from './ShiftTeamCard';
 
 function ShiftTeamList() {
     const {
-        state: {shiftTeams, selectedNurse},
+        state: {shiftTeams, selectedNurse, isAddingNurse},
         actions: {selectNurse, createShiftTeam, moveNurseOrder, updateShiftTeam, addNurse, editDivision, deleteShiftTeam},
     } = useEditShiftTeam();
     const showMemberTutorial = useTutorialStore((state) => state.showMemberTutorial);
@@ -66,6 +66,7 @@ function ShiftTeamList() {
                             clickAwayShiftTeamNameRef={clickAwayShiftTeamNameRef}
                             selectNurse={selectNurse}
                             addNurse={addNurse}
+                            isAddingNurse={isAddingNurse}
                             editDivision={editDivision}
                             deleteShiftTeam={deleteShiftTeam}
                             onOpenMenu={setOpenMenuShiftTeamId}


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-869](https://gom3.atlassian.net/browse/DUT-869)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 간호사 추가 직후 새 간호사 드로어를 자동으로 열고, 첫 저장 전 안내 문구와 성공 토스트를 추가했습니다.
- 간호사 수정 드로어에 변경 사항, 저장 중, 저장 완료, 저장 실패 상태 안내를 넣고 저장 중에는 입력과 삭제/취소 액션을 제어했습니다.
- 저장하지 않은 변경 사항이 있을 때 드로어 닫기나 다른 간호사 선택 시 확인 단계를 추가하고, 실제 변경 여부 비교 로직과 테스트를 보강했습니다.

<br>

## To Reviewers

- 전체 `tsc -b`는 이번 변경과 무관한 기존 `RequestShiftPage`, `shared/util/event.ts` 타입 오류로 실패합니다.
- 새 간호사 추가는 기존처럼 기본값 생성 후 수정하는 흐름을 유지했고, 이번 작업에서는 해당 흐름의 UX 명확화에만 집중했습니다.


[DUT-869]: https://gom3.atlassian.net/browse/DUT-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ