### PR TITLE
[DUT-889]: 모노레포 경계 회귀 테스트 보강

### DIFF
--- a/apps/app/src/pages/LandingPage/landing-page-redirect.test.tsx
+++ b/apps/app/src/pages/LandingPage/landing-page-redirect.test.tsx
@@ -60,4 +60,17 @@ describe('LandingPageRedirect', () => {
 
         expect(replaceSpy).toHaveBeenCalledWith(ROUTE.MAKE);
     });
+
+    it('sends unauthenticated users to login once hydration is loaded', () => {
+        mockedUseAuth.mockReturnValue({
+            state: {
+                isAuth: false,
+                _loaded: true,
+            },
+        } as never);
+
+        render(<LandingPageRedirect />);
+
+        expect(replaceSpy).toHaveBeenCalledWith(ROUTE.LOGIN);
+    });
 });

--- a/apps/app/src/pages/RefreshPage/index.test.tsx
+++ b/apps/app/src/pages/RefreshPage/index.test.tsx
@@ -1,0 +1,103 @@
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import useRefresh from '@/features/auth/useRefresh';
+import ROUTE from '@/shared/constant/path';
+import {render, waitFor} from '@/shared/util/test-utils';
+import RefreshPage from './index';
+
+vi.mock('@/features/auth/useRefresh', () => ({
+    default: vi.fn(),
+}));
+
+vi.mock('@/shared/hook/use-typed-translation', () => ({
+    useTypedTranslation: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+const mockedUseRefresh = vi.mocked(useRefresh);
+
+describe('RefreshPage', () => {
+    const refreshSpy = vi.fn();
+    const replaceSpy = vi.fn();
+
+    beforeEach(() => {
+        refreshSpy.mockReset();
+        replaceSpy.mockReset();
+        mockedUseRefresh.mockReset();
+        mockedUseRefresh.mockReturnValue({
+            refresh: refreshSpy,
+        } as never);
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {
+                ...window.location,
+                replace: replaceSpy,
+            },
+        });
+    });
+
+    it('redirects to the requested internal path after refresh succeeds', async () => {
+        refreshSpy.mockResolvedValue(undefined);
+
+        render(
+            <MemoryRouter initialEntries={['/refresh?next=%2Fmember%3Ftab%3Dprofile']}>
+                <Routes>
+                    <Route path={ROUTE.REFRESH} element={<RefreshPage />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(replaceSpy).toHaveBeenCalledWith('/member?tab=profile');
+        });
+    });
+
+    it('falls back to make when the next path is external', async () => {
+        refreshSpy.mockResolvedValue(undefined);
+
+        render(
+            <MemoryRouter initialEntries={['/refresh?next=https%3A%2F%2Fevil.example%2Fphish']}>
+                <Routes>
+                    <Route path={ROUTE.REFRESH} element={<RefreshPage />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(replaceSpy).toHaveBeenCalledWith(ROUTE.MAKE);
+        });
+    });
+
+    it('falls back to make when the next path is protocol-relative', async () => {
+        refreshSpy.mockResolvedValue(undefined);
+
+        render(
+            <MemoryRouter initialEntries={['/refresh?next=%2F%2Fevil.example%2Fphish']}>
+                <Routes>
+                    <Route path={ROUTE.REFRESH} element={<RefreshPage />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(replaceSpy).toHaveBeenCalledWith(ROUTE.MAKE);
+        });
+    });
+
+    it('returns to the landing root when refresh fails', async () => {
+        refreshSpy.mockRejectedValue(new Error('expired'));
+
+        render(
+            <MemoryRouter initialEntries={['/refresh?next=%2Fmake']}>
+                <Routes>
+                    <Route path={ROUTE.REFRESH} element={<RefreshPage />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(replaceSpy).toHaveBeenCalledWith(ROUTE.ROOT);
+        });
+    });
+});

--- a/apps/app/src/shared/config/runtime.test.ts
+++ b/apps/app/src/shared/config/runtime.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it, vi} from 'vitest';
 import ROUTE from '@/shared/constant/path';
-import {buildAuthAuthorizeUrl, resolveSafeRedirectTarget, sanitizeInternalPath} from './runtime';
+import {buildAppUrl, buildAuthAuthorizeUrl, resolveSafeRedirectTarget, sanitizeInternalPath} from './runtime';
 
 describe('sanitizeInternalPath', () => {
     it('keeps app-relative paths', () => {
@@ -31,6 +31,29 @@ describe('resolveSafeRedirectTarget', () => {
         });
 
         expect(resolveSafeRedirectTarget('https://evil.example/request')).toBe(ROUTE.MAKE);
+    });
+
+    it('accepts redirects that match the configured public app origin in local development', () => {
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.net');
+        vi.stubGlobal('window', {
+            location: {
+                origin: 'https://local.app.dutying.net:3000',
+            },
+        });
+
+        expect(resolveSafeRedirectTarget('https://app.dutying.net/login?next=%2Fmake#cta')).toBe('/login?next=%2Fmake#cta');
+    });
+
+    it('rejects protocol-relative redirect targets', () => {
+        expect(resolveSafeRedirectTarget('//evil.example/phish')).toBe(ROUTE.MAKE);
+    });
+});
+
+describe('buildAppUrl', () => {
+    it('uses the configured public app url and strips trailing slashes', () => {
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://staging.app.dutying.net///');
+
+        expect(buildAppUrl('/member')).toBe('https://staging.app.dutying.net/member');
     });
 });
 

--- a/apps/landing/src/components/landing/LandingPage.astro
+++ b/apps/landing/src/components/landing/LandingPage.astro
@@ -1,5 +1,5 @@
 ---
-import {siteConfig} from '../../config/site';
+import {landingPrimaryCtas, siteConfig} from '../../config/site';
 
 const appStoreLink = 'https://abr.ge/bv13wa';
 const inquiryLink = 'https://ye620.channel.io';
@@ -48,11 +48,6 @@ const featureSections = [
         tone: 'dark',
         align: 'start',
     },
-];
-
-const primaryCtas = [
-    {label: '근무표 작성 체험하기', href: siteConfig.appLinks.makeEntry},
-    {label: '근무표 만들기', href: siteConfig.appLinks.make},
 ];
 
 const formattedFeatureSections = featureSections.map((section) => ({
@@ -131,7 +126,7 @@ const formattedFeatureSections = featureSections.map((section) => ({
                         <p>근무표 작성 (수간호사 용)</p>
                     </div>
                     <div class="cta-row">
-                        {primaryCtas.map((cta) => (
+                        {landingPrimaryCtas.map((cta) => (
                             <a class="button button--store" href={cta.href}>{cta.label}</a>
                         ))}
                     </div>

--- a/apps/landing/src/config/site.test.ts
+++ b/apps/landing/src/config/site.test.ts
@@ -26,6 +26,17 @@ describe('createSiteConfig', () => {
         expect(config.appLinks.login).toBe('https://preview.app.dutying.net/login');
         expect(config.appLinks.makeEntry).toBe('https://preview.app.dutying.net/login?next=%2Fmake');
     });
+
+    it('falls back safely when env overrides are blank strings', () => {
+        const config = createSiteConfig({
+            PUBLIC_MARKETING_SITE_URL: '   ',
+            PUBLIC_APP_SITE_URL: '',
+        });
+
+        expect(config.marketingOrigin).toBe('https://dutying.net');
+        expect(config.appOrigin).toBe('https://app.dutying.net');
+        expect(config.appLinks.login).toBe('https://app.dutying.net/login');
+    });
 });
 
 describe('createLandingPrimaryCtas', () => {

--- a/apps/landing/src/config/site.test.ts
+++ b/apps/landing/src/config/site.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest';
+import {createLandingPrimaryCtas, createSiteConfig} from './site';
+
+describe('createSiteConfig', () => {
+    it('falls back to the production dutying domains', () => {
+        const config = createSiteConfig({});
+
+        expect(config.marketingOrigin).toBe('https://dutying.net');
+        expect(config.appOrigin).toBe('https://app.dutying.net');
+        expect(config.appLinks).toEqual({
+            home: 'https://app.dutying.net',
+            login: 'https://app.dutying.net/login',
+            makeEntry: 'https://app.dutying.net/login?next=%2Fmake',
+            make: 'https://app.dutying.net/make',
+            register: 'https://app.dutying.net/register',
+        });
+    });
+
+    it('trims trailing slashes from overridden origins before composing links', () => {
+        const config = createSiteConfig({
+            PUBLIC_MARKETING_SITE_URL: 'https://preview.dutying.net///',
+            PUBLIC_APP_SITE_URL: 'https://preview.app.dutying.net//',
+        });
+
+        expect(config.marketingOrigin).toBe('https://preview.dutying.net');
+        expect(config.appLinks.login).toBe('https://preview.app.dutying.net/login');
+        expect(config.appLinks.makeEntry).toBe('https://preview.app.dutying.net/login?next=%2Fmake');
+    });
+});
+
+describe('createLandingPrimaryCtas', () => {
+    it('keeps the web CTA entrypoints pinned to the app login and make routes', () => {
+        const ctas = createLandingPrimaryCtas(
+            createSiteConfig({
+                PUBLIC_APP_SITE_URL: 'https://staging.app.dutying.net/',
+            }),
+        );
+
+        expect(ctas).toEqual([
+            {label: '근무표 작성 체험하기', href: 'https://staging.app.dutying.net/login?next=%2Fmake'},
+            {label: '근무표 만들기', href: 'https://staging.app.dutying.net/make'},
+        ]);
+    });
+});

--- a/apps/landing/src/config/site.ts
+++ b/apps/landing/src/config/site.ts
@@ -1,17 +1,37 @@
 const stripTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 
-const marketingOrigin = stripTrailingSlash(import.meta.env.PUBLIC_MARKETING_SITE_URL ?? 'https://dutying.net');
-const appOrigin = stripTrailingSlash(import.meta.env.PUBLIC_APP_SITE_URL ?? 'https://app.dutying.net');
-
-export const siteConfig = {
-    productName: 'Dutying',
-    marketingOrigin,
-    appOrigin,
-    appLinks: {
-        home: appOrigin,
-        login: `${appOrigin}/login`,
-        makeEntry: `${appOrigin}/login?next=%2Fmake`,
-        make: `${appOrigin}/make`,
-        register: `${appOrigin}/register`,
-    },
+type SiteEnv = {
+    PUBLIC_MARKETING_SITE_URL?: string;
+    PUBLIC_APP_SITE_URL?: string;
 };
+
+const readSiteEnv = (): SiteEnv => ({
+    PUBLIC_MARKETING_SITE_URL: import.meta.env.PUBLIC_MARKETING_SITE_URL,
+    PUBLIC_APP_SITE_URL: import.meta.env.PUBLIC_APP_SITE_URL,
+});
+
+export const createSiteConfig = (env: SiteEnv = readSiteEnv()) => {
+    const marketingOrigin = stripTrailingSlash(env.PUBLIC_MARKETING_SITE_URL ?? 'https://dutying.net');
+    const appOrigin = stripTrailingSlash(env.PUBLIC_APP_SITE_URL ?? 'https://app.dutying.net');
+
+    return {
+        productName: 'Dutying',
+        marketingOrigin,
+        appOrigin,
+        appLinks: {
+            home: appOrigin,
+            login: `${appOrigin}/login`,
+            makeEntry: `${appOrigin}/login?next=%2Fmake`,
+            make: `${appOrigin}/make`,
+            register: `${appOrigin}/register`,
+        },
+    };
+};
+
+export const createLandingPrimaryCtas = (config: ReturnType<typeof createSiteConfig>) => [
+    {label: '근무표 작성 체험하기', href: config.appLinks.makeEntry},
+    {label: '근무표 만들기', href: config.appLinks.make},
+];
+
+export const siteConfig = createSiteConfig(readSiteEnv());
+export const landingPrimaryCtas = createLandingPrimaryCtas(siteConfig);

--- a/apps/landing/src/config/site.ts
+++ b/apps/landing/src/config/site.ts
@@ -1,4 +1,13 @@
 const stripTrailingSlash = (value: string) => value.replace(/\/+$/, '');
+const getRuntimeOrigin = (value: string | undefined, fallback: string) => {
+    const normalized = value?.trim();
+
+    if (normalized === '') {
+        return stripTrailingSlash(fallback);
+    }
+
+    return stripTrailingSlash(normalized ?? fallback);
+};
 
 type SiteEnv = {
     PUBLIC_MARKETING_SITE_URL?: string;
@@ -11,8 +20,8 @@ const readSiteEnv = (): SiteEnv => ({
 });
 
 export const createSiteConfig = (env: SiteEnv = readSiteEnv()) => {
-    const marketingOrigin = stripTrailingSlash(env.PUBLIC_MARKETING_SITE_URL ?? 'https://dutying.net');
-    const appOrigin = stripTrailingSlash(env.PUBLIC_APP_SITE_URL ?? 'https://app.dutying.net');
+    const marketingOrigin = getRuntimeOrigin(env.PUBLIC_MARKETING_SITE_URL, 'https://dutying.net');
+    const appOrigin = getRuntimeOrigin(env.PUBLIC_APP_SITE_URL, 'https://app.dutying.net');
 
     return {
         productName: 'Dutying',

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "@changesets/cli": "^2.29.8",
         "lint-staged": "^16.2.7",
         "prettier": "3.5.3",
-        "prettier-plugin-tailwindcss": "^0.7.1"
+        "prettier-plugin-tailwindcss": "^0.7.1",
+        "vitest": "^4.0.14"
     }
 }

--- a/packages/api/src/index.test.ts
+++ b/packages/api/src/index.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it, vi} from 'vitest';
+import type {IApiClient} from './client';
+import {createAccountApi, createNurseApi, createWardApi} from './index';
+
+const createClient = (): IApiClient => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+});
+
+describe('@dutying/api public entry', () => {
+    it('exposes the package factories from the root export', () => {
+        expect(createAccountApi).toBeTypeOf('function');
+        expect(createNurseApi).toBeTypeOf('function');
+        expect(createWardApi).toBeTypeOf('function');
+    });
+
+    it('keeps account and ward factories callable through the package root', async () => {
+        const client = createClient();
+        const getMock = client.get as ReturnType<typeof vi.fn>;
+        const postMock = client.post as ReturnType<typeof vi.fn>;
+
+        getMock.mockResolvedValueOnce({data: {accountId: 12}});
+        postMock.mockResolvedValueOnce({data: undefined});
+
+        const accountApi = createAccountApi(client);
+        const wardApi = createWardApi(client);
+
+        await expect(accountApi.getAccountMe()).resolves.toEqual({accountId: 12});
+        await expect(wardApi.postShift(7, 3, 2026, 3)).resolves.toBeUndefined();
+
+        expect(getMock).toHaveBeenCalledWith('/accounts/me');
+        expect(postMock).toHaveBeenCalledWith('/wards/7/shift-teams/3/post?year=2026&month=03');
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.7.1
         version: 0.7.1(prettier@3.5.3)
+      vitest:
+        specifier: ^4.0.14
+        version: 4.0.14(@types/node@24.10.1)(@vitest/ui@4.0.14)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.3)
 
   apps/app:
     dependencies:
@@ -10566,6 +10569,14 @@ snapshots:
     optionalDependencies:
       vite: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(lightningcss@1.30.2)(yaml@2.8.3)
 
+  '@vitest/mocker@4.0.14(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.0.14
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
+
   '@vitest/pretty-format@4.0.14':
     dependencies:
       tinyrainbow: 3.0.3
@@ -10592,7 +10603,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@types/node@24.10.1)(@vitest/ui@4.0.14)(jiti@1.21.7)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.3)
+      vitest: 4.0.14(@types/node@24.10.1)(@vitest/ui@4.0.14)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.3)
 
   '@vitest/utils@4.0.14':
     dependencies:
@@ -15561,6 +15572,21 @@ snapshots:
       lightningcss: 1.30.2
       yaml: 2.8.3
 
+  vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.53.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.10.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      yaml: 2.8.3
+
   vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
@@ -15650,6 +15676,45 @@ snapshots:
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
       vite: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(lightningcss@1.30.2)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.1
+      '@vitest/ui': 4.0.14(vitest@4.0.14)
+      jsdom: 27.2.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.14(@types/node@24.10.1)(@vitest/ui@4.0.14)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.3):
+    dependencies:
+      '@vitest/expect': 4.0.14
+      '@vitest/mocker': 4.0.14(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.0.14
+      '@vitest/runner': 4.0.14
+      '@vitest/snapshot': 4.0.14
+      '@vitest/spy': 4.0.14
+      '@vitest/utils': 4.0.14
+      es-module-lexer: 1.7.0
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.1


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-889](https://gom3.atlassian.net/browse/DUT-889)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 앱 런타임 URL 계산과 랜딩/리프레시 리다이렉트 경로에 대한 회귀 테스트를 보강했습니다.
- 랜딩의 앱 진입 CTA를 설정 함수로 분리하고, 도메인 override 및 trailing slash 처리 테스트를 추가했습니다.
- packages/api 루트 공개 엔트리가 핵심 팩토리를 계속 노출하는지 검증하는 경계 테스트를 추가했습니다.
- 루트에서 landing/packages 테스트를 실행할 수 있도록 vitest 의존성을 추가했습니다.

<br>

## To Reviewers

- 앱 전체 vitest 스위트는 현재 통과하며, landing은 `astro check`, landing/packages 경계 테스트는 루트 vitest로 별도 확인했습니다.
- docs 도메인 자체 설정은 이번 범위에서 직접 다루지 않았고, 앱/랜딩/packages 경계의 회귀 포인트에 집중했습니다.


[DUT-889]: https://gom3.atlassian.net/browse/DUT-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 사용자 인증 및 페이지 리다이렉션 동작에 대한 테스트 추가
  * 페이지 새로고침 흐름 및 외부 URL 리다이렉션 처리 검증
  * 설정 유효성 확인 및 API 팩토리 함수 테스트 추가

* **Chores**
  * 사이트 설정 구조 최적화 및 리팩토링
  * 개발 의존성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->