### PR TITLE
[DUT-868]: 신청근무 상태 표현 정리

### DIFF
--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -377,8 +377,14 @@ const useRequestShift = (activeEffect = false) => {
         handleToggleEditMode();
     };
     const retry = useCallback(async () => {
-        await Promise.all([refetchShiftTeams(), refetchDutyRequestList(), refetchRequestShift()]);
-    }, [refetchDutyRequestList, refetchRequestShift, refetchShiftTeams]);
+        const retryTasks: Promise<unknown>[] = [refetchShiftTeams()];
+
+        if (currentShiftTeamId !== null) {
+            retryTasks.push(refetchDutyRequestList(), refetchRequestShift());
+        }
+
+        await Promise.all(retryTasks);
+    }, [currentShiftTeamId, refetchDutyRequestList, refetchRequestShift, refetchShiftTeams]);
 
     useEffect(() => {
         if (activeEffect && requestShift) {

--- a/src/pages/RequestShiftPage/index.test.tsx
+++ b/src/pages/RequestShiftPage/index.test.tsx
@@ -1,0 +1,145 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen, userEvent} from '@/shared/util/test-utils';
+import RequestShiftPage from './index';
+
+const mockUseRequestShift = vi.fn();
+
+vi.mock('@/features/shift/useRequestShift', () => ({
+    default: (...args: unknown[]) => mockUseRequestShift(...args),
+}));
+
+vi.mock('./ui/Toolbar', () => ({
+    default: () => <div>toolbar</div>,
+}));
+
+vi.mock('./ui/RequestCalendar', () => ({
+    default: () => <div>request-calendar</div>,
+}));
+
+type TMockUseRequestShiftValue = {
+    state: {
+        readonly: boolean;
+        requestShift: {shiftId: number} | null;
+        shiftStatus: 'pending' | 'error' | 'success';
+        shiftTeams: Array<{shiftTeamId: number; name: string}>;
+        shiftTeamsStatus: 'pending' | 'error' | 'success';
+    };
+    actions: {
+        retry: ReturnType<typeof vi.fn>;
+        createNextMonthShift: ReturnType<typeof vi.fn>;
+    };
+};
+
+const createUseRequestShiftValue = (overrides?: {
+    state?: Partial<TMockUseRequestShiftValue['state']>;
+    actions?: Partial<TMockUseRequestShiftValue['actions']>;
+}): TMockUseRequestShiftValue => {
+    const baseValue = baseUseRequestShiftValue();
+
+    return {
+        ...baseValue,
+        ...overrides,
+        state: {
+            ...baseValue.state,
+            ...overrides?.state,
+        },
+        actions: {
+            ...baseValue.actions,
+            ...overrides?.actions,
+        },
+    };
+};
+
+function baseUseRequestShiftValue(): TMockUseRequestShiftValue {
+    return {
+        state: {
+            readonly: true,
+            requestShift: {shiftId: 1},
+            shiftStatus: 'success' as const,
+            shiftTeams: [{shiftTeamId: 1, name: '중환자실 A팀'}],
+            shiftTeamsStatus: 'success' as const,
+        },
+        actions: {
+            retry: vi.fn(),
+            createNextMonthShift: vi.fn(),
+        },
+    };
+}
+
+describe('RequestShiftPage', () => {
+    beforeEach(() => {
+        mockUseRequestShift.mockReset();
+    });
+
+    it('근무 팀을 불러오는 중이면 초기 로딩 상태를 보여준다', () => {
+        mockUseRequestShift.mockReturnValue(
+            createUseRequestShiftValue({
+                state: {
+                    shiftTeamsStatus: 'pending',
+                },
+            }),
+        );
+
+        render(<RequestShiftPage />);
+
+        expect(screen.getByText('신청 근무 화면을 준비하고 있어요')).toBeInTheDocument();
+        expect(screen.getByText('근무 팀과 신청 근무표를 순서대로 불러오고 있어요.')).toBeInTheDocument();
+    });
+
+    it('신청 근무표 조회 실패 시 재시도를 노출하고 실행한다', async () => {
+        const retry = vi.fn();
+        const user = userEvent.setup();
+
+        mockUseRequestShift.mockReturnValue(
+            createUseRequestShiftValue({
+                state: {
+                    shiftStatus: 'error',
+                },
+                actions: {
+                    retry,
+                },
+            }),
+        );
+
+        render(<RequestShiftPage />);
+
+        expect(screen.getByText('신청 근무표를 불러오지 못했어요')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', {name: '다시 시도'}));
+
+        expect(retry).toHaveBeenCalledTimes(1);
+    });
+
+    it('신청 근무표가 없으면 다음 달 작성 액션을 노출한다', async () => {
+        const createNextMonthShift = vi.fn();
+        const user = userEvent.setup();
+
+        mockUseRequestShift.mockReturnValue(
+            createUseRequestShiftValue({
+                state: {
+                    requestShift: null,
+                },
+                actions: {
+                    createNextMonthShift,
+                },
+            }),
+        );
+
+        render(<RequestShiftPage />);
+
+        expect(screen.getByText('이번 달 신청 근무표가 아직 없어요')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', {name: '다음 달 신청 근무 작성하기'}));
+
+        expect(createNextMonthShift).toHaveBeenCalledTimes(1);
+    });
+
+    it('모든 데이터가 준비되면 캘린더를 보여준다', () => {
+        mockUseRequestShift.mockReturnValue(createUseRequestShiftValue());
+
+        render(<RequestShiftPage />);
+
+        expect(screen.getByText('신청 근무를 확인해 주세요')).toBeInTheDocument();
+        expect(screen.getByText('request-calendar')).toBeInTheDocument();
+    });
+});

--- a/src/pages/RequestShiftPage/index.tsx
+++ b/src/pages/RequestShiftPage/index.tsx
@@ -1,4 +1,5 @@
 import useRequestShift from '@/features/shift/useRequestShift';
+import Button from '@/shared/ui/form-controls/Button';
 import PageState from '@/shared/ui/PageState';
 import SectionHeader from '@/shared/ui/SectionHeader';
 import RequestCalendar from './ui/RequestCalendar';
@@ -10,56 +11,67 @@ const RequestShiftPage = () => {
         actions: {retry, createNextMonthShift},
     } = useRequestShift(true);
     const shiftTeamCount = shiftTeams?.length ?? 0;
-    const showNoTeamsState = shiftTeamsStatus === 'success' && shiftTeamCount === 0;
-    const showLoadingState =
-        shiftTeamsStatus === 'pending' || (shiftTeamsStatus === 'success' && shiftTeamCount > 0 && shiftStatus === 'pending');
-    const showErrorState =
-        shiftTeamsStatus === 'error' || (shiftTeamsStatus === 'success' && shiftTeamCount > 0 && shiftStatus === 'error');
-    const showEmptyState = shiftTeamsStatus === 'success' && shiftTeamCount > 0 && shiftStatus === 'success' && !requestShift;
+    const pageState =
+        shiftTeamsStatus === 'pending'
+            ? {
+                  tone: 'loading' as const,
+                  title: '신청 근무 화면을 준비하고 있어요',
+                  description: '근무 팀과 신청 근무표를 순서대로 불러오고 있어요.',
+              }
+            : shiftTeamsStatus === 'error'
+              ? {
+                    tone: 'error' as const,
+                    title: '근무 팀을 불러오지 못했어요',
+                    description: '잠시 후 다시 시도해 주세요. 문제가 계속되면 새로고침 후 다시 확인해 주세요.',
+                    action: {label: '다시 시도', onClick: () => void retry()},
+                }
+              : shiftTeamCount === 0
+                ? {
+                      tone: 'empty' as const,
+                      title: '아직 등록된 팀이 없어요',
+                      description: '신청 근무를 작성하려면 먼저 근무 팀을 등록해 주세요.',
+                  }
+                : shiftStatus === 'pending'
+                  ? {
+                        tone: 'loading' as const,
+                        title: '신청 근무표를 불러오는 중이에요',
+                        description: '선택한 팀의 신청 근무와 신청 내역을 정리하고 있어요.',
+                    }
+                  : shiftStatus === 'error'
+                    ? {
+                          tone: 'error' as const,
+                          title: '신청 근무표를 불러오지 못했어요',
+                          description: '잠시 후 다시 시도해 주세요. 문제가 계속되면 새로고침 후 다시 확인해 주세요.',
+                          action: {label: '다시 시도', onClick: () => void retry()},
+                      }
+                    : !requestShift
+                      ? {
+                            tone: 'empty' as const,
+                            title: '이번 달 신청 근무표가 아직 없어요',
+                            description: '다음 달 신청 근무표를 먼저 열어 작성할 수 있어요.',
+                        }
+                      : null;
 
     return (
         <div className="flex min-h-screen w-full flex-col px-5 py-5 md:px-10 md:py-10">
             <Toolbar />
 
             <div className="mt-3 flex flex-1 flex-col rounded-[20px] bg-white px-5 py-6 md:px-10 md:py-8">
-                {showNoTeamsState ? (
-                    <PageState
-                        tone="empty"
-                        title="아직 등록된 팀이 없어요"
-                        description="신청 근무를 작성하려면 먼저 근무 팀을 등록해 주세요."
-                        className="py-0"
-                    />
-                ) : showLoadingState ? (
-                    <PageState
-                        tone="loading"
-                        title="신청 근무표를 불러오는 중이에요"
-                        description="잠시만 기다려 주세요."
-                        className="py-0"
-                    />
-                ) : showErrorState ? (
-                    <PageState
-                        tone="error"
-                        title="신청 근무표를 불러오지 못했어요"
-                        description="네트워크 상태를 확인한 뒤 다시 시도해 주세요."
-                        action={{label: '다시 시도', onClick: () => void retry()}}
-                        className="py-0"
-                    />
-                ) : showEmptyState ? (
-                    <PageState
-                        tone="empty"
-                        title="이번 달 신청 근무표가 아직 없어요"
-                        description="다음 달 신청 근무표를 먼저 열어 작성할 수 있어요."
-                        className="py-0"
-                    >
-                        <div className="mt-1 flex justify-center">
-                            <button
-                                type="button"
-                                className="inline-flex h-11 items-center justify-center rounded-[14px] bg-main-light px-5 font-apple text-base font-semibold text-main-1 transition-colors hover:bg-main-4"
-                                onClick={createNextMonthShift}
-                            >
-                                다음 달 신청 근무 작성하기
-                            </button>
-                        </div>
+                {pageState ? (
+                    <PageState {...pageState} className="py-0">
+                        {pageState.tone === 'empty' && !requestShift && shiftTeamCount > 0 ? (
+                            <div className="mt-1 flex justify-center">
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="md"
+                                    className="h-11 rounded-[14px] px-5 font-semibold"
+                                    onClick={createNextMonthShift}
+                                >
+                                    다음 달 신청 근무 작성하기
+                                </Button>
+                            </div>
+                        ) : null}
                     </PageState>
                 ) : (
                     <>

--- a/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.test.tsx
+++ b/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.test.tsx
@@ -1,0 +1,30 @@
+import {describe, expect, it, vi} from 'vitest';
+import {render, screen} from '@/shared/util/test-utils';
+import RequestDutyRequestPanel from './RequestDutyRequestPanel';
+
+vi.mock('@/entities/shift/ui/shift-badge', () => ({
+    default: () => <div>shift-badge</div>,
+}));
+
+describe('RequestDutyRequestPanel', () => {
+    it('신청 내역이 없으면 빈 상태를 일관된 PageState로 보여준다', () => {
+        render(
+            <RequestDutyRequestPanel
+                dutyRequestList={[]}
+                dutyRequestStatus="success"
+                wardShiftTypeMap={new Map()}
+                unresolvedRequestCount={0}
+                readonly={true}
+                updatingRequestId={null}
+                shiftNurseIdByNurseId={new Map()}
+                changeFocus={vi.fn()}
+                acceptRequest={vi.fn()}
+                retry={vi.fn()}
+                onAcceptAnalytics={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText('아직 제출된 신청이 없어요')).toBeInTheDocument();
+        expect(screen.getByText('신청이 들어오면 이 패널에서 바로 확인하고 처리할 수 있어요.')).toBeInTheDocument();
+    });
+});

--- a/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
+++ b/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
@@ -64,7 +64,7 @@ export default function RequestDutyRequestPanel({
                     <PageState
                         tone="error"
                         title="신청 내역을 불러오지 못했어요"
-                        description="잠시 후 다시 시도해 주세요."
+                        description="잠시 후 다시 시도해 주세요. 문제가 계속되면 새로고침 후 다시 확인해 주세요."
                         action={{label: '다시 시도', onClick: () => void retry()}}
                         className="px-0 py-0"
                     />
@@ -143,13 +143,12 @@ export default function RequestDutyRequestPanel({
                         })}
                     </div>
                 ) : (
-                    <div className="flex min-h-[220px] items-center justify-center rounded-[16px] bg-gray-7 px-6 text-center">
-                        <p className="font-apple text-sm leading-6 font-medium text-gray-4">
-                            아직 제출된 신청 근무가 없어요.
-                            <br />
-                            신청이 들어오면 이 패널에서 바로 확인할 수 있어요.
-                        </p>
-                    </div>
+                    <PageState
+                        tone="empty"
+                        title="아직 제출된 신청이 없어요"
+                        description="신청이 들어오면 이 패널에서 바로 확인하고 처리할 수 있어요."
+                        className="min-h-[220px] px-0 py-0"
+                    />
                 )}
             </div>
         </Card>


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-868](https://gom3.atlassian.net/browse/DUT-868)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 신청근무 페이지의 메인 상태 분기를 순차형 `pageState` 계산으로 정리해 로딩/빈 상태/에러 상태의 우선순위를 명확하게 맞췄습니다.
- 근무 팀 조회 실패와 신청 근무표 조회 실패를 구분해 각각 더 직접적인 메시지와 재시도 동선을 제공했습니다.
- 신청 내역 패널의 빈 상태도 `PageState`로 통일하고, 재시도 로직은 팀이 없는 경우 불필요한 refetch를 하지 않도록 정리했습니다.
- 변경된 상태 표현이 회귀되지 않도록 신청근무 페이지와 신청 내역 패널 테스트를 추가했습니다.

<br>

## To Reviewers

- `pnpm type-check`는 기존 `src/shared/util/event.ts`의 미사용 선언 2건으로 현재도 실패합니다. 이번 변경분 자체의 테스트와 대상 파일 lint는 통과했습니다.


[DUT-868]: https://gom3.atlassian.net/browse/DUT-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 오류 상태에서 새로고침 및 재확인 가이드 추가로 사용자 경험 개선
  * 근무표 요청 상태별 메시지 및 UI 일관성 강화

* **테스트**
  * 요청 근무표 페이지 및 관련 컴포넌트 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->