### PR TITLE
[DUT-871]: 팀 연결/이동 상태 UX 정리

### DIFF
--- a/src/features/ward/useEditWard/index.ts
+++ b/src/features/ward/useEditWard/index.ts
@@ -1,5 +1,6 @@
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {useCallback} from 'react';
+import toast from 'react-hot-toast';
 import {wardQueryKeys, wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import {WardAPI} from '@/shared/api';
@@ -70,9 +71,19 @@ const useEditWard = () => {
         async (waitingNurseId: number, shiftTeamId: number) => {
             if (!wardId) return;
 
-            await WardAPI.approveWatingNurses(wardId, waitingNurseId, shiftTeamId);
-            await queryClient.invalidateQueries({queryKey: wardQueryKey});
-            await queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
+            try {
+                await WardAPI.approveWatingNurses(wardId, waitingNurseId, shiftTeamId);
+                await queryClient.invalidateQueries({queryKey: wardQueryKey});
+                await queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
+
+                toast.success('선택한 팀에 간호사를 추가했어요.');
+
+                return true;
+            } catch (error) {
+                showActionErrorFeedback(error, '팀 추가에 실패했습니다.');
+
+                return false;
+            }
         },
         [queryClient, wardId, wardQueryKey, wardWaitingNursesQueryKey],
     );
@@ -80,9 +91,19 @@ const useEditWard = () => {
         async (waitingNurseId: number, targetNurseId: number) => {
             if (!wardId) return;
 
-            await WardAPI.connectWatingNurses(wardId, waitingNurseId, targetNurseId);
-            await queryClient.invalidateQueries({queryKey: wardQueryKey});
-            await queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
+            try {
+                await WardAPI.connectWatingNurses(wardId, waitingNurseId, targetNurseId);
+                await queryClient.invalidateQueries({queryKey: wardQueryKey});
+                await queryClient.invalidateQueries({queryKey: wardWaitingNursesQueryKey});
+
+                toast.success('기존 간호사 계정과 연결했어요.');
+
+                return true;
+            } catch (error) {
+                showActionErrorFeedback(error, '기존 간호사 계정 연결에 실패했습니다.');
+
+                return false;
+            }
         },
         [queryClient, wardId, wardQueryKey, wardWaitingNursesQueryKey],
     );

--- a/src/pages/MemberPage/model/connectionManage.test.ts
+++ b/src/pages/MemberPage/model/connectionManage.test.ts
@@ -1,0 +1,86 @@
+import {describe, expect, it} from 'vitest';
+import {type TShiftTeam} from '@/entities/ward';
+import {getConnectionManageResultCopy, getConnectionManageTargetLabel} from './connectionManage';
+
+const shiftTeams: TShiftTeam[] = [
+    {
+        shiftTeamId: 10,
+        name: 'A팀',
+        nurseCnt: 1,
+        nurses: [
+            {
+                nurseId: 1,
+                accountId: 100,
+                shiftTeamId: 10,
+                wardId: 20,
+                name: '김간호',
+                phoneNum: '01012345678',
+                isConnected: true,
+                nurseShiftTypes: [],
+                isWorker: true,
+                isDutyManager: false,
+                isWardManager: false,
+                gender: '여',
+                employmentDate: '2021-08-01',
+                memo: '',
+                isDeleted: false,
+                divisionNum: 0,
+                priority: 1,
+            },
+        ],
+    },
+    {
+        shiftTeamId: 20,
+        name: 'B팀',
+        nurseCnt: 0,
+        nurses: [],
+    },
+];
+
+describe('getConnectionManageTargetLabel', () => {
+    it('returns nurse and team label for link mode', () => {
+        expect(
+            getConnectionManageTargetLabel({
+                connectMode: 'link',
+                shiftTeams,
+                toLinkNurseId: 1,
+                toAddShiftTeamId: null,
+            }),
+        ).toBe('김간호 · A팀');
+    });
+
+    it('returns team label for add mode', () => {
+        expect(
+            getConnectionManageTargetLabel({
+                connectMode: 'add',
+                shiftTeams,
+                toLinkNurseId: null,
+                toAddShiftTeamId: 20,
+            }),
+        ).toBe('B팀');
+    });
+});
+
+describe('getConnectionManageResultCopy', () => {
+    it('explains linked account continuity on success', () => {
+        expect(
+            getConnectionManageResultCopy({
+                submitStatus: 'success',
+                connectMode: 'link',
+                waitingNurseName: '박신청',
+                targetLabel: '김간호 · A팀',
+            }).description,
+        ).toContain('이어서 확인할 수 있어요');
+    });
+
+    it('guides retry and recovery on add failure', () => {
+        expect(
+            getConnectionManageResultCopy({
+                submitStatus: 'error',
+                connectMode: 'add',
+                waitingNurseName: '박신청',
+                targetLabel: 'B팀',
+            }).description,
+        ).toContain('다시 시도하거나 이전 단계로 돌아가');
+    });
+});

--- a/src/pages/MemberPage/model/connectionManage.ts
+++ b/src/pages/MemberPage/model/connectionManage.ts
@@ -1,9 +1,11 @@
 import {groupBy} from 'lodash-es';
 import type {TNurse, TWaitingNurse} from '@/entities/nurse';
+import type {TShiftTeam} from '@/entities/ward';
 
 export type TConnectionManageStep = 0 | 1 | 2 | 3;
 
 export type TConnectMode = 'link' | 'add';
+export type TConnectionManageSubmitStatus = 'idle' | 'loading' | 'success' | 'error';
 
 export const getFormattedPhoneNumber = (phoneNumber: string) =>
     `${phoneNumber.slice(0, 3)}-${phoneNumber.slice(3, 7)}-${phoneNumber.slice(7, 11)}`;
@@ -15,3 +17,75 @@ export const getWaitingNurseSummary = (waitingNurse: TWaitingNurse) => ({
 
 export const getGroupedDivisionNurses = (nurses: TNurse[]) =>
     Object.entries(groupBy(nurses, 'divisionNum')).sort((a, b) => parseInt(a[0]) - parseInt(b[0]));
+
+interface IGetConnectionManageTargetLabelParams {
+    connectMode: TConnectMode;
+    shiftTeams: TShiftTeam[] | undefined;
+    toLinkNurseId: number | null;
+    toAddShiftTeamId: number | null;
+}
+
+export function getConnectionManageTargetLabel({
+    connectMode,
+    shiftTeams,
+    toLinkNurseId,
+    toAddShiftTeamId,
+}: IGetConnectionManageTargetLabelParams) {
+    if (!shiftTeams) return null;
+
+    if (connectMode === 'link') {
+        const targetShiftTeam = shiftTeams.find((shiftTeam) => shiftTeam.nurses.some((nurse) => nurse.nurseId === toLinkNurseId));
+        const targetNurse = targetShiftTeam?.nurses.find((nurse) => nurse.nurseId === toLinkNurseId);
+
+        if (!targetShiftTeam || !targetNurse) return null;
+
+        return `${targetNurse.name} · ${targetShiftTeam.name}`;
+    }
+
+    return shiftTeams.find((shiftTeam) => shiftTeam.shiftTeamId === toAddShiftTeamId)?.name ?? null;
+}
+
+interface IGetConnectionManageResultCopyParams {
+    submitStatus: Exclude<TConnectionManageSubmitStatus, 'idle'>;
+    connectMode: TConnectMode;
+    waitingNurseName?: string;
+    targetLabel?: string | null;
+}
+
+export function getConnectionManageResultCopy({
+    submitStatus,
+    connectMode,
+    waitingNurseName,
+    targetLabel,
+}: IGetConnectionManageResultCopyParams) {
+    const safeWaitingNurseName = waitingNurseName ?? '선택한 간호사';
+    const safeTargetLabel = targetLabel ?? (connectMode === 'link' ? '선택한 간호사 계정' : '선택한 팀');
+
+    if (submitStatus === 'loading') {
+        return {
+            title: connectMode === 'link' ? '기존 계정과 연결하고 있어요' : '선택한 팀으로 이동을 반영하고 있어요',
+            description:
+                connectMode === 'link'
+                    ? `${safeWaitingNurseName} 신청 정보를 ${safeTargetLabel} 계정에 연결하고 있습니다. 잠시만 기다려 주세요.`
+                    : `${safeWaitingNurseName}님을 ${safeTargetLabel} 팀에 추가하고 있습니다. 팀과 관계 변경이 반영될 때까지 잠시만 기다려 주세요.`,
+        };
+    }
+
+    if (submitStatus === 'success') {
+        return {
+            title: connectMode === 'link' ? '기존 계정과 연결했어요' : '팀 추가를 완료했어요',
+            description:
+                connectMode === 'link'
+                    ? `${safeWaitingNurseName} 신청을 ${safeTargetLabel} 계정에 연결했습니다. 이제 기존 계정에서 팀과 관계 정보를 이어서 확인할 수 있어요.`
+                    : `${safeWaitingNurseName}님을 ${safeTargetLabel} 팀에 추가했습니다. 근무자 관리에서 새 관계와 팀 배치를 바로 확인할 수 있어요.`,
+        };
+    }
+
+    return {
+        title: connectMode === 'link' ? '기존 계정과 연결하지 못했어요' : '팀 추가를 완료하지 못했어요',
+        description:
+            connectMode === 'link'
+                ? `${safeTargetLabel} 계정과 연결하지 못했습니다. 다시 시도하거나 이전 단계로 돌아가 다른 계정을 선택해 주세요.`
+                : `${safeWaitingNurseName}님을 ${safeTargetLabel} 팀에 추가하지 못했습니다. 다시 시도하거나 이전 단계로 돌아가 다른 팀을 선택해 주세요.`,
+    };
+}

--- a/src/pages/MemberPage/model/useConnectionManageController.test.tsx
+++ b/src/pages/MemberPage/model/useConnectionManageController.test.tsx
@@ -1,0 +1,60 @@
+import {act} from 'react';
+import {describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@/shared/util/test-utils';
+import useConnectionManageController from './useConnectionManageController';
+
+const waitingNurse = {
+    waitingNurseId: 1,
+    nurseId: 11,
+    name: '박신청',
+    gender: '여',
+    phoneNum: '01012345678',
+    employmentDate: '2024-01-01',
+    profileImgUrl: '',
+};
+
+describe('useConnectionManageController', () => {
+    it('ignores stale submit completion after the flow is reset', async () => {
+        let resolveConnect: ((value: boolean | undefined) => void) | null = null;
+
+        const connectWaitingNurses = vi.fn(
+            () =>
+                new Promise<boolean | undefined>((resolve) => {
+                    resolveConnect = resolve;
+                }),
+        );
+        const approveWaitingNurses = vi.fn();
+        const {result} = renderHook(() =>
+            useConnectionManageController({
+                open: true,
+                approveWaitingNurses,
+                connectWaitingNurses,
+            }),
+        );
+
+        act(() => {
+            result.current.actions.handleSelectWaitingNurse(waitingNurse);
+            result.current.actions.setToLinkNurseId(99);
+        });
+
+        let submitPromise: Promise<void> | undefined;
+
+        act(() => {
+            submitPromise = result.current.actions.handleCompleteSelection();
+        });
+
+        expect(result.current.state.submitStatus).toBe('loading');
+
+        act(() => {
+            result.current.actions.initialize();
+        });
+
+        await act(async () => {
+            resolveConnect?.(true);
+            await submitPromise;
+        });
+
+        expect(result.current.state.step).toBe(0);
+        expect(result.current.state.submitStatus).toBe('idle');
+    });
+});

--- a/src/pages/MemberPage/model/useConnectionManageController.ts
+++ b/src/pages/MemberPage/model/useConnectionManageController.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import type {TWaitingNurse} from '@/entities/nurse';
 import type {TConnectionManageStep, TConnectionManageSubmitStatus, TConnectMode} from './connectionManage';
 
@@ -15,7 +15,10 @@ function useConnectionManageController({open, approveWaitingNurses, connectWaiti
     const [toLinkNurseId, setToLinkNurseId] = useState<number | null>(null);
     const [toAddShiftTeamId, setToAddShiftTeamId] = useState<number | null>(null);
     const [submitStatus, setSubmitStatus] = useState<TConnectionManageSubmitStatus>('idle');
+    const submitRequestIdRef = useRef(0);
+    const isActiveSubmitRequest = useCallback((requestId: number) => submitRequestIdRef.current === requestId, []);
     const initialize = useCallback(() => {
+        submitRequestIdRef.current += 1;
         setStep(0);
         setCurrentWaitingNurse(null);
         setConnectMode('link');
@@ -47,33 +50,52 @@ function useConnectionManageController({open, approveWaitingNurses, connectWaiti
     const handleCompleteSelection = useCallback(async () => {
         if (!currentWaitingNurse) return;
 
+        const requestId = submitRequestIdRef.current + 1;
+
+        submitRequestIdRef.current = requestId;
         setStep(3);
         setSubmitStatus('loading');
 
         if (connectMode === 'link') {
             if (!toLinkNurseId) {
-                setSubmitStatus('error');
+                if (isActiveSubmitRequest(requestId)) {
+                    setSubmitStatus('error');
+                }
 
                 return;
             }
 
             const isSuccess = await connectWaitingNurses(currentWaitingNurse.waitingNurseId, toLinkNurseId);
 
-            setSubmitStatus(isSuccess ? 'success' : 'error');
+            if (isActiveSubmitRequest(requestId)) {
+                setSubmitStatus(isSuccess ? 'success' : 'error');
+            }
 
             return;
         } else {
             if (!toAddShiftTeamId) {
-                setSubmitStatus('error');
+                if (isActiveSubmitRequest(requestId)) {
+                    setSubmitStatus('error');
+                }
 
                 return;
             }
 
             const isSuccess = await approveWaitingNurses(currentWaitingNurse.waitingNurseId, toAddShiftTeamId);
 
-            setSubmitStatus(isSuccess ? 'success' : 'error');
+            if (isActiveSubmitRequest(requestId)) {
+                setSubmitStatus(isSuccess ? 'success' : 'error');
+            }
         }
-    }, [approveWaitingNurses, connectMode, connectWaitingNurses, currentWaitingNurse, toAddShiftTeamId, toLinkNurseId]);
+    }, [
+        approveWaitingNurses,
+        connectMode,
+        connectWaitingNurses,
+        currentWaitingNurse,
+        isActiveSubmitRequest,
+        toAddShiftTeamId,
+        toLinkNurseId,
+    ]);
     const isNextDisabled = useMemo(() => {
         if (!currentWaitingNurse) return true;
 

--- a/src/pages/MemberPage/model/useConnectionManageController.ts
+++ b/src/pages/MemberPage/model/useConnectionManageController.ts
@@ -1,11 +1,11 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import type {TWaitingNurse} from '@/entities/nurse';
-import type {TConnectionManageStep, TConnectMode} from './connectionManage';
+import type {TConnectionManageStep, TConnectionManageSubmitStatus, TConnectMode} from './connectionManage';
 
 interface IUseConnectionManageControllerParams {
     open: boolean;
-    approveWaitingNurses: (waitingNurseId: number, shiftTeamId: number) => void;
-    connectWaitingNurses: (waitingNurseId: number, nurseId: number) => void;
+    approveWaitingNurses: (waitingNurseId: number, shiftTeamId: number) => Promise<boolean | undefined>;
+    connectWaitingNurses: (waitingNurseId: number, nurseId: number) => Promise<boolean | undefined>;
 }
 
 function useConnectionManageController({open, approveWaitingNurses, connectWaitingNurses}: IUseConnectionManageControllerParams) {
@@ -14,12 +14,14 @@ function useConnectionManageController({open, approveWaitingNurses, connectWaiti
     const [connectMode, setConnectMode] = useState<TConnectMode>('link');
     const [toLinkNurseId, setToLinkNurseId] = useState<number | null>(null);
     const [toAddShiftTeamId, setToAddShiftTeamId] = useState<number | null>(null);
+    const [submitStatus, setSubmitStatus] = useState<TConnectionManageSubmitStatus>('idle');
     const initialize = useCallback(() => {
         setStep(0);
         setCurrentWaitingNurse(null);
         setConnectMode('link');
         setToLinkNurseId(null);
         setToAddShiftTeamId(null);
+        setSubmitStatus('idle');
     }, []);
     const goToWaitingList = () => {
         initialize();
@@ -27,36 +29,59 @@ function useConnectionManageController({open, approveWaitingNurses, connectWaiti
     const goToMethodSelection = () => {
         setToLinkNurseId(null);
         setToAddShiftTeamId(null);
+        setSubmitStatus('idle');
         setStep(1);
     };
-    const goToTargetSelection = () => setStep(2);
+    const goToTargetSelection = () => {
+        setSubmitStatus('idle');
+        setStep(2);
+    };
     const handleSelectWaitingNurse = (waitingNurse: TWaitingNurse) => {
         setConnectMode('link');
         setToLinkNurseId(null);
         setToAddShiftTeamId(null);
+        setSubmitStatus('idle');
         setCurrentWaitingNurse(waitingNurse);
         setStep(1);
     };
-    const handleCompleteSelection = () => {
+    const handleCompleteSelection = useCallback(async () => {
         if (!currentWaitingNurse) return;
 
-        if (connectMode === 'link') {
-            if (!toLinkNurseId) return;
-
-            connectWaitingNurses(currentWaitingNurse.waitingNurseId, toLinkNurseId);
-        } else {
-            if (!toAddShiftTeamId) return;
-
-            approveWaitingNurses(currentWaitingNurse.waitingNurseId, toAddShiftTeamId);
-        }
-
         setStep(3);
-    };
+        setSubmitStatus('loading');
+
+        if (connectMode === 'link') {
+            if (!toLinkNurseId) {
+                setSubmitStatus('error');
+
+                return;
+            }
+
+            const isSuccess = await connectWaitingNurses(currentWaitingNurse.waitingNurseId, toLinkNurseId);
+
+            setSubmitStatus(isSuccess ? 'success' : 'error');
+
+            return;
+        } else {
+            if (!toAddShiftTeamId) {
+                setSubmitStatus('error');
+
+                return;
+            }
+
+            const isSuccess = await approveWaitingNurses(currentWaitingNurse.waitingNurseId, toAddShiftTeamId);
+
+            setSubmitStatus(isSuccess ? 'success' : 'error');
+        }
+    }, [approveWaitingNurses, connectMode, connectWaitingNurses, currentWaitingNurse, toAddShiftTeamId, toLinkNurseId]);
     const isNextDisabled = useMemo(() => {
         if (!currentWaitingNurse) return true;
 
         return connectMode === 'link' ? !toLinkNurseId : !toAddShiftTeamId;
     }, [connectMode, currentWaitingNurse, toAddShiftTeamId, toLinkNurseId]);
+    const retryCompleteSelection = useCallback(() => {
+        void handleCompleteSelection();
+    }, [handleCompleteSelection]);
 
     useEffect(() => {
         if (!open) {
@@ -72,6 +97,7 @@ function useConnectionManageController({open, approveWaitingNurses, connectWaiti
             toLinkNurseId,
             toAddShiftTeamId,
             isNextDisabled,
+            submitStatus,
         },
         actions: {
             setConnectMode,
@@ -83,6 +109,7 @@ function useConnectionManageController({open, approveWaitingNurses, connectWaiti
             goToTargetSelection,
             handleSelectWaitingNurse,
             handleCompleteSelection,
+            retryCompleteSelection,
         },
     };
 }

--- a/src/pages/MemberPage/ui/ConnectionManage.tsx
+++ b/src/pages/MemberPage/ui/ConnectionManage.tsx
@@ -2,6 +2,7 @@ import {createPortal} from 'react-dom';
 import {match} from 'ts-pattern';
 import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
 import useEditWard from '@/features/ward/useEditWard';
+import {getConnectionManageTargetLabel} from '../model/connectionManage';
 import useConnectionManageController from '../model/useConnectionManageController';
 import ConnectionManageCompleteStep from './connection-manage/ConnectionManageCompleteStep';
 import ConnectionManageMethodStep from './connection-manage/ConnectionManageMethodStep';
@@ -22,7 +23,7 @@ function ConnectionManage({open, setOpen}: IConnectionManageProps) {
         state: {shiftTeams},
     } = useEditShiftTeam();
     const {
-        state: {step, currentWaitingNurse, connectMode, toLinkNurseId, toAddShiftTeamId, isNextDisabled},
+        state: {step, currentWaitingNurse, connectMode, toLinkNurseId, toAddShiftTeamId, isNextDisabled, submitStatus},
         actions: {
             setConnectMode,
             setToLinkNurseId,
@@ -33,6 +34,7 @@ function ConnectionManage({open, setOpen}: IConnectionManageProps) {
             goToTargetSelection,
             handleSelectWaitingNurse,
             handleCompleteSelection,
+            retryCompleteSelection,
         },
     } = useConnectionManageController({
         open,
@@ -40,6 +42,12 @@ function ConnectionManage({open, setOpen}: IConnectionManageProps) {
         connectWaitingNurses: connectWatingNurses,
     });
     const handleClose = () => setOpen(false);
+    const targetLabel = getConnectionManageTargetLabel({
+        connectMode,
+        shiftTeams,
+        toLinkNurseId,
+        toAddShiftTeamId,
+    });
 
     return open
         ? createPortal(
@@ -67,6 +75,7 @@ function ConnectionManage({open, setOpen}: IConnectionManageProps) {
                       ))
                       .with(2, () => (
                           <ConnectionManageTargetStep
+                              currentWaitingNurse={currentWaitingNurse}
                               shiftTeams={shiftTeams}
                               connectMode={connectMode}
                               toLinkNurseId={toLinkNurseId}
@@ -78,7 +87,18 @@ function ConnectionManage({open, setOpen}: IConnectionManageProps) {
                               onSelectShiftTeam={setToAddShiftTeamId}
                           />
                       ))
-                      .with(3, () => <ConnectionManageCompleteStep onRestart={initialize} onClose={handleClose} />)
+                      .with(3, () => (
+                          <ConnectionManageCompleteStep
+                              submitStatus={submitStatus}
+                              connectMode={connectMode}
+                              waitingNurseName={currentWaitingNurse?.name}
+                              targetLabel={targetLabel}
+                              onRestart={initialize}
+                              onBack={goToMethodSelection}
+                              onRetry={retryCompleteSelection}
+                              onClose={handleClose}
+                          />
+                      ))
                       .otherwise(() => null)}
               </div>,
               document.getElementById('modal-root')!,

--- a/src/pages/MemberPage/ui/connection-manage/ConnectionManageCompleteStep.tsx
+++ b/src/pages/MemberPage/ui/connection-manage/ConnectionManageCompleteStep.tsx
@@ -1,39 +1,98 @@
+import {TriangleAlert} from 'lucide-react';
 import {SuccessCircleIcon} from '@/shared/assets/svg';
+import {type TConnectMode, getConnectionManageResultCopy, type TConnectionManageSubmitStatus} from '../../model/connectionManage';
 
 interface IConnectionManageCompleteStepProps {
+    submitStatus: TConnectionManageSubmitStatus;
+    connectMode: TConnectMode;
+    waitingNurseName?: string;
+    targetLabel?: string | null;
     onRestart: () => void;
+    onBack: () => void;
+    onRetry: () => void;
     onClose: () => void;
 }
 
-function ConnectionManageCompleteStep({onRestart, onClose}: IConnectionManageCompleteStepProps) {
+function ConnectionManageCompleteStep({
+    submitStatus,
+    connectMode,
+    waitingNurseName,
+    targetLabel,
+    onRestart,
+    onBack,
+    onRetry,
+    onClose,
+}: IConnectionManageCompleteStepProps) {
+    if (submitStatus === 'idle') return null;
+
+    const feedback = getConnectionManageResultCopy({
+        submitStatus,
+        connectMode,
+        waitingNurseName,
+        targetLabel,
+    });
+    const isLoading = submitStatus === 'loading';
+    const isError = submitStatus === 'error';
+
     return (
         <div
             className="flex min-h-96 w-[40%] min-w-190 flex-col items-center justify-center rounded-[1.25rem] bg-white"
             onClick={(event) => event.stopPropagation()}
         >
-            <SuccessCircleIcon className="h-15 w-15" />
-            <h1 className="mt-5 font-apple text-[1.75rem] font-semibold text-text-1">간호사 계정이 연동되었습니다.</h1>
-            <p className="mt-[.5rem] font-apple text-[1rem] text-sub-3">
-                연동된 간호사의 계정은{' '}
-                <span className="cursor-pointer text-main-1 underline" onClick={onClose}>
-                    간호사 관리 탭
-                </span>
-                에서 확인하실 수 있어요!
-            </p>
+            {isLoading ? (
+                <div
+                    className="h-15 w-15 animate-spin rounded-full border-[.25rem] border-main-2/20 border-t-main-1"
+                    aria-label="loading"
+                />
+            ) : isError ? (
+                <div className="flex h-15 w-15 items-center justify-center rounded-full bg-[#FFE7EA] text-red">
+                    <TriangleAlert className="h-8 w-8" />
+                </div>
+            ) : (
+                <SuccessCircleIcon className="h-15 w-15" />
+            )}
+            <h1 className="mt-5 font-apple text-[1.75rem] font-semibold text-text-1">{feedback.title}</h1>
+            <p className="mt-[.5rem] max-w-115 text-center font-apple text-[1rem] leading-7 text-sub-3">{feedback.description}</p>
 
             <div className="mt-12 flex w-100">
-                <button
-                    className="h-11.5 flex-1 rounded-l-[3.125rem] border-[.0625rem] border-main-3 bg-main-1 font-apple text-[1.5rem] font-medium text-white"
-                    onClick={onRestart}
-                >
-                    돌아가기
-                </button>
-                <button
-                    className="h-11.5 flex-1 rounded-r-[3.125rem] border-[.0625rem] border-main-3 bg-sub-5 font-apple text-[1.5rem] font-medium text-sub-2.5"
-                    onClick={onClose}
-                >
-                    닫기
-                </button>
+                {isLoading ? (
+                    <button
+                        className="h-11.5 flex-1 rounded-[3.125rem] border-[.0625rem] border-sub-4.5 bg-sub-5 font-apple text-[1.5rem] font-medium text-sub-2.5"
+                        disabled
+                    >
+                        처리 중...
+                    </button>
+                ) : isError ? (
+                    <>
+                        <button
+                            className="h-11.5 flex-1 rounded-l-[3.125rem] border-[.0625rem] border-sub-3 bg-sub-5 font-apple text-[1.5rem] font-medium text-sub-2.5"
+                            onClick={onBack}
+                        >
+                            이전 단계
+                        </button>
+                        <button
+                            className="h-11.5 flex-1 rounded-r-[3.125rem] border-[.0625rem] border-main-3 bg-main-1 font-apple text-[1.5rem] font-medium text-white"
+                            onClick={onRetry}
+                        >
+                            다시 시도
+                        </button>
+                    </>
+                ) : (
+                    <>
+                        <button
+                            className="h-11.5 flex-1 rounded-l-[3.125rem] border-[.0625rem] border-main-3 bg-main-1 font-apple text-[1.5rem] font-medium text-white"
+                            onClick={onRestart}
+                        >
+                            다른 신청 보기
+                        </button>
+                        <button
+                            className="h-11.5 flex-1 rounded-r-[3.125rem] border-[.0625rem] border-main-3 bg-sub-5 font-apple text-[1.5rem] font-medium text-sub-2.5"
+                            onClick={onClose}
+                        >
+                            닫기
+                        </button>
+                    </>
+                )}
             </div>
         </div>
     );

--- a/src/pages/MemberPage/ui/connection-manage/ConnectionManageMethodStep.tsx
+++ b/src/pages/MemberPage/ui/connection-manage/ConnectionManageMethodStep.tsx
@@ -74,12 +74,13 @@ function ConnectionManageMethodStep({
                     )}
                     onClick={() => onChangeConnectMode('add')}
                 >
-                    새로 추가하기
+                    팀에 추가하기
                 </button>
             </div>
-            <p className="mt-[.625rem] font-apple text-[.875rem] text-main-2">
-                *기존 간호사와 연동 시, 미연동 상태인 간호사 목록에서 일치하는 계정을 연결시킬 수 있어요.
-            </p>
+            <div className="mt-[.625rem] space-y-1 font-apple text-[.875rem] text-main-2">
+                <p>*기존 간호사와 연동 시, 미연동 상태인 간호사 목록에서 일치하는 계정을 연결할 수 있어요.</p>
+                <p>*팀에 추가 시, 선택한 팀에 새 간호사 관계가 생성돼요.</p>
+            </div>
         </div>
     );
 }

--- a/src/pages/MemberPage/ui/connection-manage/ConnectionManageTargetStep.tsx
+++ b/src/pages/MemberPage/ui/connection-manage/ConnectionManageTargetStep.tsx
@@ -1,10 +1,12 @@
 import {twMerge} from 'tailwind-merge';
+import {type TWaitingNurse} from '@/entities/nurse';
 import {type TShiftTeam} from '@/entities/ward';
 import {CheckedIcon, MoreIcon, PersonIcon, UncheckedIcon2, UnlinkedIcon} from '@/shared/assets/svg';
 import type {TConnectMode} from '../../model/connectionManage';
-import {getGroupedDivisionNurses} from '../../model/connectionManage';
+import {getConnectionManageTargetLabel, getGroupedDivisionNurses} from '../../model/connectionManage';
 
 interface IConnectionManageTargetStepProps {
+    currentWaitingNurse: TWaitingNurse | null;
     shiftTeams: TShiftTeam[] | undefined;
     connectMode: TConnectMode;
     toLinkNurseId: number | null;
@@ -17,6 +19,7 @@ interface IConnectionManageTargetStepProps {
 }
 
 function ConnectionManageTargetStep({
+    currentWaitingNurse,
     shiftTeams,
     connectMode,
     toLinkNurseId,
@@ -27,6 +30,13 @@ function ConnectionManageTargetStep({
     onSelectLinkNurse,
     onSelectShiftTeam,
 }: IConnectionManageTargetStepProps) {
+    const targetLabel = getConnectionManageTargetLabel({
+        connectMode,
+        shiftTeams,
+        toLinkNurseId,
+        toAddShiftTeamId,
+    });
+
     return (
         <div
             className="h-[83%] min-h-225.75 w-[40%] min-w-190 rounded-[1.25rem] bg-white px-10.5 py-8.75"
@@ -57,8 +67,20 @@ function ConnectionManageTargetStep({
                     ? '미연동 상태인 간호사 목록 중에 일치하는 계정을 선택해주세요.'
                     : '팀을 선택해주시면 해당 팀에 계정이 추가됩니다.'}
             </p>
+            <div className="mt-6 rounded-[1rem] border border-main-3/40 bg-main-4/35 px-5 py-4">
+                <p className="font-apple text-[.9375rem] font-semibold text-main-1">선택 결과 미리보기</p>
+                <p className="mt-2 font-apple text-[1rem] leading-6 text-sub-1">
+                    {targetLabel
+                        ? connectMode === 'link'
+                            ? `${currentWaitingNurse?.name ?? '선택한 간호사'} 신청이 ${targetLabel} 계정에 연결됩니다.`
+                            : `${currentWaitingNurse?.name ?? '선택한 간호사'}님이 ${targetLabel} 팀에 추가됩니다.`
+                        : connectMode === 'link'
+                          ? '대상 계정을 선택하면 어떤 계정으로 연결되는지 바로 확인할 수 있어요.'
+                          : '팀을 선택하면 어느 팀으로 추가되는지 바로 확인할 수 있어요.'}
+                </p>
+            </div>
             <div
-                className={`mb-8 scrollbar-hide flex h-[calc(100%-5rem)] items-start gap-10 overflow-y-scroll ${
+                className={`mb-8 scrollbar-hide flex h-[calc(100%-9.5rem)] items-start gap-10 overflow-y-scroll ${
                     connectMode === 'add' ? 'pt-25.5' : ''
                 }`}
             >


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-871](https://gom3.atlassian.net/browse/DUT-871)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 팀 연결과 팀 추가 흐름에 진행 중/성공/실패 상태를 추가하고, 실패 시 이전 단계 복귀와 재시도 액션을 노출했습니다.
- 대상 선택 단계에서 선택 결과 미리보기를 보여줘 어떤 계정에 연결되거나 어떤 팀으로 추가되는지 사용자 관점에서 바로 이해할 수 있게 했습니다.
- 연결/추가 결과 문구와 토스트 메시지를 분리해 관계 변경 결과가 더 명확하게 전달되도록 정리했습니다.
- `connectionManage` 모델 테스트를 추가해 결과 문구와 대상 라벨 계산을 검증했습니다.

<br>

## To Reviewers

- 전체 `pnpm type-check`는 기존 저장소의 `src/shared/util/event.ts` 미사용 변수 2건 때문에 실패합니다. 이번 변경 파일 대상 `pnpm eslint`와 모델 테스트는 통과했습니다.
- `ConnectionManage` 플로우는 기존 API 호출을 유지한 채 상태 노출만 강화했으니, 실제 QA에서는 링크/팀추가 성공과 실패 케이스를 한 번씩 확인해 주세요.


[DUT-871]: https://gom3.atlassian.net/browse/DUT-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ