### PR TITLE
[DUT-896]: 근무자 관리 model 테스트 보강

### DIFF
--- a/apps/app/src/pages/MemberPage/model/connectionManage.test.ts
+++ b/apps/app/src/pages/MemberPage/model/connectionManage.test.ts
@@ -59,6 +59,17 @@ describe('getConnectionManageTargetLabel', () => {
             }),
         ).toBe('B팀');
     });
+
+    it('returns null when the requested target no longer exists', () => {
+        expect(
+            getConnectionManageTargetLabel({
+                connectMode: 'link',
+                shiftTeams,
+                toLinkNurseId: 999,
+                toAddShiftTeamId: null,
+            }),
+        ).toBeNull();
+    });
 });
 
 describe('getConnectionManageResultCopy', () => {
@@ -82,5 +93,26 @@ describe('getConnectionManageResultCopy', () => {
                 targetLabel: 'B팀',
             }).description,
         ).toContain('다시 시도하거나 이전 단계로 돌아가');
+    });
+
+    it('keeps the loading copy specific to add mode', () => {
+        expect(
+            getConnectionManageResultCopy({
+                submitStatus: 'loading',
+                connectMode: 'add',
+                waitingNurseName: '박신청',
+                targetLabel: 'B팀',
+            }).description,
+        ).toContain('팀과 관계 변경이 반영될 때까지');
+    });
+
+    it('falls back to safe labels when waiting nurse information is missing', () => {
+        const result = getConnectionManageResultCopy({
+            submitStatus: 'error',
+            connectMode: 'link',
+        });
+
+        expect(result.title).toBe('기존 계정과 연결하지 못했어요');
+        expect(result.description).toContain('선택한 간호사 계정');
     });
 });

--- a/apps/app/src/pages/MemberPage/model/nurseEdit.test.ts
+++ b/apps/app/src/pages/MemberPage/model/nurseEdit.test.ts
@@ -53,6 +53,23 @@ describe('hasNurseChanges', () => {
 
         expect(hasNurseChanges(nurse, draft)).toBe(true);
     });
+
+    it('returns false when the original or draft value is missing', () => {
+        const nurse = createNurse();
+
+        expect(hasNurseChanges(nurse, null)).toBe(false);
+        expect(hasNurseChanges(undefined, nurse)).toBe(false);
+    });
+
+    it('detects reordered shift types as a change', () => {
+        const nurse = createNurse();
+        const draft = {
+            ...nurse,
+            nurseShiftTypes: [...nurse.nurseShiftTypes].reverse(),
+        };
+
+        expect(hasNurseChanges(nurse, draft)).toBe(true);
+    });
 });
 
 describe('getNurseDrawerFeedback', () => {
@@ -74,5 +91,35 @@ describe('getNurseDrawerFeedback', () => {
                 isDirty: true,
             }).title,
         ).toBe('저장하지 못했어요');
+    });
+
+    it('describes that the draft is preserved on save failure', () => {
+        expect(
+            getNurseDrawerFeedback({
+                mode: 'edit',
+                saveStatus: 'error',
+                isDirty: false,
+            }).description,
+        ).toContain('입력한 내용은 그대로 남아 있어요');
+    });
+
+    it('returns success feedback after a clean save in edit mode', () => {
+        expect(
+            getNurseDrawerFeedback({
+                mode: 'edit',
+                saveStatus: 'success',
+                isDirty: false,
+            }).title,
+        ).toBe('저장이 완료되었어요');
+    });
+
+    it('warns about losing edits when the drawer is closed with unsaved changes', () => {
+        expect(
+            getNurseDrawerFeedback({
+                mode: 'edit',
+                saveStatus: 'idle',
+                isDirty: true,
+            }).description,
+        ).toContain('저장하지 않고 닫으면');
     });
 });

--- a/apps/app/src/pages/MemberPage/model/shiftTeamList.test.ts
+++ b/apps/app/src/pages/MemberPage/model/shiftTeamList.test.ts
@@ -1,0 +1,131 @@
+import {describe, expect, it} from 'vitest';
+import {type TNurse} from '@/entities/nurse';
+import {type TShiftTeam} from '@/entities/ward';
+import {createMoveNurseOrderPayload} from './shiftTeamList';
+
+const createNurse = (params: Partial<TNurse> & Pick<TNurse, 'nurseId' | 'shiftTeamId' | 'divisionNum' | 'priority' | 'name'>): TNurse => ({
+    nurseId: params.nurseId,
+    accountId: params.accountId ?? null,
+    shiftTeamId: params.shiftTeamId,
+    wardId: params.wardId ?? 20,
+    name: params.name,
+    phoneNum: params.phoneNum ?? '01012345678',
+    isConnected: params.isConnected ?? true,
+    nurseShiftTypes: params.nurseShiftTypes ?? [],
+    isWorker: params.isWorker ?? true,
+    isDutyManager: params.isDutyManager ?? false,
+    isWardManager: params.isWardManager ?? false,
+    gender: params.gender ?? '여',
+    employmentDate: params.employmentDate ?? '2021-08-01',
+    memo: params.memo ?? '',
+    isDeleted: params.isDeleted ?? false,
+    divisionNum: params.divisionNum,
+    priority: params.priority,
+});
+
+const createShiftTeams = (): TShiftTeam[] => [
+    {
+        shiftTeamId: 10,
+        name: 'A팀',
+        nurseCnt: 3,
+        nurses: [
+            createNurse({nurseId: 1, shiftTeamId: 10, divisionNum: 1, priority: 100, name: '김하나'}),
+            createNurse({nurseId: 2, shiftTeamId: 10, divisionNum: 1, priority: 200, name: '김둘'}),
+            createNurse({nurseId: 3, shiftTeamId: 10, divisionNum: 2, priority: 300, name: '김셋'}),
+        ],
+    },
+    {
+        shiftTeamId: 20,
+        name: 'B팀',
+        nurseCnt: 1,
+        nurses: [createNurse({nurseId: 4, shiftTeamId: 20, divisionNum: 1, priority: 150, name: '박넷'})],
+    },
+];
+
+describe('createMoveNurseOrderPayload', () => {
+    it('returns null when the nurse is dropped in the same position', () => {
+        expect(
+            createMoveNurseOrderPayload({
+                shiftTeams: createShiftTeams(),
+                sourceDroppableId: '10,1',
+                destinationDroppableId: '10,1',
+                sourceIndex: 0,
+                destinationIndex: 0,
+                draggableId: '1',
+            }),
+        ).toBeNull();
+    });
+
+    it('recomputes priorities when moving down within the same division', () => {
+        expect(
+            createMoveNurseOrderPayload({
+                shiftTeams: createShiftTeams(),
+                sourceDroppableId: '10,1',
+                destinationDroppableId: '10,1',
+                sourceIndex: 0,
+                destinationIndex: 1,
+                draggableId: '1',
+            }),
+        ).toEqual({
+            nurseId: 1,
+            sourceShiftTeamId: 10,
+            destinationShiftTeamId: 10,
+            divisionNum: 1,
+            prevPriority: 200,
+            nextPriority: 2224,
+        });
+    });
+
+    it('creates a cross-team payload when appending to another team', () => {
+        expect(
+            createMoveNurseOrderPayload({
+                shiftTeams: createShiftTeams(),
+                sourceDroppableId: '10,1',
+                destinationDroppableId: '20,1',
+                sourceIndex: 0,
+                destinationIndex: 1,
+                draggableId: '1',
+            }),
+        ).toEqual({
+            nurseId: 1,
+            sourceShiftTeamId: 10,
+            destinationShiftTeamId: 20,
+            divisionNum: 1,
+            prevPriority: 150,
+            nextPriority: 2174,
+        });
+    });
+
+    it('normalizes division 0 drops into the first division insertion payload', () => {
+        expect(
+            createMoveNurseOrderPayload({
+                shiftTeams: createShiftTeams(),
+                sourceDroppableId: '10,1',
+                destinationDroppableId: '20,0',
+                sourceIndex: 0,
+                destinationIndex: 0,
+                draggableId: '1',
+            }),
+        ).toEqual({
+            nurseId: 1,
+            sourceShiftTeamId: 10,
+            destinationShiftTeamId: 20,
+            divisionNum: 1,
+            prevPriority: 0,
+            nextPriority: 2024,
+        });
+    });
+
+    it('returns null when the destination team cannot be resolved', () => {
+        expect(
+            createMoveNurseOrderPayload({
+                shiftTeams: createShiftTeams(),
+                sourceDroppableId: '10,1',
+                destinationDroppableId: '999,1',
+                sourceIndex: 0,
+                destinationIndex: 0,
+                draggableId: '1',
+            }),
+        ).toBeNull();
+    });
+});

--- a/apps/app/src/pages/MemberPage/model/useConnectionManageController.test.tsx
+++ b/apps/app/src/pages/MemberPage/model/useConnectionManageController.test.tsx
@@ -66,6 +66,32 @@ describe('useConnectionManageController', () => {
         expect(result.current.state.submitStatus).toBe('success');
     });
 
+    it('enters the error state when add mode completes without a selected team', async () => {
+        const connectWaitingNurses = vi.fn();
+        const approveWaitingNurses = vi.fn();
+        const {result} = renderHook(() =>
+            useConnectionManageController({
+                open: true,
+                approveWaitingNurses,
+                connectWaitingNurses,
+            }),
+        );
+
+        act(() => {
+            result.current.actions.handleSelectWaitingNurse(waitingNurse);
+            result.current.actions.setConnectMode('add');
+        });
+
+        await act(async () => {
+            await result.current.actions.handleCompleteSelection();
+        });
+
+        expect(result.current.state.step).toBe(3);
+        expect(result.current.state.submitStatus).toBe('error');
+        expect(connectWaitingNurses).not.toHaveBeenCalled();
+        expect(approveWaitingNurses).not.toHaveBeenCalled();
+    });
+
     it('clears selected targets when returning to method selection', () => {
         const {result} = renderHook(() =>
             useConnectionManageController({

--- a/apps/app/src/pages/MemberPage/model/useConnectionManageController.test.tsx
+++ b/apps/app/src/pages/MemberPage/model/useConnectionManageController.test.tsx
@@ -14,6 +14,107 @@ const waitingNurse = {
 };
 
 describe('useConnectionManageController', () => {
+    it('enters the error state when link mode completes without a selected nurse', async () => {
+        const connectWaitingNurses = vi.fn();
+        const approveWaitingNurses = vi.fn();
+        const {result} = renderHook(() =>
+            useConnectionManageController({
+                open: true,
+                approveWaitingNurses,
+                connectWaitingNurses,
+            }),
+        );
+
+        act(() => {
+            result.current.actions.handleSelectWaitingNurse(waitingNurse);
+        });
+
+        await act(async () => {
+            await result.current.actions.handleCompleteSelection();
+        });
+
+        expect(result.current.state.step).toBe(3);
+        expect(result.current.state.submitStatus).toBe('error');
+        expect(connectWaitingNurses).not.toHaveBeenCalled();
+        expect(approveWaitingNurses).not.toHaveBeenCalled();
+    });
+
+    it('submits add mode through approveWaitingNurses and stores a success result', async () => {
+        const connectWaitingNurses = vi.fn();
+        const approveWaitingNurses = vi.fn().mockResolvedValue(true);
+        const {result} = renderHook(() =>
+            useConnectionManageController({
+                open: true,
+                approveWaitingNurses,
+                connectWaitingNurses,
+            }),
+        );
+
+        act(() => {
+            result.current.actions.handleSelectWaitingNurse(waitingNurse);
+            result.current.actions.setConnectMode('add');
+            result.current.actions.setToAddShiftTeamId(20);
+        });
+
+        await act(async () => {
+            await result.current.actions.handleCompleteSelection();
+        });
+
+        expect(approveWaitingNurses).toHaveBeenCalledWith(1, 20);
+        expect(connectWaitingNurses).not.toHaveBeenCalled();
+        expect(result.current.state.step).toBe(3);
+        expect(result.current.state.submitStatus).toBe('success');
+    });
+
+    it('clears selected targets when returning to method selection', () => {
+        const {result} = renderHook(() =>
+            useConnectionManageController({
+                open: true,
+                approveWaitingNurses: vi.fn(),
+                connectWaitingNurses: vi.fn(),
+            }),
+        );
+
+        act(() => {
+            result.current.actions.handleSelectWaitingNurse(waitingNurse);
+            result.current.actions.setConnectMode('add');
+            result.current.actions.setToLinkNurseId(99);
+            result.current.actions.setToAddShiftTeamId(20);
+            result.current.actions.goToMethodSelection();
+        });
+
+        expect(result.current.state.step).toBe(1);
+        expect(result.current.state.toLinkNurseId).toBeNull();
+        expect(result.current.state.toAddShiftTeamId).toBeNull();
+        expect(result.current.state.submitStatus).toBe('idle');
+    });
+
+    it('reinitializes when the modal is closed', () => {
+        const {result, rerender} = renderHook(
+            ({open}) =>
+                useConnectionManageController({
+                    open,
+                    approveWaitingNurses: vi.fn(),
+                    connectWaitingNurses: vi.fn(),
+                }),
+            {
+                initialProps: {open: true},
+            },
+        );
+
+        act(() => {
+            result.current.actions.handleSelectWaitingNurse(waitingNurse);
+            result.current.actions.setToLinkNurseId(99);
+        });
+
+        rerender({open: false});
+
+        expect(result.current.state.step).toBe(0);
+        expect(result.current.state.currentWaitingNurse).toBeNull();
+        expect(result.current.state.toLinkNurseId).toBeNull();
+        expect(result.current.state.submitStatus).toBe('idle');
+    });
+
     it('ignores stale submit completion after the flow is reset', async () => {
         let resolveConnect: ((value: boolean | undefined) => void) | null = null;
 


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-896](https://gom3.atlassian.net/browse/DUT-896)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- MemberPage 연결 관리 model 테스트에 타깃 누락, link/add mode 미선택 제출 에러, add mode 로딩/에러 fallback 케이스를 추가했습니다.
- useConnectionManageController 테스트에 link/add 상태 전이, 대상 초기화, 모달 close reset 시나리오를 추가했습니다.
- shiftTeamList 이동 payload 계산 테스트를 추가해 같은 팀 재정렬, 다른 팀 이동, division 0 drop, invalid destination 예외를 고정했습니다.
- nurseEdit 테스트에 변경 감지 예외와 저장 실패/성공/취소 피드백 시나리오를 추가했습니다.

<br>

## To Reviewers

- 실행 검증: `pnpm --dir ./apps/app run test:run -- src/pages/MemberPage/model/useConnectionManageController.test.tsx`, `pnpm --dir ./apps/app run type-check`
- 이전 검증: `pnpm --dir ./apps/app run test:run -- src/pages/MemberPage/model/connectionManage.test.ts src/pages/MemberPage/model/nurseEdit.test.ts src/pages/MemberPage/model/shiftTeamList.test.ts src/pages/MemberPage/model/useConnectionManageController.test.tsx`, `pnpm --dir ./apps/app run type-check`
- 테스트 실행 시 worktree에 `node_modules`가 없어 원본 작업공간의 `node_modules` 심볼릭 링크를 임시로 사용했습니다. 코드 변경에는 포함되지 않습니다.

<br>

## Follow-up

- `useShiftTeamListControllerHook`의 키보드 포커스 이동과 click-away 동작은 이번 PR에서 직접 검증하지 않았습니다. 다음 단계에서 hook 단위 테스트로 보강하면 모델 규칙 회귀를 더 줄일 수 있습니다.
- `features/ward` mutation hook과 MemberPage controller 사이의 통합 레벨 실패 분기(API 오류 shape, 서버 응답 변형)는 아직 비어 있습니다. 후속 티켓에서 통합 테스트 범위로 다루는 편이 적절합니다.


[DUT-896]: https://gom3.atlassian.net/browse/DUT-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ