### PR TITLE
[DUT-870]: MemberPage 연동 관리 2차 분해

### DIFF
--- a/src/pages/MemberPage/model/connectionManage.ts
+++ b/src/pages/MemberPage/model/connectionManage.ts
@@ -1,0 +1,17 @@
+import {groupBy} from 'lodash-es';
+import type {TNurse, TWaitingNurse} from '@/entities/nurse';
+
+export type TConnectionManageStep = 0 | 1 | 2 | 3;
+
+export type TConnectMode = 'link' | 'add';
+
+export const getFormattedPhoneNumber = (phoneNumber: string) =>
+    `${phoneNumber.slice(0, 3)}-${phoneNumber.slice(3, 7)}-${phoneNumber.slice(7, 11)}`;
+
+export const getWaitingNurseSummary = (waitingNurse: TWaitingNurse) => ({
+    ...waitingNurse,
+    formattedPhoneNumber: getFormattedPhoneNumber(waitingNurse.phoneNum),
+});
+
+export const getGroupedDivisionNurses = (nurses: TNurse[]) =>
+    Object.entries(groupBy(nurses, 'divisionNum')).sort((a, b) => parseInt(a[0]) - parseInt(b[0]));

--- a/src/pages/MemberPage/model/useConnectionManageController.ts
+++ b/src/pages/MemberPage/model/useConnectionManageController.ts
@@ -1,0 +1,90 @@
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import type {TWaitingNurse} from '@/entities/nurse';
+import type {TConnectionManageStep, TConnectMode} from './connectionManage';
+
+interface IUseConnectionManageControllerParams {
+    open: boolean;
+    approveWaitingNurses: (waitingNurseId: number, shiftTeamId: number) => void;
+    connectWaitingNurses: (waitingNurseId: number, nurseId: number) => void;
+}
+
+function useConnectionManageController({open, approveWaitingNurses, connectWaitingNurses}: IUseConnectionManageControllerParams) {
+    const [step, setStep] = useState<TConnectionManageStep>(0);
+    const [currentWaitingNurse, setCurrentWaitingNurse] = useState<TWaitingNurse | null>(null);
+    const [connectMode, setConnectMode] = useState<TConnectMode>('link');
+    const [toLinkNurseId, setToLinkNurseId] = useState<number | null>(null);
+    const [toAddShiftTeamId, setToAddShiftTeamId] = useState<number | null>(null);
+    const initialize = useCallback(() => {
+        setStep(0);
+        setCurrentWaitingNurse(null);
+        setConnectMode('link');
+        setToLinkNurseId(null);
+        setToAddShiftTeamId(null);
+    }, []);
+    const goToWaitingList = () => {
+        setStep(0);
+        setCurrentWaitingNurse(null);
+        setToLinkNurseId(null);
+        setToAddShiftTeamId(null);
+    };
+    const goToMethodSelection = () => {
+        setToLinkNurseId(null);
+        setToAddShiftTeamId(null);
+        setStep(1);
+    };
+    const goToTargetSelection = () => setStep(2);
+    const handleSelectWaitingNurse = (waitingNurse: TWaitingNurse) => {
+        setCurrentWaitingNurse(waitingNurse);
+        setStep(1);
+    };
+    const handleCompleteSelection = () => {
+        if (!currentWaitingNurse) return;
+
+        if (connectMode === 'link') {
+            if (!toLinkNurseId) return;
+
+            connectWaitingNurses(currentWaitingNurse.waitingNurseId, toLinkNurseId);
+        } else {
+            if (!toAddShiftTeamId) return;
+
+            approveWaitingNurses(currentWaitingNurse.waitingNurseId, toAddShiftTeamId);
+        }
+
+        setStep(3);
+    };
+    const isNextDisabled = useMemo(() => {
+        if (!currentWaitingNurse) return true;
+
+        return connectMode === 'link' ? !toLinkNurseId : !toAddShiftTeamId;
+    }, [connectMode, currentWaitingNurse, toAddShiftTeamId, toLinkNurseId]);
+
+    useEffect(() => {
+        if (!open) {
+            initialize();
+        }
+    }, [initialize, open]);
+
+    return {
+        state: {
+            step,
+            currentWaitingNurse,
+            connectMode,
+            toLinkNurseId,
+            toAddShiftTeamId,
+            isNextDisabled,
+        },
+        actions: {
+            setConnectMode,
+            setToLinkNurseId,
+            setToAddShiftTeamId,
+            initialize,
+            goToWaitingList,
+            goToMethodSelection,
+            goToTargetSelection,
+            handleSelectWaitingNurse,
+            handleCompleteSelection,
+        },
+    };
+}
+
+export default useConnectionManageController;

--- a/src/pages/MemberPage/model/useConnectionManageController.ts
+++ b/src/pages/MemberPage/model/useConnectionManageController.ts
@@ -22,10 +22,7 @@ function useConnectionManageController({open, approveWaitingNurses, connectWaiti
         setToAddShiftTeamId(null);
     }, []);
     const goToWaitingList = () => {
-        setStep(0);
-        setCurrentWaitingNurse(null);
-        setToLinkNurseId(null);
-        setToAddShiftTeamId(null);
+        initialize();
     };
     const goToMethodSelection = () => {
         setToLinkNurseId(null);
@@ -34,6 +31,9 @@ function useConnectionManageController({open, approveWaitingNurses, connectWaiti
     };
     const goToTargetSelection = () => setStep(2);
     const handleSelectWaitingNurse = (waitingNurse: TWaitingNurse) => {
+        setConnectMode('link');
+        setToLinkNurseId(null);
+        setToAddShiftTeamId(null);
         setCurrentWaitingNurse(waitingNurse);
         setStep(1);
     };

--- a/src/pages/MemberPage/ui/ConnectionManage.tsx
+++ b/src/pages/MemberPage/ui/ConnectionManage.tsx
@@ -1,13 +1,12 @@
-import {groupBy} from 'lodash-es';
-import {useEffect, useState} from 'react';
 import {createPortal} from 'react-dom';
-import {twMerge} from 'tailwind-merge';
 import {match} from 'ts-pattern';
-import {ProfileImage} from '@/entities/account/ui/profile-image';
-import {type TWaitingNurse} from '@/entities/nurse';
 import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
 import useEditWard from '@/features/ward/useEditWard';
-import {CancelIcon, CheckedIcon, MoreIcon, PersonIcon, SuccessCircleIcon, UncheckedIcon2, UnlinkedIcon} from '@/shared/assets/svg';
+import useConnectionManageController from '../model/useConnectionManageController';
+import ConnectionManageCompleteStep from './connection-manage/ConnectionManageCompleteStep';
+import ConnectionManageMethodStep from './connection-manage/ConnectionManageMethodStep';
+import ConnectionManageTargetStep from './connection-manage/ConnectionManageTargetStep';
+import ConnectionManageWaitingStep from './connection-manage/ConnectionManageWaitingStep';
 
 interface IConnectionManageProps {
     open: boolean;
@@ -22,347 +21,64 @@ function ConnectionManage({open, setOpen}: IConnectionManageProps) {
     const {
         state: {shiftTeams},
     } = useEditShiftTeam();
-    const [step, setStep] = useState(0);
-    const [currentWaitingNurse, setCurrentWaitingNurse] = useState<TWaitingNurse | null>(null);
-    const [connectMode, setConnectMode] = useState<'link' | 'add'>('link');
-    const [toLinkNurseId, setToLinkNurseId] = useState<number | null>(null);
-    const [toAddShiftTeamId, setToAddShiftTeamId] = useState<number | null>(null);
-    const initialize = () => {
-        setStep(0);
-        setCurrentWaitingNurse(null);
-        setConnectMode('link');
-        setToLinkNurseId(null);
-        setToAddShiftTeamId(null);
-    };
-
-    useEffect(() => {
-        if (open === false) {
-            initialize();
-        }
-    }, [open]);
+    const {
+        state: {step, currentWaitingNurse, connectMode, toLinkNurseId, toAddShiftTeamId, isNextDisabled},
+        actions: {
+            setConnectMode,
+            setToLinkNurseId,
+            setToAddShiftTeamId,
+            initialize,
+            goToWaitingList,
+            goToMethodSelection,
+            goToTargetSelection,
+            handleSelectWaitingNurse,
+            handleCompleteSelection,
+        },
+    } = useConnectionManageController({
+        open,
+        approveWaitingNurses: approveWatingNurses,
+        connectWaitingNurses: connectWatingNurses,
+    });
+    const handleClose = () => setOpen(false);
 
     return open
         ? createPortal(
               <div
                   className="fixed top-0 left-0 z-1001 flex h-screen w-screen items-center justify-center bg-[#00000099] backdrop-blur-[.125rem]"
-                  onClick={() => setOpen(false)}
+                  onClick={handleClose}
               >
                   {match(step)
                       .with(0, () => (
-                          <div
-                              className="h-[44%] min-h-117.5 w-[40%] min-w-190 rounded-[1.25rem] bg-white px-10.5 py-8.75"
-                              onClick={(e) => e.stopPropagation()}
-                          >
-                              <div className="flex items-center justify-between">
-                                  <div className="flex items-center gap-4">
-                                      <h1 className="font-apple text-[1.75rem] font-semibold text-text-1">연동 관리</h1>
-                                  </div>
-                                  <CancelIcon className="h-7.5 w-7.5" onClick={() => setOpen(false)} />
-                              </div>
-                              <div className="h-full overflow-hidden pt-10.5">
-                                  <p className="font-apple text-[1rem] font-medium text-sub-3">신청 내역</p>
-                                  {watingNurses?.length === 0 ? (
-                                      <div className="flex h-[calc(100%-80px)] items-center justify-center font-apple text-[1.7rem] text-sub-2">
-                                          연동 신청을 한 간호사가 없습니다.
-                                      </div>
-                                  ) : (
-                                      <div className="mt-6 scrollbar-hide flex h-[calc(100%-5.9375rem)] flex-col gap-4 overflow-scroll">
-                                          {watingNurses?.map((waitingNurse) => (
-                                              <div
-                                                  key={waitingNurse.waitingNurseId}
-                                                  className="flex h-18 shrink-0 items-center rounded-[.625rem] border-[.0625rem] border-sub-4.5 bg-main-bg px-5"
-                                              >
-                                                  <ProfileImage
-                                                      className="h-8 w-8"
-                                                      profileImg={{profileImgUrl: waitingNurse.profileImgUrl}}
-                                                  />
-                                                  <p className="ml-[.625rem] font-apple text-[1.5rem] font-medium text-sub-1">
-                                                      {waitingNurse.name}
-                                                  </p>
-                                                  <div
-                                                      className={`ml-8 flex h-5 w-7 items-center justify-center rounded-[.3125rem] bg-sub-5 font-apple text-[.875rem] ${
-                                                          waitingNurse.gender === '남' ? 'text-[#A2A6F5]' : 'text-[#F5A2C5]'
-                                                      }`}
-                                                  >
-                                                      {waitingNurse.gender}
-                                                  </div>
-                                                  <p className="ml-4 font-poppins text-[1.25rem] font-medium text-sub-1">
-                                                      {waitingNurse.phoneNum.slice(0, 3) +
-                                                          '-' +
-                                                          waitingNurse.phoneNum.slice(3, 7) +
-                                                          '-' +
-                                                          waitingNurse.phoneNum.slice(7, 11)}
-                                                  </p>
-                                                  <div className="ml-auto flex h-11.5 w-36.5 items-center justify-center gap-[.125rem] rounded-[.3125rem] border-[.0313rem] border-sub-4 bg-sub-5 p-[.125rem]">
-                                                      <button
-                                                          className="flex h-9.5 flex-1 items-center justify-center rounded-[.3125rem] font-poppins text-[1.5rem] text-sub-2.5 hover:bg-main-1 hover:text-white"
-                                                          onClick={() => {
-                                                              setStep(1);
-                                                              setCurrentWaitingNurse(waitingNurse);
-                                                          }}
-                                                      >
-                                                          수락
-                                                      </button>
-                                                      <button
-                                                          className="flex h-9.5 flex-1 items-center justify-center rounded-[.3125rem] font-poppins text-[1.5rem] text-sub-2.5 hover:bg-sub-2 hover:text-white"
-                                                          onClick={() =>
-                                                              confirm('정말 거절하시겠습니까?') && cancelWaiting(waitingNurse.nurseId)
-                                                          }
-                                                      >
-                                                          거절
-                                                      </button>
-                                                  </div>
-                                              </div>
-                                          ))}
-                                      </div>
-                                  )}
-                              </div>
-                          </div>
+                          <ConnectionManageWaitingStep
+                              waitingNurses={watingNurses}
+                              onClose={handleClose}
+                              onAccept={handleSelectWaitingNurse}
+                              onReject={cancelWaiting}
+                          />
                       ))
                       .with(1, () => (
-                          <div
-                              className="h-[36%] min-h-95 w-[40%] min-w-190 rounded-[1.25rem] bg-white px-10.5 py-8.75"
-                              onClick={(e) => e.stopPropagation()}
-                          >
-                              <div className="flex items-center justify-between">
-                                  <h1 className="font-apple text-[1.75rem] font-semibold text-text-1">간호사 계정을 어떻게 생성할까요?</h1>
-                                  <div className="ml-auto flex gap-5">
-                                      <button
-                                          className="flex h-7.5 items-center rounded-[1.875rem] border-[.0625rem] border-sub-3 px-[.75rem] font-apple text-[1rem] text-sub-3"
-                                          onClick={() => {
-                                              setStep(0);
-                                              setCurrentWaitingNurse(null);
-                                          }}
-                                      >
-                                          이전
-                                      </button>
-                                      <button
-                                          className="flex h-7.5 items-center rounded-[1.875rem] border-[.0625rem] border-main-1 px-[.75rem] font-apple text-[1rem] text-main-1"
-                                          onClick={() => {
-                                              setStep(2);
-                                          }}
-                                      >
-                                          다음
-                                      </button>
-                                  </div>
-                              </div>
-                              <div className="pt-10.5">
-                                  <p className="font-apple text-[1rem] font-medium text-sub-3">연동할 간호사</p>
-                                  <div className="mt-6 flex h-18 shrink-0 items-center rounded-[.625rem] border-[.0625rem] border-sub-4.5 bg-main-bg px-5">
-                                      <img className="rounded-full" src="" alt="" />
-                                      <p className="ml-[.625rem] font-apple text-[1.5rem] font-medium text-sub-1">
-                                          {currentWaitingNurse?.name}
-                                      </p>
-                                      <div
-                                          className={`ml-8 flex h-5 w-7 items-center justify-center rounded-[.3125rem] bg-sub-5 font-apple text-[.875rem] ${
-                                              currentWaitingNurse?.gender === '남' ? 'text-[#A2A6F5]' : 'text-[#F5A2C5]'
-                                          }`}
-                                      >
-                                          {currentWaitingNurse?.gender}
-                                      </div>
-                                      <p className="ml-4 font-poppins text-[1.25rem] font-medium text-sub-1">
-                                          {currentWaitingNurse?.phoneNum.slice(0, 3) +
-                                              '-' +
-                                              currentWaitingNurse?.phoneNum.slice(3, 7) +
-                                              '-' +
-                                              currentWaitingNurse?.phoneNum.slice(7, 11)}
-                                      </p>
-                                  </div>
-                              </div>
-                              <div className="mt-4.75 flex w-full">
-                                  <button
-                                      className={twMerge(
-                                          'h-11.5 flex-1 rounded-l-[3.125rem] border-[.0625rem] border-main-3 font-apple text-[1.5rem] font-medium',
-                                          connectMode === 'link' ? 'bg-main-1 text-white' : 'bg-sub-5 text-sub-2.5',
-                                      )}
-                                      onClick={() => setConnectMode('link')}
-                                  >
-                                      기존 간호사와 연동하기
-                                  </button>
-                                  <button
-                                      className={twMerge(
-                                          'h-11.5 flex-1 rounded-r-[3.125rem] border-[.0625rem] border-main-3 font-apple text-[1.5rem] font-medium',
-                                          connectMode === 'link' ? 'bg-sub-5 text-sub-2.5' : 'bg-main-1 text-white',
-                                      )}
-                                      onClick={() => setConnectMode('add')}
-                                  >
-                                      새로 추가하기
-                                  </button>
-                              </div>
-                              <p className="mt-[.625rem] font-apple text-[.875rem] text-main-2">
-                                  *기존 간호사와 연동 시, 미연동 상태인 간호사 목록에서 일치하는 계정을 연결시킬 수 있어요.
-                              </p>
-                          </div>
+                          <ConnectionManageMethodStep
+                              currentWaitingNurse={currentWaitingNurse}
+                              connectMode={connectMode}
+                              onBack={goToWaitingList}
+                              onNext={goToTargetSelection}
+                              onChangeConnectMode={setConnectMode}
+                          />
                       ))
                       .with(2, () => (
-                          <div
-                              className="h-[83%] min-h-225.75 w-[40%] min-w-190 rounded-[1.25rem] bg-white px-10.5 py-8.75"
-                              onClick={(e) => e.stopPropagation()}
-                          >
-                              <div className="flex items-center justify-between">
-                                  <h1 className="font-apple text-[1.75rem] font-semibold text-text-1">
-                                      {connectMode === 'link' ? '연동할 간호사를 선택해 주세요.' : '팀을 선택해 주세요.'}
-                                  </h1>
-                                  <div className="ml-auto flex gap-5">
-                                      <button
-                                          className="flex h-7.5 items-center rounded-[1.875rem] border-[.0625rem] border-sub-3 px-[.75rem] font-apple text-[1rem] text-sub-3"
-                                          onClick={() => {
-                                              setToAddShiftTeamId(null);
-                                              setToLinkNurseId(null);
-                                              setStep(1);
-                                          }}
-                                      >
-                                          이전
-                                      </button>
-                                      <button
-                                          disabled={(connectMode === 'link' ? !toLinkNurseId : !toAddShiftTeamId) || !currentWaitingNurse}
-                                          className="flex h-7.5 items-center rounded-[1.875rem] border-[.0625rem] border-main-1 px-[.75rem] font-apple text-[1rem] text-main-1 disabled:border-sub-3 disabled:text-sub-3"
-                                          onClick={() => {
-                                              if (connectMode === 'link') {
-                                                  connectWatingNurses(currentWaitingNurse!.waitingNurseId, toLinkNurseId!);
-                                              } else {
-                                                  approveWatingNurses(currentWaitingNurse!.waitingNurseId, toAddShiftTeamId!);
-                                              }
-
-                                              setStep(3);
-                                          }}
-                                      >
-                                          다음
-                                      </button>
-                                  </div>
-                              </div>
-                              <p className="pt-[.375rem] font-apple text-[1rem] font-medium text-sub-3">
-                                  {connectMode === 'link'
-                                      ? '미연동 상태인 간호사 목록 중에 일치하는 계정을 선택해주세요.'
-                                      : '팀을 선택해주시면 해당 팀에 계정이 추가됩니다.'}
-                              </p>
-                              <div
-                                  className={`mb-8 scrollbar-hide flex h-[calc(100%-5rem)] items-start gap-10 overflow-y-scroll ${
-                                      connectMode === 'add' && 'pt-25.5'
-                                  }`}
-                              >
-                                  {shiftTeams?.map((shiftTeam) => (
-                                      <div
-                                          className={twMerge(
-                                              'relative mt-5.5 flex w-75 flex-col rounded-2xl border-[.0625rem] border-sub-4.5 shadow-banner',
-                                              toAddShiftTeamId === shiftTeam.shiftTeamId && 'border-[.125rem] border-main-1',
-                                          )}
-                                          key={shiftTeam.shiftTeamId}
-                                      >
-                                          {connectMode === 'add' ? (
-                                              toAddShiftTeamId === shiftTeam.shiftTeamId ? (
-                                                  <CheckedIcon className="absolute -top-6 left-[50%] h-9 w-9 translate-x-[-50%] -translate-y-full cursor-pointer" />
-                                              ) : (
-                                                  <UncheckedIcon2
-                                                      className="absolute -top-6 left-[50%] h-9 w-9 translate-x-[-50%] -translate-y-full cursor-pointer"
-                                                      onClick={() => setToAddShiftTeamId(shiftTeam.shiftTeamId)}
-                                                  />
-                                              )
-                                          ) : null}
-                                          <div className="relative flex w-full items-center justify-between rounded-t-[.9375rem] bg-sub-2 px-5 py-[.875rem]">
-                                              <div className="flex flex-col gap-[.3125rem]">
-                                                  <h2 className="font-apple text-[1.5rem] font-semibold text-white">{shiftTeam.name}</h2>
-
-                                                  <div className="flex items-center">
-                                                      <PersonIcon className="h-4 w-4" />
-                                                      <p className="font-poppins text-[.75rem] text-white">{shiftTeam.nurses.length}</p>
-                                                  </div>
-                                              </div>
-                                              <MoreIcon className="h-7.5 w-7.5 cursor-pointer" />
-                                          </div>
-                                          {shiftTeam.nurses.length === 0 && (
-                                              <div className={`flex h-14 w-full cursor-pointer items-center justify-center select-none`}>
-                                                  <h3 className="font-apple text-[1.25rem] font-semibold text-sub-2.5">
-                                                      아직 간호사가 없습니다!
-                                                  </h3>
-                                              </div>
-                                          )}
-                                          {Object.entries(groupBy(shiftTeam.nurses, 'divisionNum'))
-                                              .sort((a, b) => parseInt(a[0]) - parseInt(b[0]))
-                                              .map(([, divisionNurses], divisionIndex) => (
-                                                  <div key={divisionIndex} className="border-b-[.0938rem] border-sub-2.5 last:border-none">
-                                                      {divisionNurses.map((nurse, index) => (
-                                                          <div
-                                                              key={index}
-                                                              className={`group relative flex h-14 w-full ${
-                                                                  nurse.isConnected ? 'cursor-default' : 'cursor-pointer'
-                                                              } items-center justify-center select-none ${
-                                                                  toLinkNurseId === nurse.nurseId
-                                                                      ? 'bg-main-4 text-main-1 underline underline-offset-2'
-                                                                      : 'bg-white text-sub-1'
-                                                              } ${
-                                                                  shiftTeam.nurses.findIndex((x) => x.nurseId === nurse.nurseId) ===
-                                                                  shiftTeam.nurses.length - 1
-                                                                      ? 'rounded-b-[.9375rem]'
-                                                                      : 'border-b-[.0313rem] border-b-sub-4.5'
-                                                              }`}
-                                                              onClick={() => {
-                                                                  if (!nurse.isConnected) {
-                                                                      setToLinkNurseId(nurse.nurseId);
-                                                                  }
-                                                              }}
-                                                          >
-                                                              <div className="peer relative font-apple text-[1.25rem] font-semibold text-sub-1">
-                                                                  {nurse.name}
-                                                                  {!nurse.isConnected && (
-                                                                      <div className="absolute top-0 right-[-.3125rem] h-[.3125rem] w-[.3125rem] rounded-full bg-red"></div>
-                                                                  )}
-                                                              </div>
-                                                              {!nurse.isConnected && (
-                                                                  <div className="invisible absolute top-0 z-30 flex translate-y-[-60%] items-center gap-[.5rem] rounded-[.3125rem] bg-white px-2 py-1 font-apple text-[.875rem] whitespace-nowrap text-sub-2 shadow-shadow-2 peer-hover:visible">
-                                                                      <div
-                                                                          className="absolute -bottom-1.5 left-[50%] h-0 w-0 translate-x-[-50%]"
-                                                                          style={{
-                                                                              borderTop: '.625rem solid white',
-                                                                              borderLeft: '.4375rem solid transparent',
-                                                                              borderRight: '.4375rem solid transparent',
-                                                                              borderBottom: '.625rem solid none',
-                                                                          }}
-                                                                      />
-                                                                      연동 되지 않은 가상의 프로필입니다.
-                                                                      <UnlinkedIcon className="h-5 w-5" />
-                                                                  </div>
-                                                              )}
-                                                          </div>
-                                                      ))}
-                                                  </div>
-                                              ))}
-                                      </div>
-                                  ))}
-                              </div>
-                          </div>
+                          <ConnectionManageTargetStep
+                              shiftTeams={shiftTeams}
+                              connectMode={connectMode}
+                              toLinkNurseId={toLinkNurseId}
+                              toAddShiftTeamId={toAddShiftTeamId}
+                              isNextDisabled={isNextDisabled}
+                              onBack={goToMethodSelection}
+                              onNext={handleCompleteSelection}
+                              onSelectLinkNurse={setToLinkNurseId}
+                              onSelectShiftTeam={setToAddShiftTeamId}
+                          />
                       ))
-                      .with(3, () => (
-                          <div
-                              className="flex min-h-96 w-[40%] min-w-190 flex-col items-center justify-center rounded-[1.25rem] bg-white"
-                              onClick={(e) => e.stopPropagation()}
-                          >
-                              <SuccessCircleIcon className="h-15 w-15" />
-                              <h1 className="mt-5 font-apple text-[1.75rem] font-semibold text-text-1">간호사 계정이 연동되었습니다.</h1>
-                              <p className="mt-[.5rem] font-apple text-[1rem] text-sub-3">
-                                  연동된 간호사의 계정은{' '}
-                                  <span className="cursor-pointer text-main-1 underline" onClick={() => setOpen(false)}>
-                                      간호사 관리 탭
-                                  </span>
-                                  에서 확인하실 수 있어요!
-                              </p>
-
-                              <div className="mt-12 flex w-100">
-                                  <button
-                                      className="h-11.5 flex-1 rounded-l-[3.125rem] border-[.0625rem] border-main-3 bg-main-1 font-apple text-[1.5rem] font-medium text-white"
-                                      onClick={() => initialize()}
-                                  >
-                                      돌아가기
-                                  </button>
-                                  <button
-                                      className="h-11.5 flex-1 rounded-r-[3.125rem] border-[.0625rem] border-main-3 bg-sub-5 font-apple text-[1.5rem] font-medium text-sub-2.5"
-                                      onClick={() => setOpen(false)}
-                                  >
-                                      닫기
-                                  </button>
-                              </div>
-                          </div>
-                      ))
+                      .with(3, () => <ConnectionManageCompleteStep onRestart={initialize} onClose={handleClose} />)
                       .otherwise(() => null)}
               </div>,
               document.getElementById('modal-root')!,

--- a/src/pages/MemberPage/ui/connection-manage/ConnectionManageCompleteStep.tsx
+++ b/src/pages/MemberPage/ui/connection-manage/ConnectionManageCompleteStep.tsx
@@ -1,0 +1,42 @@
+import {SuccessCircleIcon} from '@/shared/assets/svg';
+
+interface IConnectionManageCompleteStepProps {
+    onRestart: () => void;
+    onClose: () => void;
+}
+
+function ConnectionManageCompleteStep({onRestart, onClose}: IConnectionManageCompleteStepProps) {
+    return (
+        <div
+            className="flex min-h-96 w-[40%] min-w-190 flex-col items-center justify-center rounded-[1.25rem] bg-white"
+            onClick={(event) => event.stopPropagation()}
+        >
+            <SuccessCircleIcon className="h-15 w-15" />
+            <h1 className="mt-5 font-apple text-[1.75rem] font-semibold text-text-1">간호사 계정이 연동되었습니다.</h1>
+            <p className="mt-[.5rem] font-apple text-[1rem] text-sub-3">
+                연동된 간호사의 계정은{' '}
+                <span className="cursor-pointer text-main-1 underline" onClick={onClose}>
+                    간호사 관리 탭
+                </span>
+                에서 확인하실 수 있어요!
+            </p>
+
+            <div className="mt-12 flex w-100">
+                <button
+                    className="h-11.5 flex-1 rounded-l-[3.125rem] border-[.0625rem] border-main-3 bg-main-1 font-apple text-[1.5rem] font-medium text-white"
+                    onClick={onRestart}
+                >
+                    돌아가기
+                </button>
+                <button
+                    className="h-11.5 flex-1 rounded-r-[3.125rem] border-[.0625rem] border-main-3 bg-sub-5 font-apple text-[1.5rem] font-medium text-sub-2.5"
+                    onClick={onClose}
+                >
+                    닫기
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default ConnectionManageCompleteStep;

--- a/src/pages/MemberPage/ui/connection-manage/ConnectionManageMethodStep.tsx
+++ b/src/pages/MemberPage/ui/connection-manage/ConnectionManageMethodStep.tsx
@@ -1,0 +1,87 @@
+import {twMerge} from 'tailwind-merge';
+import {type TWaitingNurse} from '@/entities/nurse';
+import type {TConnectMode} from '../../model/connectionManage';
+import {getWaitingNurseSummary} from '../../model/connectionManage';
+
+interface IConnectionManageMethodStepProps {
+    currentWaitingNurse: TWaitingNurse | null;
+    connectMode: TConnectMode;
+    onBack: () => void;
+    onNext: () => void;
+    onChangeConnectMode: (mode: TConnectMode) => void;
+}
+
+function ConnectionManageMethodStep({
+    currentWaitingNurse,
+    connectMode,
+    onBack,
+    onNext,
+    onChangeConnectMode,
+}: IConnectionManageMethodStepProps) {
+    const waitingNurseSummary = currentWaitingNurse ? getWaitingNurseSummary(currentWaitingNurse) : null;
+
+    return (
+        <div
+            className="h-[36%] min-h-95 w-[40%] min-w-190 rounded-[1.25rem] bg-white px-10.5 py-8.75"
+            onClick={(event) => event.stopPropagation()}
+        >
+            <div className="flex items-center justify-between">
+                <h1 className="font-apple text-[1.75rem] font-semibold text-text-1">간호사 계정을 어떻게 생성할까요?</h1>
+                <div className="ml-auto flex gap-5">
+                    <button
+                        className="flex h-7.5 items-center rounded-[1.875rem] border-[.0625rem] border-sub-3 px-[.75rem] font-apple text-[1rem] text-sub-3"
+                        onClick={onBack}
+                    >
+                        이전
+                    </button>
+                    <button
+                        className="flex h-7.5 items-center rounded-[1.875rem] border-[.0625rem] border-main-1 px-[.75rem] font-apple text-[1rem] text-main-1"
+                        onClick={onNext}
+                    >
+                        다음
+                    </button>
+                </div>
+            </div>
+            <div className="pt-10.5">
+                <p className="font-apple text-[1rem] font-medium text-sub-3">연동할 간호사</p>
+                <div className="mt-6 flex h-18 shrink-0 items-center rounded-[.625rem] border-[.0625rem] border-sub-4.5 bg-main-bg px-5">
+                    <img className="rounded-full" src="" alt="" />
+                    <p className="ml-[.625rem] font-apple text-[1.5rem] font-medium text-sub-1">{currentWaitingNurse?.name}</p>
+                    <div
+                        className={`ml-8 flex h-5 w-7 items-center justify-center rounded-[.3125rem] bg-sub-5 font-apple text-[.875rem] ${
+                            currentWaitingNurse?.gender === '남' ? 'text-[#A2A6F5]' : 'text-[#F5A2C5]'
+                        }`}
+                    >
+                        {currentWaitingNurse?.gender}
+                    </div>
+                    <p className="ml-4 font-poppins text-[1.25rem] font-medium text-sub-1">{waitingNurseSummary?.formattedPhoneNumber}</p>
+                </div>
+            </div>
+            <div className="mt-4.75 flex w-full">
+                <button
+                    className={twMerge(
+                        'h-11.5 flex-1 rounded-l-[3.125rem] border-[.0625rem] border-main-3 font-apple text-[1.5rem] font-medium',
+                        connectMode === 'link' ? 'bg-main-1 text-white' : 'bg-sub-5 text-sub-2.5',
+                    )}
+                    onClick={() => onChangeConnectMode('link')}
+                >
+                    기존 간호사와 연동하기
+                </button>
+                <button
+                    className={twMerge(
+                        'h-11.5 flex-1 rounded-r-[3.125rem] border-[.0625rem] border-main-3 font-apple text-[1.5rem] font-medium',
+                        connectMode === 'link' ? 'bg-sub-5 text-sub-2.5' : 'bg-main-1 text-white',
+                    )}
+                    onClick={() => onChangeConnectMode('add')}
+                >
+                    새로 추가하기
+                </button>
+            </div>
+            <p className="mt-[.625rem] font-apple text-[.875rem] text-main-2">
+                *기존 간호사와 연동 시, 미연동 상태인 간호사 목록에서 일치하는 계정을 연결시킬 수 있어요.
+            </p>
+        </div>
+    );
+}
+
+export default ConnectionManageMethodStep;

--- a/src/pages/MemberPage/ui/connection-manage/ConnectionManageTargetStep.tsx
+++ b/src/pages/MemberPage/ui/connection-manage/ConnectionManageTargetStep.tsx
@@ -1,0 +1,153 @@
+import {twMerge} from 'tailwind-merge';
+import {type TShiftTeam} from '@/entities/ward';
+import {CheckedIcon, MoreIcon, PersonIcon, UncheckedIcon2, UnlinkedIcon} from '@/shared/assets/svg';
+import type {TConnectMode} from '../../model/connectionManage';
+import {getGroupedDivisionNurses} from '../../model/connectionManage';
+
+interface IConnectionManageTargetStepProps {
+    shiftTeams: TShiftTeam[] | undefined;
+    connectMode: TConnectMode;
+    toLinkNurseId: number | null;
+    toAddShiftTeamId: number | null;
+    isNextDisabled: boolean;
+    onBack: () => void;
+    onNext: () => void;
+    onSelectLinkNurse: (nurseId: number) => void;
+    onSelectShiftTeam: (shiftTeamId: number) => void;
+}
+
+function ConnectionManageTargetStep({
+    shiftTeams,
+    connectMode,
+    toLinkNurseId,
+    toAddShiftTeamId,
+    isNextDisabled,
+    onBack,
+    onNext,
+    onSelectLinkNurse,
+    onSelectShiftTeam,
+}: IConnectionManageTargetStepProps) {
+    return (
+        <div
+            className="h-[83%] min-h-225.75 w-[40%] min-w-190 rounded-[1.25rem] bg-white px-10.5 py-8.75"
+            onClick={(event) => event.stopPropagation()}
+        >
+            <div className="flex items-center justify-between">
+                <h1 className="font-apple text-[1.75rem] font-semibold text-text-1">
+                    {connectMode === 'link' ? '연동할 간호사를 선택해 주세요.' : '팀을 선택해 주세요.'}
+                </h1>
+                <div className="ml-auto flex gap-5">
+                    <button
+                        className="flex h-7.5 items-center rounded-[1.875rem] border-[.0625rem] border-sub-3 px-[.75rem] font-apple text-[1rem] text-sub-3"
+                        onClick={onBack}
+                    >
+                        이전
+                    </button>
+                    <button
+                        disabled={isNextDisabled}
+                        className="flex h-7.5 items-center rounded-[1.875rem] border-[.0625rem] border-main-1 px-[.75rem] font-apple text-[1rem] text-main-1 disabled:border-sub-3 disabled:text-sub-3"
+                        onClick={onNext}
+                    >
+                        다음
+                    </button>
+                </div>
+            </div>
+            <p className="pt-[.375rem] font-apple text-[1rem] font-medium text-sub-3">
+                {connectMode === 'link'
+                    ? '미연동 상태인 간호사 목록 중에 일치하는 계정을 선택해주세요.'
+                    : '팀을 선택해주시면 해당 팀에 계정이 추가됩니다.'}
+            </p>
+            <div
+                className={`mb-8 scrollbar-hide flex h-[calc(100%-5rem)] items-start gap-10 overflow-y-scroll ${
+                    connectMode === 'add' ? 'pt-25.5' : ''
+                }`}
+            >
+                {shiftTeams?.map((shiftTeam) => (
+                    <div
+                        className={twMerge(
+                            'relative mt-5.5 flex w-75 flex-col rounded-2xl border-[.0625rem] border-sub-4.5 shadow-banner',
+                            toAddShiftTeamId === shiftTeam.shiftTeamId && 'border-[.125rem] border-main-1',
+                        )}
+                        key={shiftTeam.shiftTeamId}
+                    >
+                        {connectMode === 'add' ? (
+                            toAddShiftTeamId === shiftTeam.shiftTeamId ? (
+                                <CheckedIcon className="absolute -top-6 left-[50%] h-9 w-9 translate-x-[-50%] -translate-y-full cursor-pointer" />
+                            ) : (
+                                <UncheckedIcon2
+                                    className="absolute -top-6 left-[50%] h-9 w-9 translate-x-[-50%] -translate-y-full cursor-pointer"
+                                    onClick={() => onSelectShiftTeam(shiftTeam.shiftTeamId)}
+                                />
+                            )
+                        ) : null}
+                        <div className="relative flex w-full items-center justify-between rounded-t-[.9375rem] bg-sub-2 px-5 py-[.875rem]">
+                            <div className="flex flex-col gap-[.3125rem]">
+                                <h2 className="font-apple text-[1.5rem] font-semibold text-white">{shiftTeam.name}</h2>
+                                <div className="flex items-center">
+                                    <PersonIcon className="h-4 w-4" />
+                                    <p className="font-poppins text-[.75rem] text-white">{shiftTeam.nurses.length}</p>
+                                </div>
+                            </div>
+                            <MoreIcon className="h-7.5 w-7.5 cursor-pointer" />
+                        </div>
+                        {shiftTeam.nurses.length === 0 && (
+                            <div className="flex h-14 w-full cursor-pointer items-center justify-center select-none">
+                                <h3 className="font-apple text-[1.25rem] font-semibold text-sub-2.5">아직 간호사가 없습니다!</h3>
+                            </div>
+                        )}
+                        {getGroupedDivisionNurses(shiftTeam.nurses).map(([, divisionNurses], divisionIndex) => (
+                            <div key={divisionIndex} className="border-b-[.0938rem] border-sub-2.5 last:border-none">
+                                {divisionNurses.map((nurse) => (
+                                    <div
+                                        key={nurse.nurseId}
+                                        className={`group relative flex h-14 w-full ${
+                                            nurse.isConnected ? 'cursor-default' : 'cursor-pointer'
+                                        } items-center justify-center select-none ${
+                                            toLinkNurseId === nurse.nurseId
+                                                ? 'bg-main-4 text-main-1 underline underline-offset-2'
+                                                : 'bg-white text-sub-1'
+                                        } ${
+                                            shiftTeam.nurses.findIndex((shiftTeamNurse) => shiftTeamNurse.nurseId === nurse.nurseId) ===
+                                            shiftTeam.nurses.length - 1
+                                                ? 'rounded-b-[.9375rem]'
+                                                : 'border-b-[.0313rem] border-b-sub-4.5'
+                                        }`}
+                                        onClick={() => {
+                                            if (!nurse.isConnected) {
+                                                onSelectLinkNurse(nurse.nurseId);
+                                            }
+                                        }}
+                                    >
+                                        <div className="peer relative font-apple text-[1.25rem] font-semibold text-sub-1">
+                                            {nurse.name}
+                                            {!nurse.isConnected && (
+                                                <div className="absolute top-0 right-[-.3125rem] h-[.3125rem] w-[.3125rem] rounded-full bg-red"></div>
+                                            )}
+                                        </div>
+                                        {!nurse.isConnected && (
+                                            <div className="invisible absolute top-0 z-30 flex translate-y-[-60%] items-center gap-[.5rem] rounded-[.3125rem] bg-white px-2 py-1 font-apple text-[.875rem] whitespace-nowrap text-sub-2 shadow-shadow-2 peer-hover:visible">
+                                                <div
+                                                    className="absolute -bottom-1.5 left-[50%] h-0 w-0 translate-x-[-50%]"
+                                                    style={{
+                                                        borderTop: '.625rem solid white',
+                                                        borderLeft: '.4375rem solid transparent',
+                                                        borderRight: '.4375rem solid transparent',
+                                                        borderBottom: '.625rem solid none',
+                                                    }}
+                                                />
+                                                연동 되지 않은 가상의 프로필입니다.
+                                                <UnlinkedIcon className="h-5 w-5" />
+                                            </div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        ))}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default ConnectionManageTargetStep;

--- a/src/pages/MemberPage/ui/connection-manage/ConnectionManageWaitingStep.tsx
+++ b/src/pages/MemberPage/ui/connection-manage/ConnectionManageWaitingStep.tsx
@@ -1,0 +1,77 @@
+import {ProfileImage} from '@/entities/account/ui/profile-image';
+import {type TWaitingNurse} from '@/entities/nurse';
+import {CancelIcon} from '@/shared/assets/svg';
+import {getWaitingNurseSummary} from '../../model/connectionManage';
+
+interface IConnectionManageWaitingStepProps {
+    waitingNurses: TWaitingNurse[] | undefined;
+    onClose: () => void;
+    onAccept: (waitingNurse: TWaitingNurse) => void;
+    onReject: (nurseId: number) => void;
+}
+
+function ConnectionManageWaitingStep({waitingNurses, onClose, onAccept, onReject}: IConnectionManageWaitingStepProps) {
+    return (
+        <div
+            className="h-[44%] min-h-117.5 w-[40%] min-w-190 rounded-[1.25rem] bg-white px-10.5 py-8.75"
+            onClick={(event) => event.stopPropagation()}
+        >
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                    <h1 className="font-apple text-[1.75rem] font-semibold text-text-1">연동 관리</h1>
+                </div>
+                <CancelIcon className="h-7.5 w-7.5" onClick={onClose} />
+            </div>
+            <div className="h-full overflow-hidden pt-10.5">
+                <p className="font-apple text-[1rem] font-medium text-sub-3">신청 내역</p>
+                {waitingNurses?.length === 0 ? (
+                    <div className="flex h-[calc(100%-80px)] items-center justify-center font-apple text-[1.7rem] text-sub-2">
+                        연동 신청을 한 간호사가 없습니다.
+                    </div>
+                ) : (
+                    <div className="mt-6 scrollbar-hide flex h-[calc(100%-5.9375rem)] flex-col gap-4 overflow-scroll">
+                        {waitingNurses?.map((waitingNurse) => {
+                            const waitingNurseSummary = getWaitingNurseSummary(waitingNurse);
+
+                            return (
+                                <div
+                                    key={waitingNurse.waitingNurseId}
+                                    className="flex h-18 shrink-0 items-center rounded-[.625rem] border-[.0625rem] border-sub-4.5 bg-main-bg px-5"
+                                >
+                                    <ProfileImage className="h-8 w-8" profileImg={{profileImgUrl: waitingNurse.profileImgUrl}} />
+                                    <p className="ml-[.625rem] font-apple text-[1.5rem] font-medium text-sub-1">{waitingNurse.name}</p>
+                                    <div
+                                        className={`ml-8 flex h-5 w-7 items-center justify-center rounded-[.3125rem] bg-sub-5 font-apple text-[.875rem] ${
+                                            waitingNurse.gender === '남' ? 'text-[#A2A6F5]' : 'text-[#F5A2C5]'
+                                        }`}
+                                    >
+                                        {waitingNurse.gender}
+                                    </div>
+                                    <p className="ml-4 font-poppins text-[1.25rem] font-medium text-sub-1">
+                                        {waitingNurseSummary.formattedPhoneNumber}
+                                    </p>
+                                    <div className="ml-auto flex h-11.5 w-36.5 items-center justify-center gap-[.125rem] rounded-[.3125rem] border-[.0313rem] border-sub-4 bg-sub-5 p-[.125rem]">
+                                        <button
+                                            className="flex h-9.5 flex-1 items-center justify-center rounded-[.3125rem] font-poppins text-[1.5rem] text-sub-2.5 hover:bg-main-1 hover:text-white"
+                                            onClick={() => onAccept(waitingNurse)}
+                                        >
+                                            수락
+                                        </button>
+                                        <button
+                                            className="flex h-9.5 flex-1 items-center justify-center rounded-[.3125rem] font-poppins text-[1.5rem] text-sub-2.5 hover:bg-sub-2 hover:text-white"
+                                            onClick={() => confirm('정말 거절하시겠습니까?') && onReject(waitingNurse.nurseId)}
+                                        >
+                                            거절
+                                        </button>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default ConnectionManageWaitingStep;


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-870](https://gom3.atlassian.net/browse/DUT-870)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `ConnectionManage`의 step 상태, 선택 상태, 완료 처리 로직을 `useConnectionManageController`로 분리했습니다.
- 연동 관리 모달의 4개 step을 page 전용 하위 컴포넌트로 분리해 view 책임을 나눴습니다.
- 전화번호 포맷팅과 division 그룹 계산을 `connectionManage` helper로 옮겨 step 컴포넌트의 계산 책임을 줄였습니다.

<br>

## To Reviewers

- 기능 동작 변경 없이 구조 개선에 집중한 PR입니다.
- `./node_modules/.bin/eslint src/pages/MemberPage/ui/ConnectionManage.tsx src/pages/MemberPage/model/connectionManage.ts src/pages/MemberPage/model/useConnectionManageController.ts src/pages/MemberPage/ui/connection-manage/*.tsx` 통과를 확인했습니다.
- `./node_modules/.bin/tsc -b`는 기존 `RequestShiftPage`/`shared/util/event.ts` 전역 타입 에러로 실패했습니다.


[DUT-870]: https://gom3.atlassian.net/browse/DUT-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ