### PR TITLE
[DUT-900]: 인증 리다이렉트 판단 로직 분리

### DIFF
--- a/apps/app/src/features/auth/useAuth/index.ts
+++ b/apps/app/src/features/auth/useAuth/index.ts
@@ -33,13 +33,6 @@ const useAuth = (activeEffect = false) => {
         setState('accessToken', accessToken);
         setAccessToken(accessToken);
 
-        // refresh 등 "상태만 세팅"이 필요할 때는 리다이렉트를 하지 않는다.
-        if (nextPageUrl === null) {
-            sendEvent(events.auth.login);
-
-            return;
-        }
-
         const redirectDecision = getLoginRedirectDecision(nextPageUrl);
 
         executeLoginRedirect(redirectDecision);

--- a/apps/app/src/features/auth/useAuth/index.ts
+++ b/apps/app/src/features/auth/useAuth/index.ts
@@ -6,8 +6,8 @@ import useLoadingUseCase from '@/features/ui/useLoading';
 import useTutorialUseCase from '@/features/ui/useTutorial';
 import {AccountAPI, AuthAPI} from '@/shared/api';
 import {setAccessToken} from '@/shared/api/client';
-import {resolveSafeRedirectTarget} from '@/shared/config/runtime';
 import ROUTE from '@/shared/constant/path';
+import {executeLoginRedirect, getLoginRedirectDecision} from './loginRedirect';
 import useAuthStore from './store';
 
 const useAuth = (activeEffect = false) => {
@@ -40,13 +40,9 @@ const useAuth = (activeEffect = false) => {
             return;
         }
 
-        const redirectTarget = resolveSafeRedirectTarget(nextPageUrl);
+        const redirectDecision = getLoginRedirectDecision(nextPageUrl);
 
-        if (redirectTarget === 'back') {
-            window.history.back();
-        } else {
-            location.replace(redirectTarget);
-        }
+        executeLoginRedirect(redirectDecision);
 
         sendEvent(events.auth.login);
     };

--- a/apps/app/src/features/auth/useAuth/loginRedirect.test.ts
+++ b/apps/app/src/features/auth/useAuth/loginRedirect.test.ts
@@ -1,0 +1,97 @@
+import {describe, expect, it, vi} from 'vitest';
+import ROUTE from '@/shared/constant/path';
+import {executeLoginRedirect, getLoginRedirectDecision} from './loginRedirect';
+
+describe('getLoginRedirectDecision', () => {
+    it('returns none when login should only update auth state', () => {
+        const resolveRedirectTarget = vi.fn();
+
+        expect(getLoginRedirectDecision(null, resolveRedirectTarget)).toEqual({type: 'none'});
+        expect(resolveRedirectTarget).not.toHaveBeenCalled();
+    });
+
+    it('maps resolved back redirects to history-back instructions', () => {
+        const resolveRedirectTarget = vi.fn().mockReturnValue('back');
+
+        expect(getLoginRedirectDecision('/request', resolveRedirectTarget)).toEqual({type: 'history-back'});
+    });
+
+    it('maps resolved targets to replace instructions', () => {
+        const resolveRedirectTarget = vi.fn().mockReturnValue('/request?month=3#calendar');
+
+        expect(getLoginRedirectDecision('/request?month=3#calendar', resolveRedirectTarget)).toEqual({
+            type: 'replace',
+            href: '/request?month=3#calendar',
+        });
+    });
+
+    it('keeps allowed app-domain subdomain redirects as in-app replace targets', () => {
+        vi.stubGlobal('window', {
+            location: {
+                origin: 'https://app.dutying.net',
+            },
+            history: {
+                back: vi.fn(),
+            },
+        });
+
+        expect(getLoginRedirectDecision('https://app.dutying.net/request?month=3#calendar')).toEqual({
+            type: 'replace',
+            href: '/request?month=3#calendar',
+        });
+    });
+
+    it('falls back when nextPageUrl points to the landing domain after subdomain split', () => {
+        vi.stubGlobal('window', {
+            location: {
+                origin: 'https://app.dutying.net',
+            },
+            history: {
+                back: vi.fn(),
+            },
+        });
+
+        expect(getLoginRedirectDecision('https://dutying.net/request?month=3')).toEqual({
+            type: 'replace',
+            href: ROUTE.MAKE,
+        });
+    });
+});
+
+describe('executeLoginRedirect', () => {
+    it('calls history back for history-back instructions', () => {
+        const executor = {
+            back: vi.fn(),
+            replace: vi.fn(),
+        };
+
+        executeLoginRedirect({type: 'history-back'}, executor);
+
+        expect(executor.back).toHaveBeenCalledTimes(1);
+        expect(executor.replace).not.toHaveBeenCalled();
+    });
+
+    it('calls replace for replace instructions', () => {
+        const executor = {
+            back: vi.fn(),
+            replace: vi.fn(),
+        };
+
+        executeLoginRedirect({type: 'replace', href: '/member'}, executor);
+
+        expect(executor.replace).toHaveBeenCalledWith('/member');
+        expect(executor.back).not.toHaveBeenCalled();
+    });
+
+    it('does nothing for none instructions', () => {
+        const executor = {
+            back: vi.fn(),
+            replace: vi.fn(),
+        };
+
+        executeLoginRedirect({type: 'none'}, executor);
+
+        expect(executor.back).not.toHaveBeenCalled();
+        expect(executor.replace).not.toHaveBeenCalled();
+    });
+});

--- a/apps/app/src/features/auth/useAuth/loginRedirect.test.ts
+++ b/apps/app/src/features/auth/useAuth/loginRedirect.test.ts
@@ -25,6 +25,22 @@ describe('getLoginRedirectDecision', () => {
         });
     });
 
+    it('falls back to the default app route when nextPageUrl is missing', () => {
+        vi.stubGlobal('window', {
+            location: {
+                origin: 'https://app.dutying.net',
+            },
+            history: {
+                back: vi.fn(),
+            },
+        });
+
+        expect(getLoginRedirectDecision(undefined)).toEqual({
+            type: 'replace',
+            href: ROUTE.MAKE,
+        });
+    });
+
     it('keeps allowed app-domain subdomain redirects as in-app replace targets', () => {
         vi.stubGlobal('window', {
             location: {

--- a/apps/app/src/features/auth/useAuth/loginRedirect.test.ts
+++ b/apps/app/src/features/auth/useAuth/loginRedirect.test.ts
@@ -1,6 +1,10 @@
-import {describe, expect, it, vi} from 'vitest';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 import ROUTE from '@/shared/constant/path';
 import {executeLoginRedirect, getLoginRedirectDecision} from './loginRedirect';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
 
 describe('getLoginRedirectDecision', () => {
     it('returns none when login should only update auth state', () => {

--- a/apps/app/src/features/auth/useAuth/loginRedirect.ts
+++ b/apps/app/src/features/auth/useAuth/loginRedirect.ts
@@ -1,0 +1,46 @@
+import {resolveSafeRedirectTarget} from '@/shared/config/runtime';
+
+export type TLoginRedirectDecision = {type: 'none'} | {type: 'history-back'} | {type: 'replace'; href: string};
+
+type TRedirectTargetResolver = (target: string | null | undefined) => string;
+type TLoginRedirectExecutor = {
+    back: () => void;
+    replace: (href: string) => void;
+};
+
+export const getLoginRedirectDecision = (
+    nextPageUrl?: string | null,
+    resolveRedirectTarget: TRedirectTargetResolver = resolveSafeRedirectTarget,
+): TLoginRedirectDecision => {
+    if (nextPageUrl === null) {
+        return {type: 'none'};
+    }
+
+    const redirectTarget = resolveRedirectTarget(nextPageUrl);
+
+    if (redirectTarget === 'back') {
+        return {type: 'history-back'};
+    }
+
+    return {
+        type: 'replace',
+        href: redirectTarget,
+    };
+};
+
+const defaultExecutor = (): TLoginRedirectExecutor => ({
+    back: () => window.history.back(),
+    replace: (href: string) => location.replace(href),
+});
+
+export const executeLoginRedirect = (decision: TLoginRedirectDecision, executor: TLoginRedirectExecutor = defaultExecutor()) => {
+    if (decision.type === 'history-back') {
+        executor.back();
+
+        return;
+    }
+
+    if (decision.type === 'replace') {
+        executor.replace(decision.href);
+    }
+};


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-900](https://gom3.atlassian.net/browse/DUT-900)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `useAuth.handleLogin`의 로그인 후 이동 판단을 `getLoginRedirectDecision`/`executeLoginRedirect`로 분리했습니다.
- 로그인 후 `back`, fallback replace, 허용된 앱 서브도메인 이동 규칙을 순수 테스트로 고정했습니다.
- `dutying.net` 랜딩 도메인으로 향하는 `nextPageUrl`은 앱 내부 fallback으로 수렴하도록 회귀 방어를 강화했습니다.

<br>

## To Reviewers

- 실제 브라우저 이동 방식은 유지하고 판단 로직만 helper로 분리한 변경입니다.
- 서브도메인 분기 회귀 방어는 helper 테스트 중심으로 보강했고, 실제 OAuth 리다이렉트 E2E는 이번 범위에 포함하지 않았습니다.

<br>

## Follow-up

- 실제 배포 환경에서 `dutying.net` -> `app.dutying.net` 로그인/복귀 흐름을 검증하는 스모크 또는 E2E 시나리오를 별도 티켓으로 보강하면 좋습니다.


[DUT-900]: https://gom3.atlassian.net/browse/DUT-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ