### PR TITLE
[DUT-897]: shift-editor 핵심 도메인 테스트 보강

### DIFF
--- a/apps/app/src/features/shift-editor/model/operation.test.ts
+++ b/apps/app/src/features/shift-editor/model/operation.test.ts
@@ -1,0 +1,69 @@
+import {describe, expect, it} from 'vitest';
+import {applyOperation, invertOperation} from './operation';
+import type {TDutyDoc, TOperation} from './types';
+
+function createDoc(): TDutyDoc {
+    return {
+        columns: ['2026-03-01', '2026-03-02', '2026-03-03'],
+        rows: [
+            {workerId: '1', cells: ['D', null, 'N']},
+            {workerId: '2', cells: ['O', 'E', null]},
+        ],
+        workerMeta: {
+            1: {name: 'Kim'},
+            2: {name: 'Lee'},
+        },
+    };
+}
+
+describe('operation', () => {
+    it('applies setCells only to changed cells within bounds', () => {
+        const doc = createDoc();
+        const op: TOperation = {
+            kind: 'setCells',
+            cells: [
+                {row: 0, col: 1, prev: null, next: 'D'},
+                {row: 1, col: 5, prev: null, next: 'N'},
+            ],
+        };
+        const nextDoc = applyOperation(doc, op);
+
+        expect(nextDoc.rows[0]?.cells).toEqual(['D', 'D', 'N']);
+        expect(nextDoc.rows[1]?.cells).toEqual(['O', 'E', null]);
+        expect(nextDoc.rows[0]).not.toBe(doc.rows[0]);
+        expect(nextDoc.rows[1]?.cells).toEqual(doc.rows[1]?.cells);
+    });
+
+    it('restores the previous document when applying an inverted setCells operation', () => {
+        const doc = createDoc();
+        const op: TOperation = {
+            kind: 'setCells',
+            cells: [
+                {row: 0, col: 0, prev: 'D', next: 'E'},
+                {row: 1, col: 2, prev: null, next: 'N'},
+            ],
+        };
+        const nextDoc = applyOperation(doc, op);
+        const restoredDoc = applyOperation(nextDoc, invertOperation(op));
+
+        expect(restoredDoc).toEqual(doc);
+    });
+
+    it('reorders rows only when nextOrder covers every row', () => {
+        const doc = createDoc();
+        const reordered = applyOperation(doc, {
+            kind: 'reorderRows',
+            prevOrder: [0, 1],
+            nextOrder: [1, 0],
+        });
+        const invalid = applyOperation(doc, {
+            kind: 'reorderRows',
+            prevOrder: [0, 1],
+            nextOrder: [1],
+        });
+
+        expect(reordered.rows.map((row) => row.workerId)).toEqual(['2', '1']);
+        expect(applyOperation(reordered, invertOperation({kind: 'reorderRows', prevOrder: [0, 1], nextOrder: [1, 0]}))).toEqual(doc);
+        expect(invalid).toBe(doc);
+    });
+});

--- a/apps/app/src/features/shift-editor/model/operation.test.ts
+++ b/apps/app/src/features/shift-editor/model/operation.test.ts
@@ -66,4 +66,15 @@ describe('operation', () => {
         expect(applyOperation(reordered, invertOperation({kind: 'reorderRows', prevOrder: [0, 1], nextOrder: [1, 0]}))).toEqual(doc);
         expect(invalid).toBe(doc);
     });
+
+    it('ignores reorder operations with duplicate row indexes', () => {
+        const doc = createDoc();
+        const invalid = applyOperation(doc, {
+            kind: 'reorderRows',
+            prevOrder: [0, 1],
+            nextOrder: [0, 0],
+        });
+
+        expect(invalid).toBe(doc);
+    });
 });

--- a/apps/app/src/features/shift-editor/model/operation.ts
+++ b/apps/app/src/features/shift-editor/model/operation.ts
@@ -60,13 +60,20 @@ function applySetCellsOp(doc: TDutyDoc, op: TSetCellsOp): TDutyDoc {
 }
 
 function applyReorderRowsOp(doc: TDutyDoc, op: TReorderRowsOp): TDutyDoc {
-    if (op.nextOrder.length !== doc.rows.length) return doc;
+    if (op.prevOrder.length !== doc.rows.length || op.nextOrder.length !== doc.rows.length) return doc;
 
-    const nextRows = op.nextOrder.map((idx) => doc.rows[idx]).filter(Boolean);
+    const prevIndexByRow = new Map(op.prevOrder.map((rowIdx, position) => [rowIdx, position]));
+    const nextRows = op.nextOrder.map((rowIdx) => {
+        const currentPosition = prevIndexByRow.get(rowIdx);
 
-    if (nextRows.length !== doc.rows.length) return doc;
+        if (currentPosition === undefined) return null;
 
-    return {...doc, rows: nextRows};
+        return doc.rows[currentPosition] ?? null;
+    });
+
+    if (nextRows.some((row) => row === null)) return doc;
+
+    return {...doc, rows: nextRows as TDutyDoc['rows']};
 }
 
 export function applyOperation(doc: TDutyDoc, op: TOperation): TDutyDoc {

--- a/apps/app/src/features/shift-editor/model/operation.ts
+++ b/apps/app/src/features/shift-editor/model/operation.ts
@@ -62,6 +62,8 @@ function applySetCellsOp(doc: TDutyDoc, op: TSetCellsOp): TDutyDoc {
 function applyReorderRowsOp(doc: TDutyDoc, op: TReorderRowsOp): TDutyDoc {
     if (op.prevOrder.length !== doc.rows.length || op.nextOrder.length !== doc.rows.length) return doc;
 
+    if (new Set(op.prevOrder).size !== op.prevOrder.length || new Set(op.nextOrder).size !== op.nextOrder.length) return doc;
+
     const prevIndexByRow = new Map(op.prevOrder.map((rowIdx, position) => [rowIdx, position]));
     const nextRows = op.nextOrder.map((rowIdx) => {
         const currentPosition = prevIndexByRow.get(rowIdx);

--- a/apps/app/src/features/shift-editor/model/selection.test.ts
+++ b/apps/app/src/features/shift-editor/model/selection.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from 'vitest';
+import {getCellsInSelection, makeSelectAllSelection, moveSelection, moveSelectionToEdge, normalizeSelection} from './selection';
+import type {TSelection} from './types';
+
+const bounds = {rowCount: 2, colCount: 3};
+
+describe('selection', () => {
+    it('moves right across columns and wraps to the next row', () => {
+        const selection: TSelection = {type: 'single', anchor: {row: 0, col: 2}};
+
+        expect(moveSelection(selection, 'right', false, bounds)).toEqual({
+            type: 'single',
+            anchor: {row: 1, col: 0},
+        });
+    });
+
+    it('keeps the current cell when movement would leave the board', () => {
+        const selection: TSelection = {type: 'single', anchor: {row: 0, col: 0}};
+
+        expect(moveSelection(selection, 'left', false, bounds)).toEqual(selection);
+        expect(moveSelection(selection, 'up', false, bounds)).toEqual(selection);
+    });
+
+    it('extends a single selection into a range and keeps the original anchor', () => {
+        const selection: TSelection = {type: 'single', anchor: {row: 0, col: 1}};
+
+        expect(moveSelection(selection, 'down', true, bounds)).toEqual({
+            type: 'range',
+            from: {row: 0, col: 1},
+            to: {row: 1, col: 1},
+        });
+    });
+
+    it('collapses a range into a single selection at the moved edge', () => {
+        const selection: TSelection = {
+            type: 'range',
+            from: {row: 1, col: 0},
+            to: {row: 0, col: 1},
+        };
+
+        expect(moveSelection(selection, 'right', false, bounds)).toEqual({
+            type: 'single',
+            anchor: {row: 0, col: 2},
+        });
+    });
+
+    it('moves to the row or column edge and preserves range anchor when extending', () => {
+        const selection: TSelection = {type: 'single', anchor: {row: 1, col: 1}};
+
+        expect(moveSelectionToEdge(selection, 'left', false, bounds)).toEqual({
+            type: 'single',
+            anchor: {row: 1, col: 0},
+        });
+        expect(moveSelectionToEdge(selection, 'up', true, bounds)).toEqual({
+            type: 'range',
+            from: {row: 1, col: 1},
+            to: {row: 0, col: 1},
+        });
+    });
+
+    it('creates select-all range only when bounds are valid', () => {
+        expect(makeSelectAllSelection(bounds)).toEqual({
+            type: 'range',
+            from: {row: 0, col: 0},
+            to: {row: 1, col: 2},
+        });
+        expect(makeSelectAllSelection({rowCount: 0, colCount: 3})).toBeNull();
+    });
+
+    it('normalizes reversed ranges and enumerates all cells in row-major order', () => {
+        const selection: TSelection = {
+            type: 'range',
+            from: {row: 1, col: 2},
+            to: {row: 0, col: 1},
+        };
+
+        expect(normalizeSelection(selection)).toEqual({
+            top: 0,
+            left: 1,
+            bottom: 1,
+            right: 2,
+        });
+        expect(getCellsInSelection(selection)).toEqual([
+            {row: 0, col: 1},
+            {row: 0, col: 2},
+            {row: 1, col: 1},
+            {row: 1, col: 2},
+        ]);
+    });
+});

--- a/apps/app/src/features/shift-editor/model/shift-adapter.test.ts
+++ b/apps/app/src/features/shift-editor/model/shift-adapter.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 import type {TShift} from '@/entities';
-import {buildWorkKeyMap, docToWardShiftsDTO, shiftToDoc} from './shift-adapter';
+import {buildWorkKeyMap, docToShift, docToWardShiftsDTO, shiftToDoc} from './shift-adapter';
 
 function createShift(): TShift {
     return {
@@ -112,5 +112,32 @@ describe('shift-adapter', () => {
             d: 'D',
             o: 'O',
         });
+    });
+
+    it('projects editor doc back onto worker rows while preserving non-worker rows', () => {
+        const shift = createShift();
+        const doc = {
+            columns: ['2026-03-01', '2026-03-02'],
+            rows: [{workerId: '1', cells: ['O', 'TR']}],
+            workerMeta: {1: {name: 'Kim'}},
+        };
+        const nextShift = docToShift(doc, shift);
+
+        expect(nextShift.divisionShiftNurses[0]?.[0]?.wardShiftList).toEqual([20, 30]);
+        expect(nextShift.divisionShiftNurses[0]?.[1]?.wardShiftList).toEqual([20, 10]);
+    });
+
+    it('falls back to null when editor cells do not map to a known ward shift type', () => {
+        const shift = createShift();
+        const doc = {
+            columns: ['2026-03-01', '2026-03-02'],
+            rows: [{workerId: '1', cells: ['UNKNOWN', 'D']}],
+            workerMeta: {1: {name: 'Kim'}},
+        };
+
+        expect(docToWardShiftsDTO(doc, shift)).toEqual([
+            {shiftNurseId: 1, date: '2026-03-01', wardShiftTypeId: null},
+            {shiftNurseId: 1, date: '2026-03-02', wardShiftTypeId: 10},
+        ]);
     });
 });

--- a/apps/app/src/features/shift-editor/model/useShiftEditorCommands.test.tsx
+++ b/apps/app/src/features/shift-editor/model/useShiftEditorCommands.test.tsx
@@ -1,0 +1,119 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {act, renderHook} from '@/shared/util/test-utils';
+import {useShiftEditorStore} from './store';
+import type {TClipboardPayload, TDutyDoc} from './types';
+import {useShiftEditorCommands} from './useShiftEditorCommands';
+
+function createDoc(): TDutyDoc {
+    return {
+        columns: ['2026-03-01', '2026-03-02', '2026-03-03'],
+        rows: [
+            {workerId: '2', cells: ['D', null, 'N']},
+            {workerId: '1', cells: [null, 'E', null]},
+        ],
+        workerMeta: {
+            1: {name: 'Kim'},
+            2: {name: 'Lee'},
+        },
+    };
+}
+
+describe('useShiftEditorCommands', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        window.localStorage.clear();
+        useShiftEditorStore.getState().reset();
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+        window.localStorage.clear();
+        useShiftEditorStore.getState().reset();
+    });
+
+    it('writes the selected range and records history for undo/redo', () => {
+        const {result} = renderHook(() => useShiftEditorCommands());
+        const selection = {type: 'range' as const, from: {row: 0, col: 0}, to: {row: 1, col: 1}};
+
+        act(() => {
+            result.current.init(createDoc(), {maxHistoryDepth: 5});
+            useShiftEditorStore.getState().setSelection(selection);
+            result.current.setSelectionValue('O');
+        });
+
+        const afterEdit = useShiftEditorStore.getState();
+
+        expect(afterEdit.doc.rows.map((row) => row.cells)).toEqual([
+            ['O', 'O', 'N'],
+            ['O', 'O', null],
+        ]);
+        expect(afterEdit.history.past).toHaveLength(1);
+        expect(afterEdit.history.past[0]?.selectionBefore).toEqual(selection);
+
+        act(() => result.current.undo());
+
+        const afterUndo = useShiftEditorStore.getState();
+
+        expect(afterUndo.doc).toEqual(createDoc());
+        expect(afterUndo.selection).toEqual(selection);
+        expect(afterUndo.history.future).toHaveLength(1);
+
+        act(() => result.current.redo());
+
+        const afterRedo = useShiftEditorStore.getState();
+
+        expect(afterRedo.doc.rows.map((row) => row.cells)).toEqual([
+            ['O', 'O', 'N'],
+            ['O', 'O', null],
+        ]);
+        expect(afterRedo.selection).toEqual(selection);
+    });
+
+    it('pastes payload from the selection anchor and trims cells outside document bounds', () => {
+        const {result} = renderHook(() => useShiftEditorCommands());
+        const payload: TClipboardPayload = {
+            width: 2,
+            height: 2,
+            cells: [
+                ['O', 'N'],
+                ['E', 'D'],
+            ],
+        };
+
+        act(() => {
+            result.current.init(createDoc());
+            useShiftEditorStore.getState().setSelection({type: 'single', anchor: {row: 1, col: 2}});
+            result.current.paste(payload);
+        });
+
+        expect(useShiftEditorStore.getState().doc.rows.map((row) => row.cells)).toEqual([
+            ['D', null, 'N'],
+            [null, 'E', 'O'],
+        ]);
+        expect(useShiftEditorStore.getState().history.past).toHaveLength(1);
+    });
+
+    it('reorders rows by worker name, clears selection, and supports undo', () => {
+        const {result} = renderHook(() => useShiftEditorCommands());
+
+        act(() => {
+            result.current.init(createDoc());
+            useShiftEditorStore.getState().setSelection({type: 'single', anchor: {row: 1, col: 1}});
+            result.current.reorderRowsByName();
+        });
+
+        const afterReorder = useShiftEditorStore.getState();
+
+        expect(afterReorder.doc.rows.map((row) => row.workerId)).toEqual(['1', '2']);
+        expect(afterReorder.selection).toBeNull();
+        expect(afterReorder.history.past[0]?.tx.source).toBe('user');
+
+        act(() => result.current.undo());
+
+        const afterUndo = useShiftEditorStore.getState();
+
+        expect(afterUndo.doc.rows.map((row) => row.workerId)).toEqual(['2', '1']);
+        expect(afterUndo.selection).toEqual({type: 'single', anchor: {row: 1, col: 1}});
+    });
+});

--- a/apps/app/src/features/shift-editor/model/useShiftEditorKeyBindings.test.tsx
+++ b/apps/app/src/features/shift-editor/model/useShiftEditorKeyBindings.test.tsx
@@ -1,0 +1,172 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@/shared/util/test-utils';
+import type {TClipboardPayload} from './types';
+import {useShiftEditorKeyBindings} from './useShiftEditorKeyBindings';
+
+const commands = {
+    moveSelection: vi.fn(),
+    selectAll: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    clearSelectionCells: vi.fn(),
+    copy: vi.fn<() => TClipboardPayload | null>(),
+    paste: vi.fn(),
+    setSelectionValue: vi.fn(),
+};
+
+vi.mock('./useShiftEditorCommands', () => ({
+    useShiftEditorCommands: () => commands,
+}));
+
+vi.mock('./store', () => ({
+    useShiftEditorStore: (selector: (state: {doc: {columns: string[]; rows: unknown[]}}) => unknown) =>
+        selector({
+            doc: {
+                columns: ['2026-03-01'],
+                rows: [{workerId: '1', cells: [null]}],
+            },
+        }),
+}));
+
+function createKeyboardEvent(
+    key: string,
+    nativeOverrides: Partial<KeyboardEvent> = {},
+): React.KeyboardEvent & {preventDefault: ReturnType<typeof vi.fn>} {
+    const preventDefault = vi.fn();
+
+    return {
+        preventDefault,
+        nativeEvent: {
+            key,
+            shiftKey: false,
+            altKey: false,
+            ctrlKey: false,
+            metaKey: false,
+            ...nativeOverrides,
+        },
+    } as unknown as React.KeyboardEvent & {preventDefault: ReturnType<typeof vi.fn>};
+}
+
+function createPasteEvent(text: string): React.ClipboardEvent & {preventDefault: ReturnType<typeof vi.fn>} {
+    const preventDefault = vi.fn();
+
+    return {
+        preventDefault,
+        clipboardData: {
+            getData: vi.fn(() => text),
+        },
+    } as unknown as React.ClipboardEvent & {preventDefault: ReturnType<typeof vi.fn>};
+}
+
+describe('useShiftEditorKeyBindings', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal('navigator', {
+            clipboard: {
+                writeText: vi.fn().mockResolvedValue(undefined),
+                readText: vi.fn().mockResolvedValue('O\tN\nE'),
+            },
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('maps arrow keys to selection movement and passes shift/meta modifiers through', async () => {
+        const {result} = renderHook(() => useShiftEditorKeyBindings());
+        const event = createKeyboardEvent('ArrowRight', {shiftKey: true, metaKey: true});
+
+        await result.current.onKeyDown(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(commands.moveSelection).toHaveBeenCalledWith('right', true, true);
+    });
+
+    it('handles select-all, undo/redo, and delete shortcuts', async () => {
+        const {result} = renderHook(() => useShiftEditorKeyBindings());
+
+        await result.current.onKeyDown(createKeyboardEvent('a', {ctrlKey: true}));
+        await result.current.onKeyDown(createKeyboardEvent('z', {metaKey: true}));
+        await result.current.onKeyDown(createKeyboardEvent('Z', {metaKey: true, shiftKey: true}));
+        await result.current.onKeyDown(createKeyboardEvent('y', {ctrlKey: true}));
+        await result.current.onKeyDown(createKeyboardEvent('Delete'));
+
+        expect(commands.selectAll).toHaveBeenCalledTimes(1);
+        expect(commands.undo).toHaveBeenCalledTimes(1);
+        expect(commands.redo).toHaveBeenCalledTimes(2);
+        expect(commands.clearSelectionCells).toHaveBeenCalledTimes(1);
+    });
+
+    it('interprets Korean IME keys through the work key map', async () => {
+        const {result} = renderHook(() =>
+            useShiftEditorKeyBindings({
+                workKeyMap: {d: 'D'},
+            }),
+        );
+
+        await result.current.onKeyDown(createKeyboardEvent('ㅇ'));
+
+        expect(commands.setSelectionValue).toHaveBeenCalledWith('D');
+    });
+
+    it('copies and cuts selected cells through the clipboard API', async () => {
+        commands.copy.mockReturnValue({
+            width: 2,
+            height: 2,
+            cells: [
+                ['D', null],
+                ['N', 'O'],
+            ],
+        });
+
+        const {result} = renderHook(() => useShiftEditorKeyBindings());
+
+        await result.current.onKeyDown(createKeyboardEvent('c', {ctrlKey: true}));
+        await result.current.onKeyDown(createKeyboardEvent('x', {metaKey: true}));
+
+        expect(navigator.clipboard.writeText).toHaveBeenNthCalledWith(1, 'D\t\nN\tO');
+        expect(navigator.clipboard.writeText).toHaveBeenNthCalledWith(2, 'D\t\nN\tO');
+        expect(commands.clearSelectionCells).toHaveBeenCalledTimes(1);
+    });
+
+    it('pastes normalized TSV from both keydown and onPaste handlers', async () => {
+        const {result} = renderHook(() => useShiftEditorKeyBindings());
+
+        await result.current.onKeyDown(createKeyboardEvent('v', {ctrlKey: true}));
+        result.current.onPaste(createPasteEvent('A\tB\r\nC'));
+
+        expect(commands.paste).toHaveBeenNthCalledWith(1, {
+            width: 2,
+            height: 2,
+            cells: [
+                ['O', 'N'],
+                ['E', null],
+            ],
+        });
+        expect(commands.paste).toHaveBeenNthCalledWith(2, {
+            width: 2,
+            height: 2,
+            cells: [
+                ['A', 'B'],
+                ['C', null],
+            ],
+        });
+    });
+
+    it('runs beforeHandlers before built-in bindings and stops when handled', async () => {
+        const beforeHandler = vi.fn(() => true);
+        const {result} = renderHook(() =>
+            useShiftEditorKeyBindings({
+                beforeHandlers: [beforeHandler],
+            }),
+        );
+        const event = createKeyboardEvent('ArrowLeft');
+
+        await result.current.onKeyDown(event);
+
+        expect(beforeHandler).toHaveBeenCalled();
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(commands.moveSelection).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-897](https://gom3.atlassian.net/browse/DUT-897)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- shift-editor selection 규칙과 edge 이동, select-all, range 정규화 동작을 순수 테스트로 고정했습니다.
- command 적용과 key binding 해석에 대한 테스트를 추가해 paste, undo/redo, reorderRows, work key 입력, clipboard shortcut 회귀를 검증합니다.
- doc 변환 테스트를 보강하고, reorderRows undo가 실제로 원복되도록 row order 적용 로직을 최소 수정했습니다.
- malformed reorder operation이 duplicate index를 포함해도 문서를 깨뜨리지 않도록 경계 조건을 보강했습니다.

<br>

## Follow-up

- `validator.ts`, `duty-constraints.ts`의 규칙 조합 테스트는 이번 티켓 범위에서 제외했고, 다음 테스트 보강 대상입니다.
- 실제 grid DOM과 selection 상호작용, 브라우저 clipboard 권한 실패 같은 UI/환경 통합 케이스는 별도 레이어에서 다루는 편이 맞습니다.

<br>

## To Reviewers

- `operation.ts`의 reorder inverse 적용과 malformed input 방어가 이번 변경의 유일한 production 로직 수정입니다.
- DUT-897 범위에 맞춰 UI 렌더링 테스트는 추가하지 않았고, 핵심 도메인 규칙을 순수 로직/모델 테스트로 고정하는 데 집중했습니다.


[DUT-897]: https://gom3.atlassian.net/browse/DUT-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ