### PR TITLE
[DUT-872]: packages/config 초안 분리

### DIFF
--- a/apps/app/eslint.config.mjs
+++ b/apps/app/eslint.config.mjs
@@ -1,230 +1,44 @@
-import js from '@eslint/js';
-import typescript from '@typescript-eslint/eslint-plugin';
-import typescriptParser from '@typescript-eslint/parser';
-import react from 'eslint-plugin-react';
-import reactHooks from 'eslint-plugin-react-hooks';
-import importPlugin from 'eslint-plugin-import';
-import prettier from 'eslint-plugin-prettier';
-import prettierConfig from 'eslint-config-prettier';
-import reactRefresh from 'eslint-plugin-react-refresh';
-import stylistic from '@stylistic/eslint-plugin';
-import globals from 'globals';
+import {dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {createReactAppConfig} from '@dutying/config/eslint/react-app';
 
-export default [
-    js.configs.recommended,
-    {
-        ignores: ['coverage/**', 'dist/**', '**/*', '!src/**', '!cypress/**'],
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+export default createReactAppConfig({
+    project: './tsconfig.app.json',
+    tsconfigRootDir: currentDir,
+    additionalRules: {
+        'import/no-restricted-paths': [
+            'warn',
+            {
+                zones: [
+                    {
+                        target: ['./src/pages'],
+                        from: ['./src/app'],
+                        message: 'pages는 app을 import할 수 없습니다.',
+                    },
+                    {
+                        target: ['./src/widgets'],
+                        from: ['./src/pages', './src/app'],
+                        message: 'widgets는 pages/app을 import할 수 없습니다.',
+                    },
+                    {
+                        target: ['./src/features'],
+                        from: ['./src/widgets', './src/pages', './src/app'],
+                        message: 'features는 widgets/pages/app을 import할 수 없습니다.',
+                    },
+                    {
+                        target: ['./src/entities'],
+                        from: ['./src/features', './src/widgets', './src/pages', './src/app'],
+                        message: 'entities는 상위 레이어를 import할 수 없습니다.',
+                    },
+                    {
+                        target: ['./src/shared'],
+                        from: ['./src/entities', './src/features', './src/widgets', './src/pages', './src/app'],
+                        message: 'shared는 상위 레이어를 import할 수 없습니다.',
+                    },
+                ],
+            },
+        ],
     },
-    {
-        files: ['src/**/*.{ts,tsx,js,jsx}', 'cypress/**/*.{ts,tsx,js,jsx}', '*.{ts,mjs}'],
-        languageOptions: {
-            parser: typescriptParser,
-            parserOptions: {
-                ecmaVersion: 'latest',
-                sourceType: 'module',
-                ecmaFeatures: {
-                    jsx: true,
-                },
-                project: './tsconfig.app.json',
-            },
-            globals: {
-                ...globals.browser,
-                ...globals.node,
-                React: 'readonly',
-            },
-        },
-        plugins: {
-            '@typescript-eslint': typescript,
-            react: react,
-            'react-refresh': reactRefresh,
-            'react-hooks': reactHooks,
-            import: importPlugin,
-            prettier: prettier,
-            '@stylistic': stylistic,
-        },
-        rules: {
-            ...typescript.configs.recommended.rules,
-            ...react.configs.recommended.rules,
-            ...reactHooks.configs.recommended.rules,
-            ...prettierConfig.rules,
-
-            // TypeScript 관련 규칙
-            '@typescript-eslint/no-require-imports': 'off',
-            '@typescript-eslint/consistent-type-imports': ['error', {fixStyle: 'inline-type-imports'}],
-
-            // 일반적인 규칙 완화
-            'no-redeclare': 'off', // TypeScript에서 처리
-            'no-import-assign': 'off', // TypeScript에서 처리
-            'no-constant-condition': 'warn', // 경고로 변경
-
-            // Import 관련 규칙
-            // -------------------------------------------------
-            // FSD 레이어 규칙 + public API 규칙 (단일 선언)
-            // -------------------------------------------------
-            'import/no-restricted-paths': [
-                'warn',
-                {
-                    zones: [
-                        // pages → app 금지
-                        {
-                            target: ['./src/pages'],
-                            from: ['./src/app'],
-                            message: 'pages는 app을 import할 수 없습니다.',
-                        },
-
-                        // widgets → pages/app 금지
-                        {
-                            target: ['./src/widgets'],
-                            from: ['./src/pages', './src/app'],
-                            message: 'widgets는 pages/app을 import할 수 없습니다.',
-                        },
-
-                        // features → widgets/pages/app 금지
-                        {
-                            target: ['./src/features'],
-                            from: ['./src/widgets', './src/pages', './src/app'],
-                            message: 'features는 widgets/pages/app을 import할 수 없습니다.',
-                        },
-
-                        // entities → features/widgets/pages/app 금지
-                        {
-                            target: ['./src/entities'],
-                            from: ['./src/features', './src/widgets', './src/pages', './src/app'],
-                            message: 'entities는 상위 레이어를 import할 수 없습니다.',
-                        },
-
-                        // shared → 모든 상위 레이어 import 금지
-                        {
-                            target: ['./src/shared'],
-                            from: ['./src/entities', './src/features', './src/widgets', './src/pages', './src/app'],
-                            message: 'shared는 상위 레이어를 import할 수 없습니다.',
-                        },
-                    ],
-                },
-            ],
-
-            // -------------------------------------------------
-            // 사이클 방지
-            // -------------------------------------------------
-            'import/no-cycle': ['error', {maxDepth: 3}],
-            'import/no-named-as-default-member': 'off',
-            'import/prefer-default-export': 'off',
-            'import/no-unresolved': 'off',
-            'import/no-extraneous-dependencies': 'off',
-            'import/no-named-as-default': 'off',
-            'import/order': [
-                'error',
-                {
-                    groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
-                    pathGroups: [
-                        {
-                            pattern: '@/**',
-                            group: 'internal',
-                            position: 'before',
-                        },
-                    ],
-                    'newlines-between': 'never',
-                    alphabetize: {order: 'asc', caseInsensitive: true},
-                },
-            ],
-
-            // React 관련 규칙
-            'react/jsx-filename-extension': [
-                1,
-                {
-                    extensions: ['.jsx', '.tsx', '.js'],
-                },
-            ],
-            'react/react-in-jsx-scope': 'off', // React 17+ JSX Transform 사용
-            'react/jsx-key': 'error',
-            'react/display-name': 'off',
-            'react/prop-types': 'off',
-
-            // Prettier 관련 규칙
-            'prettier/prettier': [
-                'error',
-                {
-                    endOfLine: 'auto',
-                },
-            ],
-
-            // @stylistic 스타일 규칙들
-            '@stylistic/no-multiple-empty-lines': ['error', {max: 2, maxEOF: 1}], // 빈 줄 제한
-            '@stylistic/padding-line-between-statements': [
-                'error',
-                // const 선언문 사이에 빈 줄
-                {blankLine: 'always', prev: 'const', next: '*'},
-                {blankLine: 'always', prev: '*', next: 'const'},
-                // let/var 선언문 사이에 빈 줄
-                {blankLine: 'always', prev: ['let', 'var'], next: '*'},
-                {blankLine: 'always', prev: '*', next: ['let', 'var']},
-                // if 문 앞뒤로 빈 줄
-                {blankLine: 'always', prev: '*', next: 'if'},
-                {blankLine: 'always', prev: 'if', next: '*'},
-                // return 문 앞에 빈 줄
-                {blankLine: 'always', prev: '*', next: 'return'},
-                // function 선언 앞뒤로 빈 줄
-                {blankLine: 'always', prev: '*', next: 'function'},
-                {blankLine: 'always', prev: 'function', next: '*'},
-                // for/while 루프 앞뒤로 빈 줄
-                {blankLine: 'always', prev: '*', next: ['for', 'while']},
-                {blankLine: 'always', prev: ['for', 'while'], next: '*'},
-                // try-catch 앞뒤로 빈 줄
-                {blankLine: 'always', prev: '*', next: 'try'},
-                {blankLine: 'always', prev: 'try', next: '*'},
-                // switch 문 앞뒤로 빈 줄
-                {blankLine: 'always', prev: '*', next: 'switch'},
-                {blankLine: 'always', prev: 'switch', next: '*'},
-                // 예외: 연속된 const/let/var 선언은 빈 줄 없이
-                {blankLine: 'never', prev: 'const', next: 'const'},
-                {blankLine: 'never', prev: 'let', next: 'let'},
-                {blankLine: 'never', prev: 'var', next: 'var'},
-            ], // 구문 사이의 빈 줄 규칙
-
-            // 기본 코드 품질 규칙들
-            'prefer-const': 'error', // const 사용 권장
-            'no-var': 'error', // var 사용 금지
-
-            // TypeScript 관련 규칙들
-            '@typescript-eslint/no-unused-vars': [
-                'error',
-                {
-                    argsIgnorePattern: '^_',
-                    varsIgnorePattern: '^_',
-                    caughtErrorsIgnorePattern: '^_',
-                },
-            ],
-
-            // 미사용 변수 체크
-            '@typescript-eslint/prefer-optional-chain': 'error', // 옵셔널 체이닝 권장
-            '@typescript-eslint/prefer-nullish-coalescing': 'error', // ?? 연산자 권장
-            '@typescript-eslint/naming-convention': [
-                'error',
-                {
-                    selector: 'interface',
-                    format: ['PascalCase'],
-                    custom: {regex: '^I[A-Z]', match: true},
-                },
-                {
-                    selector: 'typeAlias',
-                    format: ['PascalCase'],
-                    custom: {regex: '^T[A-Z]', match: true},
-                },
-            ],
-        },
-        settings: {
-            react: {
-                version: 'detect',
-            },
-            'import/parsers': {
-                '@typescript-eslint/parser': ['.ts', '.tsx'],
-            },
-            'import/resolver': {
-                typescript: true,
-                node: {
-                    extensions: ['.js', '.jsx', '.ts', '.tsx'],
-                },
-            },
-        },
-    },
-];
+});

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -68,6 +68,7 @@
         "zustand": "^5.0.8"
     },
     "devDependencies": {
+        "@dutying/config": "workspace:*",
         "@eslint/js": "^9.39.1",
         "@locator/babel-jsx": "^0.5.1",
         "@locator/runtime": "^0.5.1",

--- a/apps/app/tsconfig.app.json
+++ b/apps/app/tsconfig.app.json
@@ -1,30 +1,8 @@
 {
+    "extends": "../../packages/config/typescript/react-app.json",
     "compilerOptions": {
         "composite": true,
         "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-        "target": "ES2020",
-        "useDefineForClassFields": false,
-        "lib": ["ES2020", "DOM", "DOM.Iterable"],
-        "module": "ESNext",
-        "skipLibCheck": true,
-        "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
-
-        /* Bundler mode */
-        "moduleResolution": "bundler",
-        "allowImportingTsExtensions": true,
-        "resolveJsonModule": true,
-        "isolatedModules": false,
-        "moduleDetection": "force",
-        "noEmit": true,
-        "jsx": "react-jsx",
-
-        /* Linting */
-        "strict": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "noFallthroughCasesInSwitch": true,
-
         "baseUrl": ".",
         "paths": {
             "@/*": ["./src/*"]

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -7,11 +7,5 @@
         {
             "path": "./tsconfig.node.json"
         }
-    ],
-    "compilerOptions": {
-        "baseUrl": ".",
-        "paths": {
-            "@/*": ["./src/*"]
-        }
-    }
+    ]
 }

--- a/apps/app/tsconfig.node.json
+++ b/apps/app/tsconfig.node.json
@@ -1,13 +1,9 @@
 {
+    "extends": "../../packages/config/typescript/node.json",
     "compilerOptions": {
         "composite": true,
         "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-        "skipLibCheck": true,
-        "module": "ESNext",
-        "moduleResolution": "bundler",
-        "allowSyntheticDefaultImports": true,
-        "strict": true,
-        "noEmit": true
+        "types": ["node"]
     },
     "include": ["vite.config.ts"]
 }

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -76,7 +76,7 @@ export default defineConfig(({command}) => ({
                 ],
             },
         }),
-        tsconfigPaths(),
+        tsconfigPaths({projects: ['./tsconfig.app.json']}),
         tailwindcss(),
         ...(command === 'serve' ? [mkcert()] : []),
     ],

--- a/packages/config/eslint/react-app.mjs
+++ b/packages/config/eslint/react-app.mjs
@@ -1,0 +1,168 @@
+import js from '@eslint/js';
+import stylistic from '@stylistic/eslint-plugin';
+import typescript from '@typescript-eslint/eslint-plugin';
+import typescriptParser from '@typescript-eslint/parser';
+import prettierConfig from 'eslint-config-prettier';
+import importPlugin from 'eslint-plugin-import';
+import prettier from 'eslint-plugin-prettier';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import globals from 'globals';
+
+const defaultFiles = ['src/**/*.{ts,tsx,js,jsx}', 'cypress/**/*.{ts,tsx,js,jsx}', '*.{ts,mjs}'];
+const defaultIgnores = ['coverage/**', 'dist/**', '**/*', '!src/**', '!cypress/**'];
+
+export function createReactAppConfig({
+    files = defaultFiles,
+    ignores = defaultIgnores,
+    project,
+    tsconfigRootDir,
+    additionalRules = {},
+} = {}) {
+    return [
+        js.configs.recommended,
+        {
+            ignores,
+        },
+        {
+            files,
+            languageOptions: {
+                parser: typescriptParser,
+                parserOptions: {
+                    ecmaVersion: 'latest',
+                    sourceType: 'module',
+                    ecmaFeatures: {
+                        jsx: true,
+                    },
+                    project,
+                    tsconfigRootDir,
+                },
+                globals: {
+                    ...globals.browser,
+                    ...globals.node,
+                    React: 'readonly',
+                },
+            },
+            plugins: {
+                '@stylistic': stylistic,
+                '@typescript-eslint': typescript,
+                import: importPlugin,
+                prettier,
+                react,
+                'react-hooks': reactHooks,
+                'react-refresh': reactRefresh,
+            },
+            rules: {
+                ...typescript.configs.recommended.rules,
+                ...react.configs.recommended.rules,
+                ...reactHooks.configs.recommended.rules,
+                ...prettierConfig.rules,
+                '@typescript-eslint/no-require-imports': 'off',
+                '@typescript-eslint/consistent-type-imports': ['error', {fixStyle: 'inline-type-imports'}],
+                'no-redeclare': 'off',
+                'no-import-assign': 'off',
+                'no-constant-condition': 'warn',
+                'import/no-cycle': ['error', {maxDepth: 3}],
+                'import/no-named-as-default-member': 'off',
+                'import/prefer-default-export': 'off',
+                'import/no-unresolved': 'off',
+                'import/no-extraneous-dependencies': 'off',
+                'import/no-named-as-default': 'off',
+                'import/order': [
+                    'error',
+                    {
+                        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+                        pathGroups: [
+                            {
+                                pattern: '@/**',
+                                group: 'internal',
+                                position: 'before',
+                            },
+                        ],
+                        'newlines-between': 'never',
+                        alphabetize: {order: 'asc', caseInsensitive: true},
+                    },
+                ],
+                'react/jsx-filename-extension': [
+                    1,
+                    {
+                        extensions: ['.jsx', '.tsx', '.js'],
+                    },
+                ],
+                'react/react-in-jsx-scope': 'off',
+                'react/jsx-key': 'error',
+                'react/display-name': 'off',
+                'react/prop-types': 'off',
+                'prettier/prettier': [
+                    'error',
+                    {
+                        endOfLine: 'auto',
+                    },
+                ],
+                '@stylistic/no-multiple-empty-lines': ['error', {max: 2, maxEOF: 1}],
+                '@stylistic/padding-line-between-statements': [
+                    'error',
+                    {blankLine: 'always', prev: 'const', next: '*'},
+                    {blankLine: 'always', prev: '*', next: 'const'},
+                    {blankLine: 'always', prev: ['let', 'var'], next: '*'},
+                    {blankLine: 'always', prev: '*', next: ['let', 'var']},
+                    {blankLine: 'always', prev: '*', next: 'if'},
+                    {blankLine: 'always', prev: 'if', next: '*'},
+                    {blankLine: 'always', prev: '*', next: 'return'},
+                    {blankLine: 'always', prev: '*', next: 'function'},
+                    {blankLine: 'always', prev: 'function', next: '*'},
+                    {blankLine: 'always', prev: '*', next: ['for', 'while']},
+                    {blankLine: 'always', prev: ['for', 'while'], next: '*'},
+                    {blankLine: 'always', prev: '*', next: 'try'},
+                    {blankLine: 'always', prev: 'try', next: '*'},
+                    {blankLine: 'always', prev: '*', next: 'switch'},
+                    {blankLine: 'always', prev: 'switch', next: '*'},
+                    {blankLine: 'never', prev: 'const', next: 'const'},
+                    {blankLine: 'never', prev: 'let', next: 'let'},
+                    {blankLine: 'never', prev: 'var', next: 'var'},
+                ],
+                'prefer-const': 'error',
+                'no-var': 'error',
+                '@typescript-eslint/no-unused-vars': [
+                    'error',
+                    {
+                        argsIgnorePattern: '^_',
+                        varsIgnorePattern: '^_',
+                        caughtErrorsIgnorePattern: '^_',
+                    },
+                ],
+                '@typescript-eslint/prefer-optional-chain': 'error',
+                '@typescript-eslint/prefer-nullish-coalescing': 'error',
+                '@typescript-eslint/naming-convention': [
+                    'error',
+                    {
+                        selector: 'interface',
+                        format: ['PascalCase'],
+                        custom: {regex: '^I[A-Z]', match: true},
+                    },
+                    {
+                        selector: 'typeAlias',
+                        format: ['PascalCase'],
+                        custom: {regex: '^T[A-Z]', match: true},
+                    },
+                ],
+                ...additionalRules,
+            },
+            settings: {
+                react: {
+                    version: 'detect',
+                },
+                'import/parsers': {
+                    '@typescript-eslint/parser': ['.ts', '.tsx'],
+                },
+                'import/resolver': {
+                    typescript: true,
+                    node: {
+                        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+                    },
+                },
+            },
+        },
+    ];
+}

--- a/packages/config/eslint/react-app.mjs
+++ b/packages/config/eslint/react-app.mjs
@@ -11,7 +11,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import globals from 'globals';
 
 const defaultFiles = ['src/**/*.{ts,tsx,js,jsx}', 'cypress/**/*.{ts,tsx,js,jsx}', '*.{ts,mjs}'];
-const defaultIgnores = ['coverage/**', 'dist/**', '**/*', '!src/**', '!cypress/**'];
+const defaultIgnores = ['coverage/**', 'dist/**', '**/*', '!src/**', '!cypress/**', '!*.{ts,mjs}'];
 
 export function createReactAppConfig({
     files = defaultFiles,
@@ -20,6 +20,10 @@ export function createReactAppConfig({
     tsconfigRootDir,
     additionalRules = {},
 } = {}) {
+    if (!project || !tsconfigRootDir) {
+        throw new Error('createReactAppConfig requires both "project" and "tsconfigRootDir".');
+    }
+
     return [
         js.configs.recommended,
         {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@dutying/config",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "exports": {
+        "./eslint/react-app": "./eslint/react-app.mjs",
+        "./typescript/base.json": "./typescript/base.json",
+        "./typescript/react-app.json": "./typescript/react-app.json",
+        "./typescript/node.json": "./typescript/node.json"
+    },
+    "peerDependencies": {
+        "@eslint/js": "^9.39.1",
+        "@stylistic/eslint-plugin": "^5.6.1",
+        "@typescript-eslint/eslint-plugin": "^8.48.0",
+        "@typescript-eslint/parser": "^8.48.0",
+        "eslint": "^9.39.1",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-prettier": "^5.5.4",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^6.1.1",
+        "eslint-plugin-react-refresh": "^0.4.24",
+        "globals": "^16.5.0"
+    }
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,6 +21,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^6.1.1",
         "eslint-plugin-react-refresh": "^0.4.24",
-        "globals": "^16.5.0"
+        "globals": "^16.5.0",
+        "typescript": "^5.9.3"
     }
 }

--- a/packages/config/typescript/base.json
+++ b/packages/config/typescript/base.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "useDefineForClassFields": false,
+        "module": "ESNext",
+        "skipLibCheck": true,
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true,
+        "isolatedModules": false,
+        "moduleDetection": "force",
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    }
+}

--- a/packages/config/typescript/base.json
+++ b/packages/config/typescript/base.json
@@ -7,7 +7,7 @@
         "moduleResolution": "bundler",
         "allowImportingTsExtensions": true,
         "resolveJsonModule": true,
-        "isolatedModules": false,
+        "isolatedModules": true,
         "moduleDetection": "force",
         "strict": true,
         "noUnusedLocals": true,

--- a/packages/config/typescript/node.json
+++ b/packages/config/typescript/node.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./base.json",
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "noEmit": true
+    }
+}

--- a/packages/config/typescript/react-app.json
+++ b/packages/config/typescript/react-app.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./base.json",
+    "compilerOptions": {
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "noEmit": true,
+        "jsx": "react-jsx"
+    }
+}

--- a/packages/config/typescript/react-app.json
+++ b/packages/config/typescript/react-app.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "lib": ["ES2020", "DOM", "DOM.Iterable"],
         "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
         "noEmit": true,
         "jsx": "react-jsx"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.7)(immer@11.0.1)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     devDependencies:
+      '@dutying/config':
+        specifier: workspace:*
+        version: link:../../packages/config
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
@@ -303,6 +306,45 @@ importers:
       vitest:
         specifier: ^4.0.14
         version: 4.0.14(@types/node@24.10.1)(@vitest/ui@4.0.14)(jiti@1.21.7)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1)
+
+  packages/config:
+    dependencies:
+      '@eslint/js':
+        specifier: ^9.39.1
+        version: 9.39.1
+      '@stylistic/eslint-plugin':
+        specifier: ^5.6.1
+        version: 5.6.1(eslint@9.39.1(jiti@2.6.1))
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.48.0
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.48.0
+        version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import:
+        specifier: ^2.32.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.5.4
+        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(prettier@3.5.3)
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react-hooks:
+        specifier: ^6.1.1
+        version: 6.1.1(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.24
+        version: 0.4.24(eslint@9.39.1(jiti@2.6.1))
+      globals:
+        specifier: ^16.5.0
+        version: 16.5.0
 
 packages:
 
@@ -6879,6 +6921,11 @@ snapshots:
       eslint: 9.39.1(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.21.1':
@@ -7491,6 +7538,16 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.3
 
+  '@stylistic/eslint-plugin@5.6.1(eslint@9.39.1(jiti@2.6.1))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
+      '@typescript-eslint/types': 8.48.0
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.3
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -7826,6 +7883,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.48.0
+      '@typescript-eslint/type-utils': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.48.0
+      eslint: 9.39.1(jiti@2.6.1)
+      graphemer: 1.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.48.0
@@ -7834,6 +7908,18 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.48.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.1(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.48.0
+      '@typescript-eslint/types': 8.48.0
+      '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.48.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7868,6 +7954,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.48.0
+      '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.48.0': {}
 
   '@typescript-eslint/typescript-estree@8.48.0(typescript@5.9.3)':
@@ -7892,6 +7990,17 @@ snapshots:
       '@typescript-eslint/types': 8.48.0
       '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.9.3)
       eslint: 9.39.1(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.48.0
+      '@typescript-eslint/types': 8.48.0
+      '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9003,6 +9112,10 @@ snapshots:
     dependencies:
       eslint: 9.39.1(jiti@1.21.7)
 
+  eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.1(jiti@2.6.1)
+
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
       get-tsconfig: 4.13.0
@@ -9044,6 +9157,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7(supports-color@8.1.1)
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -9073,6 +9196,35 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7(supports-color@8.1.1)
+      doctrine: 2.1.0
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))(prettier@3.5.3):
     dependencies:
       eslint: 9.39.1(jiti@1.21.7)
@@ -9081,6 +9233,15 @@ snapshots:
       synckit: 0.11.11
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.39.1(jiti@1.21.7))
+
+  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(prettier@3.5.3):
+    dependencies:
+      eslint: 9.39.1(jiti@2.6.1)
+      prettier: 3.5.3
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.11.11
+    optionalDependencies:
+      eslint-config-prettier: 10.1.8(eslint@9.39.1(jiti@2.6.1))
 
   eslint-plugin-react-hooks@6.1.1(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
@@ -9092,9 +9253,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-react-hooks@6.1.1(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/parser': 7.28.5
+      eslint: 9.39.1(jiti@2.6.1)
+      zod: 4.1.13
+      zod-validation-error: 4.0.2(zod@4.1.13)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-react-refresh@0.4.24(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       eslint: 9.39.1(jiti@1.21.7)
+
+  eslint-plugin-react-refresh@0.4.24(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.1(jiti@2.6.1)
 
   eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
@@ -9105,6 +9280,28 @@ snapshots:
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
       eslint: 9.39.1(jiti@1.21.7)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
+  eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.1
+      eslint: 9.39.1(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -9171,6 +9368,47 @@ snapshots:
       optionator: 0.9.4
     optionalDependencies:
       jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.39.1(jiti@2.6.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.1
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.3
+      '@eslint/js': 9.39.1
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
       globals:
         specifier: ^16.5.0
         version: 16.5.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
 packages:
 


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-872](https://gom3.atlassian.net/browse/DUT-872)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `packages/config` 워크스페이스 패키지를 추가하고 재사용 가능한 TypeScript 베이스 설정과 React 앱 ESLint 베이스 설정을 노출했습니다.
- `apps/app`의 `tsconfig`를 공통 베이스 확장 구조로 정리하고, 솔루션 엔트리/앱 전용 옵션/공통 옵션의 책임을 분리했습니다.
- `apps/app` ESLint 설정을 공통 베이스 + 앱 전용 FSD 경계 규칙 조합으로 단순화하고 `@dutying/config`를 실제 참조하도록 연결했습니다.

<br>

## To Reviewers

- `pnpm lint`는 기존에 존재하던 `apps/app/src/entities/account/ui/profile-image/index.tsx`의 FSD restricted-path 경고 1건만 출력하며 exit code 0으로 통과했습니다.
- 이번 티켓에서는 `apps/app`만 새 config 패키지를 실제 사용하도록 연결했고, 다른 패키지/앱 연결은 후속 티켓 범위로 남겨두었습니다.


[DUT-872]: https://gom3.atlassian.net/browse/DUT-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기타 (Chores)**
  * 개발 환경 설정을 패키지화해 중앙에서 관리하도록 통합했습니다.
  * TypeScript 및 ESLint 설정을 공통 기준으로 표준화했습니다.
  * 빌드 도구의 경로 해석 설정을 명시적으로 제한해 일관성을 강화했습니다.
  * 앱별 구성 파일을 간소화해 유지보수성과 설정 재사용성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->