### PR TITLE
[DUT-895]: 온보딩 draft validation 테스트 보강

### DIFF
--- a/apps/app/src/pages/OnboardingWardCreatePage/adapter.test.ts
+++ b/apps/app/src/pages/OnboardingWardCreatePage/adapter.test.ts
@@ -105,6 +105,72 @@ describe('OnboardingWardCreatePage adapter', () => {
         expect(nextDraft.nurses[0]?.employmentDate).toBe(today);
     });
 
+    it('remaps existing nurse possible shifts by short name after uploaded shift types replace ids', () => {
+        const draft = createInitialDraft();
+        const dayShift = draft.shiftTypes.find((shiftType) => shiftType.shortName === 'D');
+        const eveningShift = draft.shiftTypes.find((shiftType) => shiftType.shortName === 'E');
+        const nurseId = draft.nurses[0]?.id ?? '';
+        const nurseScopedDraft = {
+            ...draft,
+            nurses: draft.nurses.map((nurse) =>
+                nurse.id === nurseId
+                    ? {
+                          ...nurse,
+                          possibleShiftTypeIds: [dayShift?.id ?? '', eveningShift?.id ?? ''],
+                      }
+                    : nurse,
+            ),
+        };
+        const nextDraft = applyParsedWardData(nurseScopedDraft, {
+            shiftTypes: [
+                {name: '데이', shortName: 'D'},
+                {name: '미드', shortName: 'M'},
+                {name: '오프', shortName: 'O', isOff: true},
+            ],
+        });
+        const remappedNurse = nextDraft.nurses.find((nurse) => nurse.id === nurseId);
+        const defaultShiftTypeIds = nextDraft.shiftTypes.filter((shiftType) => !shiftType.isOff).map((shiftType) => shiftType.id);
+
+        expect(remappedNurse?.possibleShiftTypeIds).toEqual([nextDraft.shiftTypes[0]?.id]);
+        expect(remappedNurse?.possibleShiftTypeIds).not.toEqual(defaultShiftTypeIds);
+    });
+
+    it('falls back nurse team ids to the first uploaded team when previous team names disappear', () => {
+        const draft = createInitialDraft();
+        const fallbackTeamName = 'A팀';
+        const renamedTeamsDraft = {
+            ...draft,
+            teams: draft.teams.map((team, index) => ({
+                ...team,
+                name: index === 0 ? fallbackTeamName : `${team.name}-기존`,
+            })),
+            nurses: draft.nurses.map((nurse, index) => ({
+                ...nurse,
+                teamId: draft.teams[index === 0 ? 0 : 1]?.id ?? nurse.teamId,
+            })),
+        };
+        const nextDraft = applyParsedWardData(renamedTeamsDraft, {
+            teams: [{name: fallbackTeamName}, {name: 'B팀'}],
+        });
+
+        expect(nextDraft.teams.map((team) => team.name)).toEqual([fallbackTeamName, 'B팀']);
+        expect(nextDraft.nurses.every((nurse) => nurse.teamId === nextDraft.teams[0]?.id)).toBe(true);
+    });
+
+    it('merges uploaded skill level config into the existing draft config', () => {
+        const draft = createInitialDraft();
+        const nextDraft = applyParsedWardData(draft, {
+            skillLevelConfig: {
+                levelCount: 4,
+            },
+        });
+
+        expect(nextDraft.skillLevelConfig).toEqual({
+            ...draft.skillLevelConfig,
+            levelCount: 4,
+        });
+    });
+
     it('normalizes parse api responses into draft injection data', () => {
         const response: TOnboardingWardParseApiResponse = {
             wardName: '중환자실',
@@ -134,6 +200,54 @@ describe('OnboardingWardCreatePage adapter', () => {
         expect(parsedWardData.teams).toEqual([{name: 'A팀'}]);
         expect(parsedWardData.nurses?.[0]?.possibleShiftShortNames).toEqual(['D']);
         expect(warnings).toEqual(['근속 연수가 없는 간호사는 오늘 날짜로 반영되었어요.']);
+    });
+
+    it('collects warnings from failed sheets and rows while trimming parsed upload fields', () => {
+        const response: TOnboardingWardParseApiResponse = {
+            fileName: ' parsed.xlsx ',
+            wardName: ' 중환자실 ',
+            hospitalName: ' 듀팅병원 ',
+            wardShiftTypes: [
+                {name: ' 데이 ', shortName: ' d '},
+                {name: ' ', shortName: ' '},
+            ],
+            shiftTeams: [{name: ' A팀 '}],
+            nurses: [
+                {
+                    name: ' 신규 간호사 ',
+                    teamName: ' A팀 ',
+                    possibleShiftShortNames: [' d ', null, ' '],
+                },
+                {
+                    name: ' ',
+                    teamName: ' ',
+                },
+            ],
+            warnings: ['기본 경고'],
+            failedSheets: ['3월'],
+            failedRows: ['12행'],
+        };
+        const {parsedWardData, warnings} = buildOnboardingParseDraftInjection(response, 'fallback.xlsx');
+
+        expect(parsedWardData).toMatchObject({
+            fileName: 'parsed.xlsx',
+            wardName: '중환자실',
+            hospitalName: '듀팅병원',
+            shiftTypes: [{name: '데이', shortName: 'D'}],
+            teams: [{name: 'A팀'}],
+        });
+        expect(parsedWardData.nurses).toEqual([
+            {
+                name: '신규 간호사',
+                teamName: 'A팀',
+                possibleShiftShortNames: ['D'],
+            },
+        ]);
+        expect(warnings).toEqual([
+            '기본 경고',
+            '시트 "3월" 데이터를 불러오지 못했어요.',
+            '일부 행(12행)을 해석하지 못해 제외했어요.',
+        ]);
     });
 
     it('detects supported upload file extensions', () => {

--- a/apps/app/src/pages/OnboardingWardCreatePage/model.test.ts
+++ b/apps/app/src/pages/OnboardingWardCreatePage/model.test.ts
@@ -9,6 +9,7 @@ import {
     deleteShiftTypeDraft,
     getStepValidation,
     reorderNursesWithinTeam,
+    saveSkillLevelConfig,
     updateNurseDraft,
     updateShiftTypeDraft,
 } from './model';
@@ -51,6 +52,37 @@ describe('OnboardingWardCreatePage model', () => {
         expect(validation.isValid).toBe(false);
         expect(validation.issues.map((issue) => issue.code)).toEqual(expect.arrayContaining(['empty-team-nurses', 'missing-nurse-name']));
         expect(canGoNext(invalidDraft)).toBe(false);
+    });
+
+    it('allows off shifts without times but blocks working shifts without times', () => {
+        const draft = createInitialDraft();
+        const offShiftId = draft.shiftTypes.find((shiftType) => shiftType.isOff)?.id ?? '';
+        const workingShiftId = draft.shiftTypes.find((shiftType) => !shiftType.isOff)?.id ?? '';
+        const withoutOffTimes = updateShiftTypeDraft(draft, offShiftId, {startTime: '', endTime: ''});
+        const withoutWorkingStartTime = updateShiftTypeDraft(withoutOffTimes, workingShiftId, {startTime: ''});
+        const validation = getStepValidation(withoutWorkingStartTime, 2);
+
+        expect(validation.issues).toEqual(
+            expect.arrayContaining([{code: 'missing-shift-time', step: 2, targetId: workingShiftId}]),
+        );
+        expect(validation.issues).not.toEqual(
+            expect.arrayContaining([{code: 'missing-shift-time', step: 2, targetId: offShiftId}]),
+        );
+    });
+
+    it('reports empty-team when all onboarding teams are removed', () => {
+        const draft = createInitialDraft();
+        const withoutTeams = {
+            ...draft,
+            currentStep: 3 as const,
+            teams: [],
+            nurses: [],
+        };
+        const validation = getStepValidation(withoutTeams, 3);
+
+        expect(validation.isValid).toBe(false);
+        expect(validation.issues).toEqual([{code: 'empty-team', step: 3}]);
+        expect(canGoNext(withoutTeams)).toBe(false);
     });
 
     it('keeps nurse order changes scoped to the active team', () => {
@@ -108,5 +140,28 @@ describe('OnboardingWardCreatePage model', () => {
         expect(getStepValidation(invalidShiftDraft, 2).isValid).toBe(false);
         expect(getStepValidation(invalidShiftDraft, 4).isValid).toBe(true);
         expect(canComplete(invalidShiftDraft)).toBe(false);
+    });
+
+    it('clamps nurse levels to the configured range when auto assignment is disabled', () => {
+        const draft = createInitialDraft();
+        const withCustomLevels = {
+            ...draft,
+            nurses: draft.nurses.map((nurse, index) => ({
+                ...nurse,
+                level: index === 0 ? null : 5,
+            })),
+        };
+        const nextDraft = saveSkillLevelConfig(withCustomLevels, {
+            levelCount: 3,
+            paletteId: 'cool',
+            autoAssign: false,
+        });
+
+        expect(nextDraft.skillLevelConfig).toEqual({
+            levelCount: 3,
+            paletteId: 'cool',
+            autoAssign: false,
+        });
+        expect(nextDraft.nurses.map((nurse) => nurse.level)).toEqual([3, 3, 3, 3]);
     });
 });


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-895](https://gom3.atlassian.net/browse/DUT-895)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 온보딩 step validation에서 `OFF` 근무 시간 예외, 빈 팀 검증, 수동 skill level clamp 규칙 테스트를 추가했습니다.
- 업로드 후 shift/team 재매핑, skill config 병합, warning 정규화 규칙 테스트를 보강했습니다.
- UI interaction 대신 `model`/`adapter` 계층의 입력-출력 규칙을 중심으로 회귀 테스트를 확장했습니다.

<br>

## Follow-up

- `useOnboardingWardWizard` 레벨에서 업로드 성공/경고/실패 시 상태 전이와 toast 호출을 고정하는 테스트는 별도 후속 작업으로 남아 있습니다.
- `buildCreateWardPayload`의 팀별 nurse ordering, 빈 문자열 nurse name 처리 규칙은 제품 명세가 더 명확해지면 추가 테스트로 보강할 수 있습니다.

<br>

## To Reviewers

- 업로드 응답이 draft에 반영될 때 `shortName`/팀 이름 기반으로 기존 데이터가 재연결되는 경계 조건을 중점적으로 봐주시면 됩니다.
- 검증은 `pnpm --dir apps/app test:run src/pages/OnboardingWardCreatePage/model.test.ts src/pages/OnboardingWardCreatePage/adapter.test.ts`, `pnpm --dir apps/app type-check`로 수행했습니다.


[DUT-895]: https://gom3.atlassian.net/browse/DUT-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ