### PR TITLE
[DUT-902]: shift-editor validator/constraints 조합 테스트 보강

### DIFF
--- a/apps/app/src/features/shift-editor/model/duty-constraints.test.ts
+++ b/apps/app/src/features/shift-editor/model/duty-constraints.test.ts
@@ -1,0 +1,96 @@
+import {describe, expect, it} from 'vitest';
+import type {TWardConstraint} from '@/entities';
+import {
+    applyBoardToWardConstraint,
+    buildInitialDutyRuleBoard,
+    buildRuleLevelByKeyFromBoard,
+} from './duty-constraints';
+import type {TDutyRuleBoard} from './types';
+
+function createWardConstraint(overrides: Partial<TWardConstraint> = {}): TWardConstraint {
+    return {
+        maxContinuousWork: true,
+        maxContinuousWorkVal: 5,
+        minNightInterval: true,
+        minNightIntervalVal: 3,
+        maxContinuousNight: false,
+        maxContinuousNightVal: 3,
+        minContinuousNight: true,
+        minContinuousNightVal: 2,
+        minOffAssignAfterNight: false,
+        minOffAssignAfterNightVal: 2,
+        excludeCertainWorkTypes: true,
+        excludeNightBeforeReqOff: false,
+        ...overrides,
+    };
+}
+
+describe('duty constraint combinations', () => {
+    it('splits active rules into error, warning, and excluded buckets with level overrides applied', () => {
+        const board = buildInitialDutyRuleBoard(createWardConstraint(), {
+            minNightInterval: 'warning',
+            minContinuousNight: 'error',
+        });
+
+        expect(board).toEqual({
+            error: ['maxContinuousWork', 'minContinuousNight'],
+            warning: ['minNightInterval', 'excludeCertainWorkTypes'],
+            excluded: ['maxContinuousNight', 'minOffAssignAfterNight', 'excludeNightBeforeReqOff'],
+        });
+    });
+
+    it('builds level maps from mixed buckets and lets warning membership override duplicated error entries', () => {
+        const board: TDutyRuleBoard = {
+            error: ['maxContinuousWork', 'minNightInterval'],
+            warning: ['minNightInterval', 'excludeCertainWorkTypes'],
+            excluded: ['maxContinuousNight'],
+        };
+
+        expect(buildRuleLevelByKeyFromBoard(board)).toEqual({
+            maxContinuousWork: 'error',
+            minNightInterval: 'warning',
+            excludeCertainWorkTypes: 'warning',
+        });
+    });
+
+    it('applies enabled buckets back to ward constraints while preserving numeric thresholds', () => {
+        const initial = createWardConstraint({
+            maxContinuousWorkVal: 6,
+            minNightIntervalVal: 4,
+            maxContinuousNightVal: 5,
+            minContinuousNightVal: 3,
+            minOffAssignAfterNightVal: 3,
+        });
+
+        const board: TDutyRuleBoard = {
+            error: ['maxContinuousNight'],
+            warning: ['minOffAssignAfterNight', 'excludeNightBeforeReqOff'],
+            excluded: ['maxContinuousWork', 'minNightInterval', 'minContinuousNight', 'excludeCertainWorkTypes'],
+        };
+
+        expect(applyBoardToWardConstraint(board, initial)).toEqual({
+            ...initial,
+            maxContinuousWork: false,
+            minNightInterval: false,
+            maxContinuousNight: true,
+            minContinuousNight: false,
+            minOffAssignAfterNight: true,
+            excludeCertainWorkTypes: false,
+            excludeNightBeforeReqOff: true,
+        });
+    });
+
+    it('treats error and warning buckets as enabled even when the same rule is also listed in excluded', () => {
+        const board: TDutyRuleBoard = {
+            error: ['maxContinuousWork'],
+            warning: ['excludeCertainWorkTypes'],
+            excluded: ['maxContinuousWork', 'excludeCertainWorkTypes', 'minNightInterval'],
+        };
+
+        expect(applyBoardToWardConstraint(board, createWardConstraint())).toMatchObject({
+            maxContinuousWork: true,
+            excludeCertainWorkTypes: true,
+            minNightInterval: false,
+        });
+    });
+});

--- a/apps/app/src/features/shift-editor/model/validator.test.ts
+++ b/apps/app/src/features/shift-editor/model/validator.test.ts
@@ -79,7 +79,7 @@ describe('validator combinations', () => {
         expect(violations.every((violation) => violation.level === 'warning')).toBe(true);
     });
 
-    it('reports requested-off warnings alongside other warnings without fabricating error violations', () => {
+    it('reports requested-off warnings without leaking unrelated warning rules', () => {
         const {violations} = validate(['N', null, 'D'], {
             wardConstraint: createWardConstraint({
                 excludeNightBeforeReqOff: true,

--- a/apps/app/src/features/shift-editor/model/validator.test.ts
+++ b/apps/app/src/features/shift-editor/model/validator.test.ts
@@ -1,0 +1,164 @@
+import {describe, expect, it} from 'vitest';
+import type {TWardConstraint} from '@/entities';
+import {buildViolationMap, createDutyValidator} from './validator';
+import type {TDutyDoc, TDutyValidationInput} from './types';
+
+function createWardConstraint(overrides: Partial<TWardConstraint> = {}): TWardConstraint {
+    return {
+        maxContinuousWork: false,
+        maxContinuousWorkVal: 5,
+        minNightInterval: false,
+        minNightIntervalVal: 3,
+        maxContinuousNight: false,
+        maxContinuousNightVal: 3,
+        minContinuousNight: false,
+        minContinuousNightVal: 2,
+        minOffAssignAfterNight: false,
+        minOffAssignAfterNightVal: 2,
+        excludeCertainWorkTypes: false,
+        excludeNightBeforeReqOff: false,
+        ...overrides,
+    };
+}
+
+function createDoc(rowCells: Array<string | null>): TDutyDoc {
+    return {
+        columns: rowCells.map((_, index) => `2026-03-${String(index + 1).padStart(2, '0')}`),
+        rows: [{workerId: 'worker-1', cells: rowCells}],
+        workerMeta: {'worker-1': {name: 'Kim'}},
+    };
+}
+
+function validate(rowCells: Array<string | null>, input: Partial<TDutyValidationInput> = {}) {
+    const doc = createDoc(rowCells);
+    const validator = createDutyValidator({
+        wardConstraint: createWardConstraint(),
+        ...input,
+    });
+    const violations = validator(doc);
+
+    return {doc, violations};
+}
+
+describe('validator combinations', () => {
+    it('keeps warning-only combinations non-blocking while reporting every matched warning rule', () => {
+        const {violations} = validate(['N', 'O', 'D'], {
+            wardConstraint: createWardConstraint({
+                minOffAssignAfterNight: true,
+                minOffAssignAfterNightVal: 2,
+                excludeCertainWorkTypes: true,
+            }),
+        });
+
+        expect(
+            violations.map((violation) => ({
+                ruleId: violation.ruleId,
+                level: violation.level,
+                cells: violation.cells,
+            })),
+        ).toEqual([
+            {
+                ruleId: 'duty.minOffAssignAfterNight',
+                level: 'warning',
+                cells: [
+                    {row: 0, col: 0},
+                    {row: 0, col: 1},
+                    {row: 0, col: 2},
+                ],
+            },
+            {
+                ruleId: 'duty.excludeCertainWorkTypes',
+                level: 'warning',
+                cells: [
+                    {row: 0, col: 0},
+                    {row: 0, col: 1},
+                    {row: 0, col: 2},
+                ],
+            },
+        ]);
+        expect(violations.every((violation) => violation.level === 'warning')).toBe(true);
+    });
+
+    it('reports requested-off warnings alongside other warnings without fabricating error violations', () => {
+        const {violations} = validate(['N', null, 'D'], {
+            wardConstraint: createWardConstraint({
+                excludeNightBeforeReqOff: true,
+                minOffAssignAfterNight: true,
+                minOffAssignAfterNightVal: 2,
+            }),
+            mode: {
+                requestedOffByRow: [[false, true, false]],
+            },
+        });
+
+        expect(violations).toEqual([
+            {
+                ruleId: 'duty.excludeNightBeforeReqOff',
+                message: '신청 오프 전날에는 나이트 근무를 권장하지 않습니다.',
+                level: 'warning',
+                cells: [
+                    {row: 0, col: 0},
+                    {row: 0, col: 1},
+                ],
+            },
+        ]);
+    });
+
+    it('preserves blocking violations when error and warning rules overlap on the same cells', () => {
+        const {violations} = validate(['N', 'D', 'E'], {
+            wardConstraint: createWardConstraint({
+                maxContinuousWork: true,
+                maxContinuousWorkVal: 2,
+                minOffAssignAfterNight: true,
+                minOffAssignAfterNightVal: 2,
+                excludeCertainWorkTypes: true,
+            }),
+        });
+
+        expect(violations.map((violation) => violation.ruleId)).toEqual([
+            'duty.maxContinuousWork',
+            'duty.minOffAssignAfterNight',
+            'duty.excludeCertainWorkTypes',
+        ]);
+
+        const map = buildViolationMap(violations, createDoc(['N', 'D', 'E']));
+        expect(map.get('worker-1,0')).toMatchObject({
+            ruleId: 'duty.maxContinuousWork',
+            level: 'error',
+            cells: [
+                {row: 0, col: 0},
+                {row: 0, col: 1},
+                {row: 0, col: 2},
+            ],
+        });
+    });
+
+    it('lets rule-level overrides downgrade blocking rules while keeping other active errors intact', () => {
+        const {doc, violations} = validate(['D', 'N', 'N', 'N'], {
+            wardConstraint: createWardConstraint({
+                maxContinuousWork: true,
+                maxContinuousWorkVal: 3,
+                maxContinuousNight: true,
+                maxContinuousNightVal: 2,
+            }),
+            ruleLevelByKey: {
+                maxContinuousWork: 'warning',
+            },
+        });
+
+        expect(violations.map((violation) => ({ruleId: violation.ruleId, level: violation.level}))).toEqual([
+            {ruleId: 'duty.maxContinuousWork', level: 'warning'},
+            {ruleId: 'duty.maxContinuousNight', level: 'error'},
+        ]);
+
+        const map = buildViolationMap(violations, doc);
+        expect(map.get('worker-1,0')).toMatchObject({
+            ruleId: 'duty.maxContinuousWork',
+            level: 'warning',
+        });
+        expect(map.get('worker-1,1')).toMatchObject({
+            ruleId: 'duty.maxContinuousNight',
+            level: 'error',
+        });
+    });
+});


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-902](https://gom3.atlassian.net/browse/DUT-902)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `validator.test.ts`를 추가해 차단+경고 중첩, warning-only 허용, requested off 경고, rule level override 조합을 고정했습니다.
- `duty-constraints.test.ts`를 추가해 board 초기화, level override, bucket 충돌 시 우선순위, wardConstraint 반영 시 값 보존을 검증했습니다.
- `shift-editor/model` 범위 테스트와 타입체크로 새 조합 테스트가 기존 순수 로직 테스트와 함께 통과하는지 확인했습니다.

<br>

## To Reviewers

- `validator.ts` 정규식 기반 규칙은 시작 셀 기준으로 `buildViolationMap`이 우선순위를 결정하므로, 동일 시작 셀 중첩 케이스를 중심으로 봐주시면 됩니다.
- 아직 경고 메시지 문구 자체나 UI 표시 계층 테스트는 추가하지 않았고, 이번 변경은 순수 로직 조합 회귀 방지에 집중했습니다.

<br>

## Follow-up

- `requestedOffByRow`는 현재 validator 내부에서 대문자 `O` 센티널로만 처리되어 `excludeNightBeforeReqOff` 규칙에만 사실상 영향을 줍니다. 향후 요청 OFF가 다른 경고 규칙과도 함께 작동해야 한다면 normalize 전략을 별도로 정리할 필요가 있습니다.


[DUT-902]: https://gom3.atlassian.net/browse/DUT-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ