### PR TITLE
[DUT-865]: 모노레포 desktop wrapper 대응 구조 정리

### DIFF
--- a/apps/app/src/features/auth/useAuth/index.ts
+++ b/apps/app/src/features/auth/useAuth/index.ts
@@ -6,6 +6,7 @@ import useLoadingUseCase from '@/features/ui/useLoading';
 import useTutorialUseCase from '@/features/ui/useTutorial';
 import {AccountAPI, AuthAPI} from '@/shared/api';
 import {setAccessToken} from '@/shared/api/client';
+import {resolveSafeRedirectTarget} from '@/shared/config/runtime';
 import ROUTE from '@/shared/constant/path';
 import useAuthStore from './store';
 
@@ -39,10 +40,12 @@ const useAuth = (activeEffect = false) => {
             return;
         }
 
-        if (nextPageUrl === 'back') {
+        const redirectTarget = resolveSafeRedirectTarget(nextPageUrl);
+
+        if (redirectTarget === 'back') {
             window.history.back();
         } else {
-            location.replace(nextPageUrl ?? ROUTE.MAKE);
+            location.replace(redirectTarget);
         }
 
         sendEvent(events.auth.login);

--- a/apps/app/src/features/file/store.ts
+++ b/apps/app/src/features/file/store.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react';
 import {AccountAPI} from '@/shared/api';
+import {RUNTIME_CONFIG} from '@/shared/config/runtime';
 import {createStore} from '@/shared/util/create-store';
 
 interface IState {
@@ -24,12 +25,12 @@ AccountAPI.getDefaultProfileImages().then((images) => {
         imageBaseUrl: (() => {
             const match = imageUrls[0]?.match(/^(https:\/\/[^/]+)\//);
 
-            return match ? match[1] : 'https://dutying-prod.s3.ap-northeast-2.amazonaws.com';
+            return match ? match[1] : RUNTIME_CONFIG.profileImageBaseUrl();
         })(),
     });
 });
 
-const DEFAULT_IMAGE_BASE_URL = 'https://dutying-prod.s3.ap-northeast-2.amazonaws.com';
+const DEFAULT_IMAGE_BASE_URL = RUNTIME_CONFIG.profileImageBaseUrl();
 
 export const initializeProfileImageStore = async () => {
     try {

--- a/apps/app/src/initializeApp.ts
+++ b/apps/app/src/initializeApp.ts
@@ -8,6 +8,9 @@ export default function initializeApp() {
     enableMapSet();
 
     if (import.meta.env.PROD) {
+        const gaTrackingId = import.meta.env.VITE_GA_TRACKING_ID;
+        const pixelId = import.meta.env.VITE_PIXEL_ID;
+
         Sentry.init({
             dsn: 'https://5035f79c451043f4b6438a90817ff608@o4505477969084416.ingest.us.sentry.io/4505477970526208',
             tracesSampleRate: 0.2,
@@ -16,16 +19,22 @@ export default function initializeApp() {
         });
 
         // GA 관련 초기화
-        ReactGA.initialize(import.meta.env.VITE_GA_TRACKING_ID, {gaOptions: {}});
+        if (gaTrackingId) {
+            ReactGA.initialize(gaTrackingId, {gaOptions: {}});
+        }
 
         const history = createBrowserHistory();
 
         history.listen(async (response) => {
-            ReactGA.send({hitType: 'pageview', page: response.location.pathname});
+            if (gaTrackingId) {
+                ReactGA.send({hitType: 'pageview', page: response.location.pathname});
+            }
         });
 
         // Pixel 관련 초기화
-        ReactPixel.init(import.meta.env.VITE_PIXEL_ID);
-        ReactPixel.pageView();
+        if (pixelId) {
+            ReactPixel.init(pixelId);
+            ReactPixel.pageView();
+        }
     }
 }

--- a/apps/app/src/initializeApp.ts
+++ b/apps/app/src/initializeApp.ts
@@ -23,13 +23,13 @@ export default function initializeApp() {
             ReactGA.initialize(gaTrackingId, {gaOptions: {}});
         }
 
-        const history = createBrowserHistory();
+        if (gaTrackingId) {
+            const history = createBrowserHistory();
 
-        history.listen(async (response) => {
-            if (gaTrackingId) {
+            history.listen(async (response) => {
                 ReactGA.send({hitType: 'pageview', page: response.location.pathname});
-            }
-        });
+            });
+        }
 
         // Pixel 관련 초기화
         if (pixelId) {

--- a/apps/app/src/pages/LoginPage/RedirectPage.tsx
+++ b/apps/app/src/pages/LoginPage/RedirectPage.tsx
@@ -11,8 +11,8 @@ const RedirectPage = () => {
 
     useEffect(() => {
         const query = qs.parse(location.search, {ignoreQueryPrefix: true});
-        const accessToken = query?.['accessToken'] as string;
-        const nextPageUrl = resolveSafeRedirectTarget(query?.['nextPageUrl'] as string | undefined);
+        const accessToken = typeof query?.['accessToken'] === 'string' ? query['accessToken'] : undefined;
+        const nextPageUrl = typeof query?.['nextPageUrl'] === 'string' ? resolveSafeRedirectTarget(query['nextPageUrl']) : undefined;
 
         if (accessToken) {
             handleLogin(accessToken, nextPageUrl);

--- a/apps/app/src/pages/LoginPage/RedirectPage.tsx
+++ b/apps/app/src/pages/LoginPage/RedirectPage.tsx
@@ -2,6 +2,7 @@ import qs from 'qs';
 import {useEffect} from 'react';
 import {TailSpin} from 'react-loader-spinner';
 import useAuth from '@/features/auth/useAuth';
+import {resolveSafeRedirectTarget} from '@/shared/config/runtime';
 
 const RedirectPage = () => {
     const {
@@ -11,7 +12,7 @@ const RedirectPage = () => {
     useEffect(() => {
         const query = qs.parse(location.search, {ignoreQueryPrefix: true});
         const accessToken = query?.['accessToken'] as string;
-        const nextPageUrl = query?.['nextPageUrl'] as string;
+        const nextPageUrl = resolveSafeRedirectTarget(query?.['nextPageUrl'] as string | undefined);
 
         if (accessToken) {
             handleLogin(accessToken, nextPageUrl);

--- a/apps/app/src/pages/LoginPage/index.tsx
+++ b/apps/app/src/pages/LoginPage/index.tsx
@@ -1,6 +1,7 @@
 import {Carousel} from 'react-responsive-carousel';
 import {useNavigate} from 'react-router';
 import {AppleIcon, BackCircle, FullLogo, KakaoIcon, LogoSymbolFill, NextCircle} from '@/shared/assets/svg';
+import {buildAuthAuthorizeUrl, RUNTIME_CONFIG} from '@/shared/config/runtime';
 import ROUTE from '@/shared/constant/path';
 import 'react-responsive-carousel/lib/styles/carousel.min.css'; // requires a loader
 import './index.css';
@@ -47,14 +48,14 @@ const LoginPage = () => {
                 <div className="flex flex-col">
                     <h1 className="font-apple text-[2rem] font-semibold text-text-1">로그인</h1>
                     <a
-                        href={`${import.meta.env.VITE_SERVER_URL}/oauth2/authorization/kakao?nextPageUrl=${location.origin}/make`}
+                        href={buildAuthAuthorizeUrl('kakao')}
                         className="mt-10.5 flex h-25 w-142.5 items-center justify-center rounded-[1.25rem] bg-[#FEE500] shadow-banner"
                     >
                         <KakaoIcon className="mr-12.5 h-8.5 w-9" />
                         <div className="font-apple text-[2rem] text-sub-1">카카오 계정으로 시작하기</div>
                     </a>
                     <a
-                        href={`${import.meta.env.VITE_SERVER_URL}/oauth2/authorization/apple?nextPageUrl=${location.origin}/make`}
+                        href={buildAuthAuthorizeUrl('apple')}
                         className="mt-6 flex h-25 w-142.5 items-center justify-center rounded-[1.25rem] bg-[#231F20] shadow-banner"
                     >
                         <AppleIcon className="mr-12.5 h-8.5 w-9" />
@@ -63,16 +64,10 @@ const LoginPage = () => {
                 </div>
                 <div className="flex font-apple text-[1rem] text-sub-3">
                     버튼을 누르면
-                    <a
-                        href="https://gom3.notion.site/5ed51c04dd5d475c868367ed05a7d903?pvs=4"
-                        className="ml-[.5rem] underline underline-offset-[.1875rem]"
-                    >
+                    <a href={RUNTIME_CONFIG.docs.termsOfService} className="ml-[.5rem] underline underline-offset-[.1875rem]">
                         서비스 약관,
                     </a>
-                    <a
-                        href="https://gom3.notion.site/5ed51c04dd5d475c868367ed05a7d903?pvs=4"
-                        className="ml-[.5rem] underline underline-offset-[.1875rem]"
-                    >
+                    <a href={RUNTIME_CONFIG.docs.privacyPolicy} className="ml-[.5rem] underline underline-offset-[.1875rem]">
                         개인정보 취급 방침
                     </a>
                     에 동의하신 것으로 간주합니다.

--- a/apps/app/src/shared/config/runtime.test.ts
+++ b/apps/app/src/shared/config/runtime.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it, vi} from 'vitest';
+import ROUTE from '@/shared/constant/path';
+import {buildAuthAuthorizeUrl, resolveSafeRedirectTarget, sanitizeInternalPath} from './runtime';
+
+describe('sanitizeInternalPath', () => {
+    it('keeps app-relative paths', () => {
+        expect(sanitizeInternalPath('/member?tab=profile')).toBe('/member?tab=profile');
+    });
+
+    it('falls back for absolute urls', () => {
+        expect(sanitizeInternalPath('https://evil.example/steal')).toBe(ROUTE.MAKE);
+    });
+});
+
+describe('resolveSafeRedirectTarget', () => {
+    it('accepts same-origin absolute redirect and converts it to app-relative path', () => {
+        vi.stubGlobal('window', {
+            location: {
+                origin: 'https://app.dutying.net',
+            },
+        });
+
+        expect(resolveSafeRedirectTarget('https://app.dutying.net/request?month=3#header')).toBe('/request?month=3#header');
+    });
+
+    it('rejects cross-origin redirects', () => {
+        vi.stubGlobal('window', {
+            location: {
+                origin: 'https://app.dutying.net',
+            },
+        });
+
+        expect(resolveSafeRedirectTarget('https://evil.example/request')).toBe(ROUTE.MAKE);
+    });
+});
+
+describe('buildAuthAuthorizeUrl', () => {
+    it('sanitizes invalid nextPath before building auth url', () => {
+        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.net');
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.net');
+
+        const url = new URL(buildAuthAuthorizeUrl('kakao', 'https://evil.example/phish'));
+
+        expect(url.origin).toBe('https://api.dutying.net');
+        expect(url.searchParams.get('nextPageUrl')).toBe('https://app.dutying.net/make');
+    });
+});

--- a/apps/app/src/shared/config/runtime.test.ts
+++ b/apps/app/src/shared/config/runtime.test.ts
@@ -44,4 +44,14 @@ describe('buildAuthAuthorizeUrl', () => {
         expect(url.origin).toBe('https://api.dutying.net');
         expect(url.searchParams.get('nextPageUrl')).toBe('https://app.dutying.net/make');
     });
+
+    it('falls back when env urls are blank strings', () => {
+        vi.stubEnv('VITE_SERVER_URL', '   ');
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.net');
+
+        const url = new URL(buildAuthAuthorizeUrl('apple', ROUTE.REQUEST));
+
+        expect(url.origin).toBe('https://app.dutying.net');
+        expect(url.searchParams.get('nextPageUrl')).toBe('https://app.dutying.net/request');
+    });
 });

--- a/apps/app/src/shared/config/runtime.ts
+++ b/apps/app/src/shared/config/runtime.ts
@@ -6,7 +6,15 @@ const getWindowOrigin = () => {
 
     return window.location.origin;
 };
-const getRuntimeUrl = (envValue: string | undefined, fallback: string) => trimTrailingSlash(envValue ?? fallback);
+const getRuntimeUrl = (envValue: string | undefined, fallback: string) => {
+    const normalized = envValue?.trim();
+
+    if (normalized === '') {
+        return trimTrailingSlash(fallback);
+    }
+
+    return trimTrailingSlash(normalized ?? fallback);
+};
 const INTERNAL_PATH_PATTERN = /^\/(?!\/)/;
 
 export const RUNTIME_CONFIG = {

--- a/apps/app/src/shared/config/runtime.ts
+++ b/apps/app/src/shared/config/runtime.ts
@@ -7,10 +7,11 @@ const getWindowOrigin = () => {
     return window.location.origin;
 };
 const getRuntimeUrl = (envValue: string | undefined, fallback: string) => trimTrailingSlash(envValue ?? fallback);
+const INTERNAL_PATH_PATTERN = /^\/(?!\/)/;
 
 export const RUNTIME_CONFIG = {
     publicAppUrl: () => getRuntimeUrl(import.meta.env.VITE_APP_PUBLIC_URL, getWindowOrigin() ?? 'https://app.dutying.net'),
-    serverUrl: () => getRuntimeUrl(import.meta.env.VITE_SERVER_URL, ''),
+    serverUrl: () => getRuntimeUrl(import.meta.env.VITE_SERVER_URL, RUNTIME_CONFIG.publicAppUrl()),
     profileImageBaseUrl: () =>
         getRuntimeUrl(import.meta.env.VITE_PUBLIC_S3_BASE_URL, 'https://dutying-prod.s3.ap-northeast-2.amazonaws.com'),
     docs: {
@@ -22,12 +23,36 @@ export const RUNTIME_CONFIG = {
     },
 } as const;
 
-export const buildAppUrl = (path: string) => new URL(path, `${RUNTIME_CONFIG.publicAppUrl()}/`).toString();
+export const sanitizeInternalPath = (path: string | null | undefined, fallback: string = ROUTE.MAKE) =>
+    path && INTERNAL_PATH_PATTERN.test(path) ? path : fallback;
+
+export const buildAppUrl = (path: string) => new URL(sanitizeInternalPath(path), `${RUNTIME_CONFIG.publicAppUrl()}/`).toString();
+
+export const resolveSafeRedirectTarget = (target: string | null | undefined, fallback: string = ROUTE.MAKE) => {
+    if (target === 'back') return 'back';
+
+    if (!target) return fallback;
+
+    if (INTERNAL_PATH_PATTERN.test(target)) return target;
+
+    try {
+        const redirectUrl = new URL(target);
+        const allowedOrigins = [getWindowOrigin(), RUNTIME_CONFIG.publicAppUrl()].filter((origin): origin is string => Boolean(origin));
+
+        if (!allowedOrigins.includes(redirectUrl.origin)) {
+            return fallback;
+        }
+
+        return `${sanitizeInternalPath(redirectUrl.pathname, fallback)}${redirectUrl.search}${redirectUrl.hash}`;
+    } catch {
+        return fallback;
+    }
+};
 
 export const buildAuthAuthorizeUrl = (provider: 'kakao' | 'apple', nextPath: string = ROUTE.MAKE) => {
     const url = new URL(`/oauth2/authorization/${provider}`, `${RUNTIME_CONFIG.serverUrl()}/`);
 
-    url.searchParams.set('nextPageUrl', buildAppUrl(nextPath));
+    url.searchParams.set('nextPageUrl', buildAppUrl(sanitizeInternalPath(nextPath)));
 
     return url.toString();
 };

--- a/apps/app/src/shared/config/runtime.ts
+++ b/apps/app/src/shared/config/runtime.ts
@@ -1,0 +1,33 @@
+import ROUTE from '@/shared/constant/path';
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
+const getWindowOrigin = () => {
+    if (typeof window === 'undefined') return undefined;
+
+    return window.location.origin;
+};
+const getRuntimeUrl = (envValue: string | undefined, fallback: string) => trimTrailingSlash(envValue ?? fallback);
+
+export const RUNTIME_CONFIG = {
+    publicAppUrl: () => getRuntimeUrl(import.meta.env.VITE_APP_PUBLIC_URL, getWindowOrigin() ?? 'https://app.dutying.net'),
+    serverUrl: () => getRuntimeUrl(import.meta.env.VITE_SERVER_URL, ''),
+    profileImageBaseUrl: () =>
+        getRuntimeUrl(import.meta.env.VITE_PUBLIC_S3_BASE_URL, 'https://dutying-prod.s3.ap-northeast-2.amazonaws.com'),
+    docs: {
+        termsOfService: import.meta.env.VITE_TERMS_OF_SERVICE_URL ?? 'https://gom3.notion.site/5ed51c04dd5d475c868367ed05a7d903?pvs=4',
+        privacyPolicy: import.meta.env.VITE_PRIVACY_POLICY_URL ?? 'https://gom3.notion.site/5ed51c04dd5d475c868367ed05a7d903?pvs=4',
+        memberTutorial: import.meta.env.VITE_MEMBER_TUTORIAL_URL ?? 'https://gom3.notion.site/befb4602f83241ed896a1700eb592b35?pvs=4',
+        requestTutorial: import.meta.env.VITE_REQUEST_TUTORIAL_URL ?? 'https://gom3.notion.site/befb4602f83241ed896a1700eb592b35?pvs=4',
+        makeTutorial: import.meta.env.VITE_MAKE_TUTORIAL_URL ?? 'https://gom3.notion.site/68d3ad01e68d4d6a8b4cb8c2409353a3?pvs=4',
+    },
+} as const;
+
+export const buildAppUrl = (path: string) => new URL(path, `${RUNTIME_CONFIG.publicAppUrl()}/`).toString();
+
+export const buildAuthAuthorizeUrl = (provider: 'kakao' | 'apple', nextPath: string = ROUTE.MAKE) => {
+    const url = new URL(`/oauth2/authorization/${provider}`, `${RUNTIME_CONFIG.serverUrl()}/`);
+
+    url.searchParams.set('nextPageUrl', buildAppUrl(nextPath));
+
+    return url.toString();
+};

--- a/apps/app/src/vite-env.d.ts
+++ b/apps/app/src/vite-env.d.ts
@@ -1,1 +1,21 @@
 /// <reference types="vite/client" />
+
+/* eslint-disable @typescript-eslint/naming-convention */
+interface ImportMetaEnv {
+    readonly VITE_SERVER_URL?: string;
+    readonly VITE_APP_PUBLIC_URL?: string;
+    readonly VITE_PUBLIC_S3_BASE_URL?: string;
+    readonly VITE_TERMS_OF_SERVICE_URL?: string;
+    readonly VITE_PRIVACY_POLICY_URL?: string;
+    readonly VITE_MEMBER_TUTORIAL_URL?: string;
+    readonly VITE_REQUEST_TUTORIAL_URL?: string;
+    readonly VITE_MAKE_TUTORIAL_URL?: string;
+    readonly VITE_GA_TRACKING_ID?: string;
+    readonly VITE_PIXEL_ID?: string;
+    readonly VITE_AI_SCHEDULE_PROVIDER?: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}
+/* eslint-enable @typescript-eslint/naming-convention */

--- a/apps/app/src/widgets/tutorial/MakeTutorial.tsx
+++ b/apps/app/src/widgets/tutorial/MakeTutorial.tsx
@@ -2,6 +2,7 @@ import {useEffect} from 'react';
 import {createPortal} from 'react-dom';
 import useTutorialUseCase from '@/features/ui/useTutorial';
 import {useTutorialStore} from '@/features/ui/useTutorial/store';
+import {RUNTIME_CONFIG} from '@/shared/config/runtime';
 import {type IStepConfig, type IStepsConfig, TutorialOverlay} from './TutorialOverlay';
 
 const MakeTutorial = () => {
@@ -56,7 +57,7 @@ const MakeTutorial = () => {
         info: '셀을 클릭하시고 D E N O를 입력하시면 근무를 작성하실 수 있어요! \n더 자세한 가이드는 메뉴얼 문서를 참고해주세요!',
         infoBoxAlignment: 'center',
         ctaText: '메뉴얼 보러가기',
-        ctaUrl: 'https://gom3.notion.site/68d3ad01e68d4d6a8b4cb8c2409353a3?pvs=4',
+        ctaUrl: RUNTIME_CONFIG.docs.makeTutorial,
     });
 
     useEffect(() => {

--- a/apps/app/src/widgets/tutorial/MemberTutorial.tsx
+++ b/apps/app/src/widgets/tutorial/MemberTutorial.tsx
@@ -3,6 +3,7 @@ import {createPortal} from 'react-dom';
 import useTutorialUseCase from '@/features/ui/useTutorial';
 import {useTutorialStore} from '@/features/ui/useTutorial/store';
 import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
+import {RUNTIME_CONFIG} from '@/shared/config/runtime';
 import {type IStepConfig, type IStepsConfig, TutorialOverlay} from './TutorialOverlay';
 
 const MemberTutorial = () => {
@@ -53,7 +54,7 @@ const MemberTutorial = () => {
         title: '간호사 관리하기',
         info: '편집을 완료하고 하단에 저장을 눌러주세요! \n더 자세한 가이드는 메뉴얼 문서를 참고해주세요!',
         ctaText: '메뉴얼 보러가기',
-        ctaUrl: 'https://gom3.notion.site/befb4602f83241ed896a1700eb592b35?pvs=4',
+        ctaUrl: RUNTIME_CONFIG.docs.memberTutorial,
 
         infoBoxAlignment: 'right',
         onNextStep: () => {

--- a/apps/app/src/widgets/tutorial/RequestTutorial.tsx
+++ b/apps/app/src/widgets/tutorial/RequestTutorial.tsx
@@ -4,6 +4,7 @@ import useRequestShift from '@/features/shift/useRequestShift';
 import {useRequestShiftStore} from '@/features/shift/useRequestShift/store';
 import useTutorialUseCase from '@/features/ui/useTutorial';
 import {useTutorialStore} from '@/features/ui/useTutorial/store';
+import {RUNTIME_CONFIG} from '@/shared/config/runtime';
 import {type IStepConfig, type IStepsConfig, TutorialOverlay} from './TutorialOverlay';
 
 const RequestTutorial = () => {
@@ -56,7 +57,7 @@ const RequestTutorial = () => {
         infoBoxAlignment: 'center',
         onPrevStep: toggleEditMode,
         ctaText: '메뉴얼 보러가기',
-        ctaUrl: 'https://gom3.notion.site/befb4602f83241ed896a1700eb592b35?pvs=4',
+        ctaUrl: RUNTIME_CONFIG.docs.requestTutorial,
     });
 
     useEffect(() => {

--- a/docs/architecture/desktop-tauri-readiness.md
+++ b/docs/architecture/desktop-tauri-readiness.md
@@ -1,0 +1,133 @@
+# Tauri desktop wrapper 대응 검토
+
+## 결론
+
+- 현재 `apps/app`은 React SPA와 API 서버 분리가 명확해서 `Tauri` webview로 감싸는 방향 자체는 가능하다.
+- 다만 인증 복귀 URL, refresh cookie 정책, 브라우저 API 직접 사용, 다운로드/클립보드/외부 링크 처리, 배포 도메인 하드코딩은 desktop 전환 전에 기준을 먼저 정해야 한다.
+- 이번 단계에서는 실제 `apps/desktop` scaffold 없이도 후속 티켓을 쪼갤 수 있을 만큼의 위험 구간을 식별했다.
+
+## 유지 가능한 영역
+
+- 라우팅, 화면 구성, 대부분의 상태 관리와 API 호출 구조는 그대로 유지 가능하다.
+- `@dutying/api`, `@dutying/domain`, `@dutying/utils` 같은 워크스페이스 패키지는 desktop wrapper 추가 시에도 재사용 가능하다.
+- `axios` 기반 API 계층은 transport adapter만 정리하면 webview 안에서도 계속 사용할 수 있다.
+
+## 주요 리스크와 제약
+
+### 1. 인증과 redirect
+
+- 로그인 시작점이 `${VITE_SERVER_URL}/oauth2/authorization/*?nextPageUrl=${appOrigin}/make` 형식이라, 현재는 브라우저 origin이 곧 복귀 주소라는 가정이 있다.
+- `RedirectPage`는 querystring의 `accessToken`, `nextPageUrl`을 바로 읽는다. Tauri에서는 `https://app.dutying.net`, `tauri://localhost`, custom scheme, loopback URL 중 무엇을 복귀 주소로 쓸지 먼저 정해야 한다.
+- refresh는 `withCredentials: true` 쿠키 기반이며 401 발생 시 `/refresh?next=...`로 강제 이동한다. desktop에서 webview cookie jar가 서버의 `SameSite`, `Secure`, domain 정책과 호환되는지 점검이 필요하다.
+- 이번 변경으로 로그인 시작 URL은 `VITE_APP_PUBLIC_URL` 우선, 브라우저 origin fallback 방식으로 정리했다. desktop에서는 이 값을 명시적으로 주입하는 쪽이 안전하다.
+
+### 2. 브라우저 전용 API
+
+- 직접 사용 확인:
+    - `window.location`, `window.history`, `window.scroll`, `window.dispatchEvent`
+    - `document.*`, `createPortal`, DOM query 및 style 조작
+    - `navigator.clipboard.readText/writeText`
+    - `window.localStorage`
+    - `Blob`, `URL.createObjectURL`, `<a download>`
+- 대부분 Tauri webview 안에서도 동작 가능하지만, 권한/UX/플랫폼 차이 때문에 adapter가 필요한 후보가 명확하다.
+
+### 3. 도메인/환경 변수 하드코딩
+
+- 앱 내부에 `app.dutying.net`, Notion 문서 URL, S3 bucket base URL이 직접 박혀 있었다.
+- 이 값들은 desktop 전용 배포 채널, staging, custom scheme 실험 시 매번 코드 수정 포인트가 된다.
+- `VITE_APP_PUBLIC_URL`, `VITE_PUBLIC_S3_BASE_URL`, 문서 URL env를 두고 런타임 구성으로 노출하는 편이 안전하다.
+
+### 4. 파일 업로드/다운로드와 저장소 접근
+
+- 업로드는 브라우저 `File` 객체 + presigned URL PUT 방식이라 Tauri에서도 파일 picker가 webview `File`을 넘겨주면 유지 가능하다.
+- 반대로 다운로드는 `Blob`과 `<a download>`에 의존하므로 desktop에서는 저장 경로 선택, OS 파일 시스템 접근, 저장 완료 피드백을 위한 별도 adapter가 필요할 수 있다.
+- local draft는 `localStorage`만 사용한다. desktop에서 앱 데이터 디렉터리 저장으로 옮길지, webview storage를 그대로 쓸지 정책 결정이 필요하다.
+
+### 5. 외부 링크 처리
+
+- 약관/튜토리얼 문서는 일반 `href`와 `target="_blank"`에 기대고 있다.
+- Tauri에서는 시스템 브라우저로 열지, 새 webview를 띄울지, in-app browser를 둘지 결정해야 한다.
+
+## 브라우저 전용 API / web-only assumption 목록
+
+### 인증/내비게이션
+
+- `apps/app/src/pages/LoginPage/index.tsx`
+    - OAuth 복귀 URL을 런타임 app public URL에 의존
+- `apps/app/src/pages/LoginPage/RedirectPage.tsx`
+    - `location.search`에서 access token 직접 파싱
+- `apps/app/src/shared/api/client.ts`
+    - 401 시 `window.location.pathname/search` 기반 refresh 이동
+- `apps/app/src/features/auth/useAuth/index.ts`
+    - `window.history.back`, `location.replace`
+- `apps/app/src/pages/RefreshPage/index.tsx`
+    - refresh 완료 후 `location.replace`
+
+### 저장/상태 복구
+
+- `apps/app/src/pages/make-shift/model/make-shift-store.ts`
+- `apps/app/src/features/shift/editDuty/model/utils/prefs.ts`
+- `apps/app/src/features/shift-editor/model/persistence.ts`
+    - 모두 `window.localStorage` 직접 사용
+
+### 클립보드
+
+- `apps/app/src/pages/MemberPage/ui/WardInfo.tsx`
+- `apps/app/src/pages/RegisterPage/ui/EnterWard.tsx`
+- `apps/app/src/features/register-ward/ui/RegisterWardShiftTeamsSection.tsx`
+- `apps/app/src/features/shift-editor/model/useShiftEditorKeyBindings.ts`
+    - `navigator.clipboard` 직접 사용
+
+### 다운로드 / 파일
+
+- `apps/app/src/features/shift-editor/model/shift-to-excel.ts`
+    - 브라우저 다운로드 anchor에 의존
+- `apps/app/src/features/file/uploadFile.ts`
+- `apps/app/src/shared/api/file/index.ts`
+    - web `File`, `FormData`, presigned URL 업로드에 의존
+
+### DOM 직접 제어
+
+- 튜토리얼, 모달, 키보드 핸들링 관련 다수 파일에서 `document.getElementById`, `createPortal`, `document.addEventListener` 사용
+- 이 부분은 Tauri에서 즉시 막히진 않지만, webview 외 환경 공유를 전제로 하면 adapter 여지가 적다.
+
+## 인증/redirect/도메인 점검 포인트
+
+- desktop 복귀 URL 정책 결정
+    - 후보: 고정 https origin 유지, custom scheme deep link, loopback local server
+- 백엔드 OAuth redirect whitelist에 desktop 복귀 주소를 어떻게 추가할지 정리
+- refresh cookie의 `SameSite`, `Secure`, `Domain`이 Tauri webview에서 유지되는지 확인
+- `nextPageUrl`를 외부 절대 URL이 아닌 앱 내부 path 중심으로 바꿀지 검토
+- `location.replace` 기반 강제 이동을 추후 navigation adapter로 감쌀지 결정
+
+## 파일/저장소/외부 링크 점검 포인트
+
+- Excel 내보내기는 desktop 저장 다이얼로그 기반으로 전환할지 검토
+- 업로드용 `File` 객체를 web input에서 받을지, Tauri file picker와 연결할지 결정
+- `localStorage` 보존 정책을 유지할지, 앱 데이터 디렉터리(JSON/SQLite)로 옮길지 결정
+- 약관/튜토리얼 등 외부 링크를 시스템 브라우저로 열기 위한 추상화 필요 여부 검토
+
+## 이번에 반영한 소규모 정리
+
+- `apps/app/src/shared/config/runtime.ts` 추가
+    - app public URL, server URL, profile image base URL, 외부 문서 URL을 런타임 구성으로 통합
+- 로그인 OAuth 시작 URL을 `buildAuthAuthorizeUrl`로 이동
+- 튜토리얼/약관/개인정보 링크 하드코딩을 runtime config 참조로 변경
+- 프로필 이미지 S3 base URL fallback 하드코딩을 runtime config 참조로 이동
+- `vite-env.d.ts`에 desktop 대응 검토용 runtime env 타입 추가
+
+## 선행 정리 포인트
+
+1. 인증 이동과 외부 링크 열기를 `platform/navigation` 또는 유사 adapter로 분리
+2. storage 접근을 `localStorage` 직접 호출 대신 driver 인터페이스 뒤로 숨기기
+3. 다운로드 로직을 browser download와 desktop save를 나눌 수 있게 분리
+4. 배포/런타임 URL을 env 기준으로 통일하고 앱 내부에서 직접 도메인을 박지 않기
+5. OAuth 복귀 payload를 querystring access token 대신 더 안전한 방식으로 바꿀지 검토
+
+## 후속 티켓 후보
+
+- `apps/app` 인증 이동 로직을 platform adapter로 분리
+- localStorage 사용 지점을 storage driver로 추상화
+- shift excel export에 desktop 저장 adapter 도입
+- 외부 링크 열기 정책 정리 및 helper 도입
+- Tauri PoC에서 OAuth refresh cookie 동작 검증


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-865](https://gom3.atlassian.net/browse/DUT-865)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `apps/app` 기준으로 Tauri desktop wrapper 적용 가능성, 제약, 선행 정리 포인트를 `docs/architecture/desktop-tauri-readiness.md`에 정리했습니다.
- 로그인 OAuth 시작 URL, 문서 링크, 프로필 이미지 base URL 하드코딩을 `shared/config/runtime.ts`로 모아 desktop/web 런타임 분리를 위한 최소 기반을 추가했습니다.
- `vite-env.d.ts`에 runtime env 타입을 추가하고, analytics 초기화가 env 미설정에서도 타입 안전하게 동작하도록 보정했습니다.

<br>

## To Reviewers

- 이번 PR은 desktop 앱 구현이 아니라 사전 구조 검토와 소규모 정리 단계입니다.
- 인증은 아직 querystring access token, refresh cookie, `location.replace` 흐름을 유지합니다. 문서에 적은 후속 티켓 기준이 타당한지 중심으로 봐주세요.
- `pnpm --filter @dutying/app lint` 실행 시 기존 `entities/account/ui/profile-image` -> `features/file/store` import 경고 1건은 남아 있습니다. 이번 티켓 범위에서는 건드리지 않았습니다.


[DUT-865]: https://gom3.atlassian.net/browse/DUT-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 환경 변수 기반 런타임 URL 설정 기능 추가 (서버 주소, 앱 공개 URL, 프로필 이미지, 문서 링크 등)
  * OAuth 인증용 동적 권한요청 URL 생성 지원

* **개선사항**
  * 약관·개인정보·튜토리얼 링크를 환경 변수로 관리
  * 분석 서비스 초기화 및 호출을 설정 값이 있을 때만 실행
  * 로그인/리다이렉트 대상의 안전성 검증 및 경로 정규화 적용

* **테스트**
  * 런타임 구성·리다이렉트·OAuth URL 관련 유닛 테스트 추가

* **문서**
  * 데스크톱 전환 준비도 평가 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->