### PR TITLE
[DUT-867]: 신청근무 조건 및 예외 메시지 정리

### DIFF
--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -354,10 +354,12 @@ const useRequestShift = (activeEffect = false) => {
         },
         [focus, requestShift, setState, changeFocusedShift],
     );
-    const handleToggleEditMode = () => {
+    const handleToggleEditMode = (targetDate?: {year: number; month: number}) => {
+        const nextEditAvailability = targetDate ? getRequestShiftEditAvailability(targetDate.year, targetDate.month) : editAvailability;
+
         if (readonly) {
-            if (!editAvailability.canEdit && editAvailability.validationMessage) {
-                showValidationFeedback(editAvailability.validationMessage);
+            if (!nextEditAvailability.canEdit && nextEditAvailability.validationMessage) {
+                showValidationFeedback(nextEditAvailability.validationMessage);
 
                 return;
             }
@@ -377,6 +379,16 @@ const useRequestShift = (activeEffect = false) => {
     };
     const handleCreateNextMonthShift = () => {
         const nextMonth = new Date().getMonth() + 2;
+        const nextDate =
+            nextMonth > 12
+                ? {
+                      year: year + 1,
+                      month: 1,
+                  }
+                : {
+                      year,
+                      month: nextMonth,
+                  };
 
         if (nextMonth > 12) {
             setState('year', year + 1);
@@ -385,7 +397,7 @@ const useRequestShift = (activeEffect = false) => {
             setState('month', nextMonth);
         }
 
-        handleToggleEditMode();
+        handleToggleEditMode(nextDate);
     };
     const retry = useCallback(async () => {
         await Promise.all([refetchShiftTeams(), refetchDutyRequestList(), refetchRequestShift()]);

--- a/src/features/shift/useRequestShift/index.ts
+++ b/src/features/shift/useRequestShift/index.ts
@@ -12,7 +12,7 @@ import {DateUtil} from '@/shared/util/date';
 import {showActionErrorFeedback, showValidationFeedback} from '@/shared/util/feedback';
 import {useRequestShiftStore} from './store';
 import {type TFocus} from './type';
-import {findNurse, keydownEventMapper, moveFocus} from './utils';
+import {findNurse, getRequestShiftEditAvailability, keydownEventMapper, moveFocus} from './utils';
 
 const useRequestShift = (activeEffect = false) => {
     const {
@@ -40,6 +40,7 @@ const useRequestShift = (activeEffect = false) => {
     const shiftTeamQueryKey = shiftTeamsQueryOptions.queryKey;
     const wardConstraintQueryKey = wardConstraintQueryOptions.queryKey;
     const dutyRequestQueryKey = requestListQueryOptions.queryKey;
+    const editAvailability = getRequestShiftEditAvailability(year, month);
     const changeStatusResetTimerRef = useRef<number | null>(null);
     const requestShiftChangeQueueRef = useRef<Array<{focus: TFocus; shiftTypeId: number | null}>>([]);
     const isProcessingRequestShiftQueueRef = useRef(false);
@@ -237,9 +238,13 @@ const useRequestShift = (activeEffect = false) => {
         [dutyRequestQueryKey, queryClient, requestShiftQueryKey, setState, wardId],
     );
     const changeMonth = (type: 'prev' | 'next') => {
+        const targetYear = type === 'prev' ? (month === 1 ? year - 1 : year) : month === 12 ? year + 1 : year;
+        const targetMonth = type === 'prev' ? (month === 1 ? 12 : month - 1) : month === 12 ? 1 : month + 1;
+        const targetAvailability = getRequestShiftEditAvailability(targetYear, targetMonth);
+
         if (type === 'prev') {
-            if (new Date(year, month, 1) <= new Date() && !readonly) {
-                showValidationFeedback('두 달 전 신청 근무는 수정할 수 없습니다.');
+            if (!readonly && targetAvailability.status === 'lockedPast' && targetAvailability.validationMessage) {
+                showValidationFeedback(targetAvailability.validationMessage);
                 setState('readonly', true);
             }
 
@@ -250,8 +255,8 @@ const useRequestShift = (activeEffect = false) => {
                 setState('month', month - 1);
             }
         } else if (type === 'next') {
-            if (new Date(year, month - 1, 1) > new Date()) {
-                showValidationFeedback('두 달 뒤 신청 근무는 아직 수정할 수 없습니다.');
+            if (targetAvailability.status === 'lockedFuture' && targetAvailability.validationMessage) {
+                showValidationFeedback(targetAvailability.validationMessage);
 
                 return;
             }
@@ -351,6 +356,12 @@ const useRequestShift = (activeEffect = false) => {
     );
     const handleToggleEditMode = () => {
         if (readonly) {
+            if (!editAvailability.canEdit && editAvailability.validationMessage) {
+                showValidationFeedback(editAvailability.validationMessage);
+
+                return;
+            }
+
             setState('readonly', false);
         } else {
             setState('readonly', true);
@@ -438,6 +449,7 @@ const useRequestShift = (activeEffect = false) => {
             updatingRequestId,
             currentShiftTeam: shiftTeams?.find((x) => x.shiftTeamId === currentShiftTeamId) as TShiftTeam | null,
             shiftTeams,
+            editAvailability,
         },
         actions: {
             changeRequestShift: (focus: TFocus, shiftTypeId: number | null) => changeRequestShift(focus, shiftTypeId),

--- a/src/features/shift/useRequestShift/type.ts
+++ b/src/features/shift/useRequestShift/type.ts
@@ -59,3 +59,12 @@ export type TFault = {
 };
 
 export type TFaults = Map<string, TFault>;
+
+export type TRequestShiftEditAvailability = {
+    canEdit: boolean;
+    status: 'editable' | 'lockedPast' | 'lockedFuture';
+    validationMessage: string | null;
+    badgeLabel: string;
+    periodLabel: string;
+    description: string;
+};

--- a/src/features/shift/useRequestShift/utils.test.ts
+++ b/src/features/shift/useRequestShift/utils.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it} from 'vitest';
+import {getRequestShiftEditAvailability} from './utils';
+
+describe('useRequestShift utils', () => {
+    const now = new Date('2026-03-21T09:00:00+09:00');
+
+    it('지난달부터 다음 달까지는 수정 가능으로 판단한다', () => {
+        expect(getRequestShiftEditAvailability(2026, 2, now)).toMatchObject({
+            canEdit: true,
+            status: 'editable',
+        });
+        expect(getRequestShiftEditAvailability(2026, 3, now)).toMatchObject({
+            canEdit: true,
+            status: 'editable',
+        });
+        expect(getRequestShiftEditAvailability(2026, 4, now)).toMatchObject({
+            canEdit: true,
+            status: 'editable',
+        });
+    });
+
+    it('두 달 전 달력은 조회 전용으로 판단한다', () => {
+        expect(getRequestShiftEditAvailability(2026, 1, now)).toMatchObject({
+            canEdit: false,
+            status: 'lockedPast',
+            validationMessage: '두 달 전 신청 근무는 수정할 수 없습니다.',
+        });
+    });
+
+    it('두 달 뒤 달력은 아직 작성할 수 없는 상태로 판단한다', () => {
+        expect(getRequestShiftEditAvailability(2026, 5, now)).toMatchObject({
+            canEdit: false,
+            status: 'lockedFuture',
+            validationMessage: '두 달 뒤 신청 근무는 아직 수정할 수 없습니다.',
+        });
+    });
+});

--- a/src/features/shift/useRequestShift/utils.ts
+++ b/src/features/shift/useRequestShift/utils.ts
@@ -1,6 +1,45 @@
 import type {TRequestShift, TWardConstraint, TShiftNurse, TWardShiftType, TShift} from '@/entities';
 import {koToEn} from '@/shared/util/koToEn';
-import {type TFault, type TCheckFaultOptions, type TFocus, type TFaultType} from './type';
+import {type TFault, type TCheckFaultOptions, type TFocus, type TFaultType, type TRequestShiftEditAvailability} from './type';
+
+const REQUEST_SHIFT_EDITABLE_PERIOD_LABEL = '수정 가능 범위: 지난달부터 다음 달까지';
+const getMonthIndex = (year: number, month: number) => year * 12 + month;
+
+export const getRequestShiftEditAvailability = (year: number, month: number, now: Date = new Date()): TRequestShiftEditAvailability => {
+    const currentMonthIndex = getMonthIndex(now.getFullYear(), now.getMonth() + 1);
+    const targetMonthIndex = getMonthIndex(year, month);
+
+    if (targetMonthIndex < currentMonthIndex - 1) {
+        return {
+            canEdit: false,
+            status: 'lockedPast',
+            validationMessage: '두 달 전 신청 근무는 수정할 수 없습니다.',
+            badgeLabel: '조회 전용',
+            periodLabel: REQUEST_SHIFT_EDITABLE_PERIOD_LABEL,
+            description: '이 달은 조회만 가능해요. 제출된 신청과 현재 배치만 확인할 수 있어요.',
+        };
+    }
+
+    if (targetMonthIndex > currentMonthIndex + 1) {
+        return {
+            canEdit: false,
+            status: 'lockedFuture',
+            validationMessage: '두 달 뒤 신청 근무는 아직 수정할 수 없습니다.',
+            badgeLabel: '작성 대기',
+            periodLabel: REQUEST_SHIFT_EDITABLE_PERIOD_LABEL,
+            description: '다음 달 신청 근무까지만 작성할 수 있어요. 아직 열리지 않은 달은 수정할 수 없어요.',
+        };
+    }
+
+    return {
+        canEdit: true,
+        status: 'editable',
+        validationMessage: null,
+        badgeLabel: '수정 가능',
+        periodLabel: REQUEST_SHIFT_EDITABLE_PERIOD_LABEL,
+        description: '현재 달력 범위에서는 신청 근무를 수정할 수 있어요.',
+    };
+};
 
 export const moveFocus = (
     direction: 'left' | 'right' | 'up' | 'down',

--- a/src/pages/RequestShiftPage/index.test.tsx
+++ b/src/pages/RequestShiftPage/index.test.tsx
@@ -19,6 +19,14 @@ vi.mock('./ui/RequestCalendar', () => ({
 type TMockUseRequestShiftValue = {
     state: {
         readonly: boolean;
+        editAvailability: {
+            canEdit: boolean;
+            status: 'editable' | 'lockedPast' | 'lockedFuture';
+            validationMessage: string | null;
+            badgeLabel: string;
+            periodLabel: string;
+            description: string;
+        };
         requestShift: {shiftId: number} | null;
         shiftStatus: 'pending' | 'error' | 'success';
         shiftTeams: Array<{shiftTeamId: number; name: string}>;
@@ -54,6 +62,14 @@ function baseUseRequestShiftValue(): TMockUseRequestShiftValue {
     return {
         state: {
             readonly: true,
+            editAvailability: {
+                canEdit: true,
+                status: 'editable',
+                validationMessage: null,
+                badgeLabel: '수정 가능',
+                periodLabel: '수정 가능 범위: 지난달부터 다음 달까지',
+                description: '현재 달력 범위에서는 신청 근무를 수정할 수 있어요.',
+            },
             requestShift: {shiftId: 1},
             shiftStatus: 'success' as const,
             shiftTeams: [{shiftTeamId: 1, name: '중환자실 A팀'}],
@@ -139,7 +155,7 @@ describe('RequestShiftPage', () => {
 
         render(<RequestShiftPage />);
 
-        expect(screen.getByText('신청 근무를 확인해 주세요')).toBeInTheDocument();
+        expect(screen.getByText('신청 근무를 검토해 주세요')).toBeInTheDocument();
         expect(screen.getByText('request-calendar')).toBeInTheDocument();
     });
 });

--- a/src/pages/RequestShiftPage/index.tsx
+++ b/src/pages/RequestShiftPage/index.tsx
@@ -6,7 +6,7 @@ import Toolbar from './ui/Toolbar';
 
 const RequestShiftPage = () => {
     const {
-        state: {readonly, requestShift, shiftStatus, shiftTeams, shiftTeamsStatus},
+        state: {readonly, requestShift, shiftStatus, shiftTeams, shiftTeamsStatus, editAvailability},
         actions: {retry, createNextMonthShift},
     } = useRequestShift(true);
     const shiftTeamCount = shiftTeams?.length ?? 0;
@@ -16,6 +16,16 @@ const RequestShiftPage = () => {
     const showErrorState =
         shiftTeamsStatus === 'error' || (shiftTeamsStatus === 'success' && shiftTeamCount > 0 && shiftStatus === 'error');
     const showEmptyState = shiftTeamsStatus === 'success' && shiftTeamCount > 0 && shiftStatus === 'success' && !requestShift;
+    const sectionTitle = readonly
+        ? editAvailability.canEdit
+            ? '신청 근무를 검토해 주세요'
+            : '신청 근무를 확인해 주세요'
+        : '신청 근무를 확정해 주세요';
+    const sectionDescription = readonly
+        ? editAvailability.canEdit
+            ? '제출된 신청과 팀별 배치를 먼저 확인한 뒤, 필요하면 수정하기로 바로 편집할 수 있어요.'
+            : editAvailability.description
+        : '셀을 선택한 뒤 단축키로 근무를 입력할 수 있고, 변경 내용은 자동 저장돼요.';
 
     return (
         <div className="flex min-h-screen w-full flex-col px-5 py-5 md:px-10 md:py-10">
@@ -64,12 +74,8 @@ const RequestShiftPage = () => {
                 ) : (
                     <>
                         <SectionHeader
-                            title={readonly ? '신청 근무를 확인해 주세요' : '신청 근무를 확정해 주세요'}
-                            description={
-                                readonly
-                                    ? '제출된 신청 근무와 팀별 배치를 한 화면에서 검토할 수 있어요.'
-                                    : '셀을 선택한 뒤 단축키로 근무를 입력하거나 간호사 신청을 바로 반영할 수 있어요.'
-                            }
+                            title={sectionTitle}
+                            description={sectionDescription}
                             className="mb-8"
                             titleClassName="text-[28px] md:text-[32px]"
                             descriptionClassName="text-base md:text-[20px]"

--- a/src/pages/RequestShiftPage/ui/Toolbar.tsx
+++ b/src/pages/RequestShiftPage/ui/Toolbar.tsx
@@ -4,6 +4,7 @@ import useRequestShift from '@/features/shift/useRequestShift';
 import {NextIcon, PenIcon, PrevIcon, SaveCompleteIcon, SavingIcon} from '@/shared/assets/svg';
 import Button from '@/shared/ui/form-controls/Button';
 import Select from '@/shared/ui/form-controls/Select';
+import StatusBadge from '@/shared/ui/StatusBadge';
 import {cn} from '@/shared/util/style';
 
 const SAVE_STATUS_LABEL: Record<'idle' | 'loading' | 'success' | 'error', string> = {
@@ -21,113 +22,127 @@ const SAVE_STATUS_STYLE: Record<'idle' | 'loading' | 'success' | 'error', string
 
 function Toolbar() {
     const {
-        state: {month, changeStatus, currentShiftTeam, shiftTeams, readonly},
+        state: {month, changeStatus, currentShiftTeam, shiftTeams, readonly, editAvailability},
         actions: {changeMonth, changeShiftTeam, toggleEditMode},
     } = useRequestShift();
     const isSaving = changeStatus === 'loading';
+    const modeTone = !readonly ? 'brand' : editAvailability.canEdit ? 'neutral' : 'warning';
+    const modeLabel = !readonly ? '수정 중' : editAvailability.badgeLabel;
+    const guideMessage = !readonly
+        ? '셀을 선택한 뒤 단축키로 입력하면 자동 저장돼요. 다른 근무를 입력하면 해당 신청은 자동으로 거절됩니다.'
+        : editAvailability.canEdit
+          ? '현재는 확인 모드예요. 제출된 신청을 검토한 뒤 수정하기를 누르면 편집을 시작할 수 있어요.'
+          : editAvailability.description;
 
     return (
-        <div
-            id="toolbar"
-            className="flex flex-col gap-4 rounded-[20px] bg-white px-5 py-5 md:px-8 md:py-6 xl:flex-row xl:items-center xl:justify-between"
-        >
-            <div className="flex flex-col gap-4 md:flex-row md:items-center">
-                <div className="flex items-center gap-2">
-                    <button
-                        type="button"
-                        className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-5"
-                        onClick={() => {
-                            changeMonth('prev');
-                            sendEvent(events.requestPage.toolbar.changeMonth);
-                        }}
-                        disabled={isSaving}
-                        aria-label="이전 달 보기"
-                    >
-                        <PrevIcon className="h-7.5 w-7.5" />
-                    </button>
-                    <p className="min-w-[6rem] text-center font-apple text-2xl font-semibold text-main-1">{month}월</p>
-                    <button
-                        type="button"
-                        className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-5"
-                        onClick={() => {
-                            changeMonth('next');
-                            sendEvent(events.requestPage.toolbar.changeMonth);
-                        }}
-                        disabled={isSaving}
-                        aria-label="다음 달 보기"
-                    >
-                        <NextIcon className="h-7.5 w-7.5" />
-                    </button>
+        <div id="toolbar" className="flex flex-col gap-4 rounded-[20px] bg-white px-5 py-5 md:px-8 md:py-6">
+            <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center">
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-5"
+                            onClick={() => {
+                                changeMonth('prev');
+                                sendEvent(events.requestPage.toolbar.changeMonth);
+                            }}
+                            disabled={isSaving}
+                            aria-label="이전 달 보기"
+                        >
+                            <PrevIcon className="h-7.5 w-7.5" />
+                        </button>
+                        <p className="min-w-[6rem] text-center font-apple text-2xl font-semibold text-main-1">{month}월</p>
+                        <button
+                            type="button"
+                            className="grid size-9 place-items-center rounded-[10px] text-gray-5 transition-colors hover:bg-gray-7 hover:text-sub-1 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-5"
+                            onClick={() => {
+                                changeMonth('next');
+                                sendEvent(events.requestPage.toolbar.changeMonth);
+                            }}
+                            disabled={isSaving}
+                            aria-label="다음 달 보기"
+                        >
+                            <NextIcon className="h-7.5 w-7.5" />
+                        </button>
+                    </div>
+
+                    {currentShiftTeam ? (
+                        <Select
+                            value={currentShiftTeam.shiftTeamId}
+                            options={shiftTeams?.map((shiftTeam) => ({
+                                label: shiftTeam.name,
+                                value: shiftTeam.shiftTeamId,
+                            }))}
+                            className="h-11 w-full md:w-[220px]"
+                            selectClassName="rounded-[14px] border border-gray-6 bg-gray-7 px-4 font-apple text-base font-semibold text-sub-1 outline-none"
+                            disabled={isSaving}
+                            onChange={(e) => {
+                                changeShiftTeam(shiftTeams!.find((shiftTeam) => shiftTeam.shiftTeamId === parseInt(e.target.value, 10))!);
+                                sendEvent(events.requestPage.toolbar.changeShiftTeam);
+                            }}
+                        />
+                    ) : null}
                 </div>
 
-                {currentShiftTeam ? (
-                    <Select
-                        value={currentShiftTeam.shiftTeamId}
-                        options={shiftTeams?.map((shiftTeam) => ({
-                            label: shiftTeam.name,
-                            value: shiftTeam.shiftTeamId,
-                        }))}
-                        className="h-11 w-full md:w-[220px]"
-                        selectClassName="rounded-[14px] border border-gray-6 bg-gray-7 px-4 font-apple text-base font-semibold text-sub-1 outline-none"
-                        disabled={isSaving}
-                        onChange={(e) => {
-                            changeShiftTeam(shiftTeams!.find((shiftTeam) => shiftTeam.shiftTeamId === parseInt(e.target.value, 10))!);
-                            sendEvent(events.requestPage.toolbar.changeShiftTeam);
-                        }}
-                    />
-                ) : null}
+                <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                    {!readonly ? (
+                        <div
+                            className={cn(
+                                'flex items-center gap-2 rounded-[12px] px-4 py-2 font-apple text-sm font-medium transition-colors',
+                                SAVE_STATUS_STYLE[changeStatus],
+                            )}
+                            aria-live="polite"
+                        >
+                            {changeStatus === 'loading' ? (
+                                <SavingIcon className="h-5 w-5" />
+                            ) : changeStatus === 'error' ? (
+                                <TriangleAlert className="h-5 w-5" strokeWidth={2.2} />
+                            ) : (
+                                <SaveCompleteIcon className="h-5 w-5" />
+                            )}
+                            {SAVE_STATUS_LABEL[changeStatus]}
+                        </div>
+                    ) : null}
+
+                    <div className="flex gap-3">
+                        {readonly ? (
+                            <Button
+                                id="editButton"
+                                type="button"
+                                size="md"
+                                className="h-11 rounded-[14px] px-5 font-semibold"
+                                onClick={() => {
+                                    toggleEditMode();
+                                    sendEvent(events.requestPage.toolbar.changeEditMode, 'edit');
+                                }}
+                            >
+                                수정하기
+                                <PenIcon className="h-5 w-5 stroke-white" />
+                            </Button>
+                        ) : (
+                            <Button
+                                type="button"
+                                size="md"
+                                className="h-11 rounded-[14px] px-5 font-semibold"
+                                disabled={isSaving}
+                                onClick={() => {
+                                    toggleEditMode();
+                                    sendEvent(events.requestPage.toolbar.changeEditMode, 'save');
+                                }}
+                            >
+                                {isSaving ? '저장 중...' : '완료'}
+                            </Button>
+                        )}
+                    </div>
+                </div>
             </div>
 
-            <div className="flex flex-col gap-3 md:flex-row md:items-center">
-                {!readonly ? (
-                    <div
-                        className={cn(
-                            'flex items-center gap-2 rounded-[12px] px-4 py-2 font-apple text-sm font-medium transition-colors',
-                            SAVE_STATUS_STYLE[changeStatus],
-                        )}
-                        aria-live="polite"
-                    >
-                        {changeStatus === 'loading' ? (
-                            <SavingIcon className="h-5 w-5" />
-                        ) : changeStatus === 'error' ? (
-                            <TriangleAlert className="h-5 w-5" strokeWidth={2.2} />
-                        ) : (
-                            <SaveCompleteIcon className="h-5 w-5" />
-                        )}
-                        {SAVE_STATUS_LABEL[changeStatus]}
-                    </div>
-                ) : null}
-
-                <div className="flex gap-3">
-                    {readonly ? (
-                        <Button
-                            id="editButton"
-                            type="button"
-                            size="md"
-                            className="h-11 rounded-[14px] px-5 font-semibold"
-                            onClick={() => {
-                                toggleEditMode();
-                                sendEvent(events.requestPage.toolbar.changeEditMode, 'edit');
-                            }}
-                        >
-                            수정하기
-                            <PenIcon className="h-5 w-5 stroke-white" />
-                        </Button>
-                    ) : (
-                        <Button
-                            type="button"
-                            size="md"
-                            className="h-11 rounded-[14px] px-5 font-semibold"
-                            disabled={isSaving}
-                            onClick={() => {
-                                toggleEditMode();
-                                sendEvent(events.requestPage.toolbar.changeEditMode, 'save');
-                            }}
-                        >
-                            {isSaving ? '저장 중...' : '완료'}
-                        </Button>
-                    )}
+            <div className="rounded-[16px] border border-sub-4.5 bg-gray-7 px-4 py-3">
+                <div className="flex flex-wrap items-center gap-2">
+                    <StatusBadge label={modeLabel} tone={modeTone} />
+                    <StatusBadge label={editAvailability.periodLabel} tone="neutral" />
                 </div>
+                <p className="mt-2 font-apple text-sm leading-6 font-medium text-gray-3">{guideMessage}</p>
             </div>
         </div>
     );

--- a/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
+++ b/src/pages/RequestShiftPage/ui/request-calendar/RequestDutyRequestPanel.tsx
@@ -5,7 +5,7 @@ import {type TWardShiftType} from '@/entities/ward';
 import {type TFocus} from '@/features/shift/useRequestShift/type';
 import Card from '@/shared/ui/Card';
 import PageState from '@/shared/ui/PageState';
-import {getDutyRequestStatusLabel, getRequestFocus} from './utils';
+import {getDutyRequestStatusDescription, getDutyRequestStatusLabel, getRequestFocus} from './utils';
 
 interface IRequestDutyRequestPanelProps {
     dutyRequestList: TDutyRequest[] | undefined;
@@ -53,6 +53,12 @@ export default function RequestDutyRequestPanel({
             </div>
 
             <div className="scrollbar-hide max-h-[calc(100vh-18rem)] overflow-y-auto px-5 py-4">
+                <div className="mb-4 rounded-[14px] bg-gray-7 px-4 py-3">
+                    <p className="font-apple text-sm leading-6 font-medium text-gray-3">
+                        신청은 이 패널에서 바로 수락하거나 거절할 수 있어요. 달력에서 다른 근무를 입력하면 해당 신청은 자동으로 거절돼요.
+                    </p>
+                </div>
+
                 {dutyRequestStatus === 'pending' ? (
                     <PageState
                         tone="loading"
@@ -73,6 +79,11 @@ export default function RequestDutyRequestPanel({
                         {dutyRequestList.map((dutyRequest) => {
                             const requestFocus = getRequestFocus(dutyRequest, shiftNurseIdByNurseId);
                             const isUpdating = updatingRequestId === dutyRequest.wardReqShiftId;
+                            const requestStatusDescription = getDutyRequestStatusDescription({
+                                isAccepted: dutyRequest.isAccepted,
+                                readonly,
+                                requestFocus,
+                            });
 
                             return (
                                 <div key={dutyRequest.wardReqShiftId} className="rounded-[16px] border border-gray-6 px-4 py-3">
@@ -99,6 +110,9 @@ export default function RequestDutyRequestPanel({
                                                     {isUpdating ? '처리 중...' : getDutyRequestStatusLabel(dutyRequest.isAccepted)}
                                                 </p>
                                             </div>
+                                            <p className="mt-2 font-apple text-sm leading-6 font-medium text-gray-3">
+                                                {isUpdating ? '신청 상태를 반영하고 있어요.' : requestStatusDescription}
+                                            </p>
                                         </div>
                                     </div>
 

--- a/src/pages/RequestShiftPage/ui/request-calendar/utils.test.ts
+++ b/src/pages/RequestShiftPage/ui/request-calendar/utils.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 import {type TRequestShift} from '@/entities/shift';
-import {getMoveNurseOrderPayload, getRequestFocus} from './utils';
+import {getDutyRequestStatusDescription, getMoveNurseOrderPayload, getRequestFocus} from './utils';
 
 const createRequestShift = (): TRequestShift => ({
     days: [],
@@ -163,5 +163,29 @@ describe('request-calendar utils', () => {
         );
 
         expect(focus).toBeNull();
+    });
+
+    it('미확인 신청은 수정 모드에서 달력 이동 안내를 보여준다', () => {
+        const description = getDutyRequestStatusDescription({
+            isAccepted: null,
+            readonly: false,
+            requestFocus: {
+                shiftNurseName: '김간호',
+                shiftNurseId: 11,
+                day: 2,
+            },
+        });
+
+        expect(description).toBe('이름을 누르면 해당 날짜로 이동해 검토할 수 있어요.');
+    });
+
+    it('달력 위치를 찾을 수 없는 신청은 예외 안내를 보여준다', () => {
+        const description = getDutyRequestStatusDescription({
+            isAccepted: null,
+            readonly: true,
+            requestFocus: null,
+        });
+
+        expect(description).toBe('현재 팀에 연결된 간호사 정보가 없어 달력 위치로는 바로 이동할 수 없어요.');
     });
 });

--- a/src/pages/RequestShiftPage/ui/request-calendar/utils.ts
+++ b/src/pages/RequestShiftPage/ui/request-calendar/utils.ts
@@ -33,6 +33,34 @@ export const getDutyRequestStatusLabel = (isAccepted: boolean | null) => {
     return '확인 필요';
 };
 
+export const getDutyRequestStatusDescription = ({
+    isAccepted,
+    readonly,
+    requestFocus,
+}: {
+    isAccepted: boolean | null;
+    readonly: boolean;
+    requestFocus: TFocus | null;
+}) => {
+    if (isAccepted === true) {
+        return '현재 신청한 근무가 반영되어 있어요.';
+    }
+
+    if (isAccepted === false) {
+        return '현재 근무표에는 다른 근무로 확정되어 있어요.';
+    }
+
+    if (requestFocus === null) {
+        return '현재 팀에 연결된 간호사 정보가 없어 달력 위치로는 바로 이동할 수 없어요.';
+    }
+
+    if (readonly) {
+        return '패널에서는 바로 처리할 수 있고, 수정하기를 누르면 해당 날짜 위치도 함께 확인할 수 있어요.';
+    }
+
+    return '이름을 누르면 해당 날짜로 이동해 검토할 수 있어요.';
+};
+
 export const getRequestFocus = (dutyRequest: TDutyRequest, shiftNurseIdByNurseId: Map<number, number>): TFocus | null => {
     const matchedShiftNurseId = shiftNurseIdByNurseId.get(dutyRequest.nurseId);
 


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-867](https://gom3.atlassian.net/browse/DUT-867)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 신청근무 월별 수정 가능 범위를 공통 헬퍼로 정리하고, 동일 기준으로 월 이동/수정 모드 진입을 안내하도록 맞췄습니다.
- 신청근무 화면 상단에 현재 모드, 수정 가능 범위, 자동 저장 및 예외 처리 규칙을 한 번에 이해할 수 있는 안내 문구를 추가했습니다.
- 신청 내역 패널에 수락/거절 처리 방식, 달력 위치 이동 가능 여부, 간호사 연결 누락 같은 예외 상태 설명을 보강했습니다.
- 조건/예외 메시지 헬퍼에 대한 단위 테스트를 추가했습니다.

<br>

## To Reviewers

- 전체 `pnpm type-check`는 기존 베이스라인 오류인 `src/shared/util/event.ts`의 미사용 상수 2건 때문에 실패합니다. 이번 변경 파일 대상 eslint와 신규/수정 테스트는 통과했습니다.
- 신청근무 수정 가능 범위는 기존 동작 기준(지난달~다음 달) 유지이며, 이번 PR에서는 해당 조건을 진입 시점과 안내 문구에 명시적으로 드러내는 데 집중했습니다.


[DUT-867]: https://gom3.atlassian.net/browse/DUT-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ