### PR TITLE
[DUT-904]: duty 완료 경계 테스트 보강

### DIFF
--- a/apps/app/src/pages/duty/model/dutyHook.test.tsx
+++ b/apps/app/src/pages/duty/model/dutyHook.test.tsx
@@ -101,8 +101,8 @@ vi.mock('@/features/shift-editor', () => ({
 }));
 
 const shiftTeams = [
-    {shiftTeamId: 10, name: 'A팀'},
-    {shiftTeamId: 20, name: 'B팀'},
+    {shiftTeamId: 10, name: 'A팀', nurseCnt: 0, nurses: []},
+    {shiftTeamId: 20, name: 'B팀', nurseCnt: 0, nurses: []},
 ];
 
 const shift = {
@@ -306,5 +306,146 @@ describe('useDutyHook', () => {
         });
         expect(mockSetLoading).toHaveBeenLastCalledWith(false);
         expect(useDutyStore.getState().readonly).toBe(true);
+    });
+
+    it('keeps edit mode active when saving fails while still clearing the loading state', async () => {
+        mockUpdateShifts.mockRejectedValue(new Error('save failed'));
+
+        const {result} = renderHook(() => useDutyHook());
+
+        await waitFor(() => {
+            expect(result.current.state.shift).toBe(shift);
+        });
+
+        mockCommands.discardPersisted.mockClear();
+        mockInvalidateQueries.mockClear();
+
+        act(() => {
+            result.current.handlers.enableEdit();
+        });
+
+        await expect(
+            act(async () => {
+                await result.current.handlers.saveEdit();
+            }),
+        ).rejects.toThrow('save failed');
+
+        expect(mockDocToWardShiftsDTO).toHaveBeenCalledWith(mockEditorState.doc, shift);
+        expect(mockUpdateShifts).toHaveBeenCalled();
+        expect(mockCommands.discardPersisted).not.toHaveBeenCalled();
+        expect(mockInvalidateQueries).not.toHaveBeenCalled();
+        expect(mockSetLoading).toHaveBeenNthCalledWith(1, true);
+        expect(mockSetLoading).toHaveBeenLastCalledWith(false);
+        expect(useDutyStore.getState().readonly).toBe(false);
+    });
+
+    it('posts the current shift and invalidates the duty query', async () => {
+        mockSearchParams = new URLSearchParams('year=2025&month=7&shiftTeamId=20');
+        mockPostShift.mockResolvedValue(undefined);
+
+        const {result} = renderHook(() => useDutyHook());
+
+        await waitFor(() => {
+            expect(result.current.state.currentShiftTeamId).toBe(20);
+        });
+
+        await act(async () => {
+            await result.current.handlers.postShift();
+        });
+
+        expect(mockPostShift).toHaveBeenCalledWith(1, 20, 2025, 7);
+        expect(mockInvalidateQueries).toHaveBeenCalledWith({
+            queryKey: ['ward', 'duty', 1, 20, 2025, 7],
+        });
+    });
+
+    it('skips postShift when no shift team is selected', async () => {
+        setQueryState({
+            shiftTeams: {data: [], isPending: false, isError: false},
+        });
+
+        const {result} = renderHook(() => useDutyHook());
+
+        await waitFor(() => {
+            expect(result.current.state.currentShiftTeamId).toBeNull();
+        });
+
+        await act(async () => {
+            await result.current.handlers.postShift();
+        });
+
+        expect(mockPostShift).not.toHaveBeenCalled();
+        expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    });
+
+    it('exports the current shift as excel with the selected month', async () => {
+        mockSearchParams = new URLSearchParams('year=2025&month=7&shiftTeamId=20');
+
+        const {result} = renderHook(() => useDutyHook());
+
+        await waitFor(() => {
+            expect(result.current.state.shift).toBe(shift);
+        });
+
+        act(() => {
+            result.current.handlers.exportExcel();
+        });
+
+        expect(mockShiftToExcel).toHaveBeenCalledWith(7, shift);
+    });
+
+    it('skips excel export when there is no shift data', async () => {
+        setQueryState({
+            duty: {data: null, isPending: false, isError: false, refetch: mockRefetch},
+        });
+
+        const {result} = renderHook(() => useDutyHook());
+
+        await waitFor(() => {
+            expect(result.current.state.shift).toBeNull();
+        });
+
+        act(() => {
+            result.current.handlers.exportExcel();
+        });
+
+        expect(mockShiftToExcel).not.toHaveBeenCalled();
+    });
+
+    it('navigates to the current month make page with the selected shift team', async () => {
+        mockSearchParams = new URLSearchParams('year=2025&month=7&shiftTeamId=20');
+
+        const {result} = renderHook(() => useDutyHook());
+
+        await waitFor(() => {
+            expect(result.current.state.currentShiftTeamId).toBe(20);
+        });
+
+        act(() => {
+            result.current.handlers.goCurrentMonthMake();
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith('/make?year=2025&month=7&shiftTeamId=20');
+    });
+
+    it('navigates to the next month make page and rolls the year forward in december', async () => {
+        useDutyStore.setState({
+            year: 2026,
+            month: 12,
+            shiftTeams,
+            currentShiftTeamId: 20,
+        });
+
+        const {result} = renderHook(() => useDutyHook());
+
+        await waitFor(() => {
+            expect(result.current.state.currentShiftTeamId).toBe(20);
+        });
+
+        act(() => {
+            result.current.handlers.goNextMonthMake();
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith('/make?year=2027&month=1&shiftTeamId=20');
     });
 });

--- a/apps/app/src/pages/duty/model/dutyHook.test.tsx
+++ b/apps/app/src/pages/duty/model/dutyHook.test.tsx
@@ -359,6 +359,28 @@ describe('useDutyHook', () => {
         });
     });
 
+    it('does not invalidate the duty query when postShift fails', async () => {
+        mockSearchParams = new URLSearchParams('year=2025&month=7&shiftTeamId=20');
+        mockPostShift.mockRejectedValue(new Error('post failed'));
+
+        const {result} = renderHook(() => useDutyHook());
+
+        await waitFor(() => {
+            expect(result.current.state.currentShiftTeamId).toBe(20);
+        });
+
+        mockInvalidateQueries.mockClear();
+
+        await expect(
+            act(async () => {
+                await result.current.handlers.postShift();
+            }),
+        ).rejects.toThrow('post failed');
+
+        expect(mockPostShift).toHaveBeenCalledWith(1, 20, 2025, 7);
+        expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    });
+
     it('skips postShift when no shift team is selected', async () => {
         setQueryState({
             shiftTeams: {data: [], isPending: false, isError: false},

--- a/apps/app/src/pages/duty/model/dutyHook.ts
+++ b/apps/app/src/pages/duty/model/dutyHook.ts
@@ -15,8 +15,8 @@ import {
 } from '@/features/shift-editor';
 import useLoadingUseCase from '@/features/ui/useLoading';
 import WardAPI from '@/shared/api/ward';
-import ROUTE from '@/shared/constant/path';
 import {useDutyStore} from './dutyStore';
+import {buildMakeShiftPath, getNextYearMonth} from './dutyNavigation';
 
 function parsePositiveInt(raw: string | null): number | null {
     if (!raw) return null;
@@ -201,23 +201,13 @@ export function useDutyHook() {
         setReadonly(true);
     };
     const navigateToMakeShift = (targetYear: number, targetMonth: number) => {
-        const params = new URLSearchParams({
-            year: String(targetYear),
-            month: String(targetMonth),
-        });
-
-        if (currentShiftTeamId !== null) {
-            params.set('shiftTeamId', String(currentShiftTeamId));
-        }
-
-        navigate(`${ROUTE.MAKE}?${params.toString()}`);
+        navigate(buildMakeShiftPath({year: targetYear, month: targetMonth, shiftTeamId: currentShiftTeamId}));
     };
     const handleGoCurrentMonthMake = () => {
         navigateToMakeShift(year, month);
     };
     const handleGoNextMonthMake = () => {
-        const nextMonth = month === 12 ? 1 : month + 1;
-        const nextYear = month === 12 ? year + 1 : year;
+        const {year: nextYear, month: nextMonth} = getNextYearMonth(year, month);
 
         navigateToMakeShift(nextYear, nextMonth);
     };

--- a/apps/app/src/pages/duty/model/dutyNavigation.test.ts
+++ b/apps/app/src/pages/duty/model/dutyNavigation.test.ts
@@ -1,0 +1,16 @@
+import {describe, expect, it} from 'vitest';
+import {buildMakeShiftPath, getNextYearMonth} from './dutyNavigation';
+
+describe('dutyNavigation', () => {
+    it('builds the make page path with the selected shift team', () => {
+        expect(buildMakeShiftPath({year: 2026, month: 3, shiftTeamId: 20})).toBe('/make?year=2026&month=3&shiftTeamId=20');
+    });
+
+    it('omits shiftTeamId when no team is selected', () => {
+        expect(buildMakeShiftPath({year: 2026, month: 3, shiftTeamId: null})).toBe('/make?year=2026&month=3');
+    });
+
+    it('rolls over to january of the next year', () => {
+        expect(getNextYearMonth(2026, 12)).toEqual({year: 2027, month: 1});
+    });
+});

--- a/apps/app/src/pages/duty/model/dutyNavigation.ts
+++ b/apps/app/src/pages/duty/model/dutyNavigation.ts
@@ -1,0 +1,27 @@
+import ROUTE from '@/shared/constant/path';
+
+export function getNextYearMonth(year: number, month: number) {
+    return {
+        year: month === 12 ? year + 1 : year,
+        month: month === 12 ? 1 : month + 1,
+    };
+}
+
+type TBuildMakeShiftPathParams = {
+    year: number;
+    month: number;
+    shiftTeamId: number | null;
+};
+
+export function buildMakeShiftPath({year, month, shiftTeamId}: TBuildMakeShiftPathParams) {
+    const params = new URLSearchParams({
+        year: String(year),
+        month: String(month),
+    });
+
+    if (shiftTeamId !== null) {
+        params.set('shiftTeamId', String(shiftTeamId));
+    }
+
+    return `${ROUTE.MAKE}?${params.toString()}`;
+}


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-904](https://gom3.atlassian.net/browse/DUT-904)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `useDutyHook` 테스트에 저장 실패, `postShift` 성공/실패/가드, excel export 성공/가드, make 화면 이동 핸들러 검증을 추가했습니다.
- make 화면 이동 경로 계산을 `dutyNavigation` helper로 분리해 월 이동과 `shiftTeamId` 포함 여부를 순수 함수로 검증 가능하게 만들었습니다.
- 12월에서 다음 달 이동 시 다음 해 1월로 넘어가는 경계와, 저장 실패 시 편집 상태가 유지되는 회귀 포인트를 고정했습니다.

<br>

## To Reviewers

- 실제 export 포맷이나 API 계약은 건드리지 않았고, 완료 단계의 경계 동작을 테스트로 보강하는 범위에만 맞췄습니다.
- 워크트리에서 의존성 재설치를 피하려고 기존 저장소의 `node_modules` 심볼릭 링크를 사용해 검증했습니다.

<br>

## Follow-up

- excel export의 실제 파일 생성 결과와 시트 포맷은 현재 단위 테스트 범위 밖이라, 필요하면 `shiftToExcel` 단위 테스트나 브라우저 통합 테스트로 별도 보강할 수 있습니다.
- make 화면 이동 이후 페이지 초기화와 쿼리스트링 반영까지는 현재 핸들러/경로 계산까지만 고정되어 있어서, 라우터 통합 테스트가 필요하면 후속 범위로 분리하는 편이 적절합니다.


[DUT-904]: https://gom3.atlassian.net/browse/DUT-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ