### PR TITLE
[DUT-899]: 온보딩 wizard 업로드 상태 전이 테스트 보강

### DIFF
--- a/apps/app/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.test.ts
+++ b/apps/app/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.test.ts
@@ -71,10 +71,7 @@ describe('useOnboardingWardWizard upload flow', () => {
 
         const {result} = renderHook(() => useOnboardingWardWizard());
 
-        await uploadFile(
-            result.current.applyUploadedFile,
-            new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}),
-        );
+        await uploadFile(result.current.applyUploadedFile, new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}));
 
         expect(result.current.uploadStatus).toBe('success');
         expect(result.current.uploadError).toBeNull();
@@ -97,10 +94,7 @@ describe('useOnboardingWardWizard upload flow', () => {
 
         const {result} = renderHook(() => useOnboardingWardWizard());
 
-        await uploadFile(
-            result.current.applyUploadedFile,
-            new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}),
-        );
+        await uploadFile(result.current.applyUploadedFile, new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}));
 
         expect(result.current.uploadStatus).toBe('warning');
         expect(result.current.uploadError).toBeNull();
@@ -118,10 +112,7 @@ describe('useOnboardingWardWizard upload flow', () => {
         const {result} = renderHook(() => useOnboardingWardWizard());
         const initialDraft = result.current.draft;
 
-        await uploadFile(
-            result.current.applyUploadedFile,
-            new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}),
-        );
+        await uploadFile(result.current.applyUploadedFile, new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}));
 
         expect(result.current.uploadStatus).toBe('error');
         expect(result.current.uploadError).toBe('업로드한 파일 형식이 올바르지 않습니다.');

--- a/apps/app/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.test.ts
+++ b/apps/app/src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.test.ts
@@ -1,0 +1,148 @@
+import {act} from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type * as SharedApiModule from '@/shared/api';
+import {renderHook} from '@/shared/util/test-utils';
+import useOnboardingWardWizard from './useOnboardingWardWizard';
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+const mockCreateWard = vi.fn();
+const mockParseOnboardingWardExcel = vi.fn();
+
+vi.mock('react-hot-toast', () => ({
+    default: {
+        success: (...args: unknown[]) => toastSuccess(...args),
+        error: (...args: unknown[]) => toastError(...args),
+    },
+}));
+
+vi.mock('@/features/auth/useRegister', () => ({
+    default: () => ({
+        actions: {
+            createWard: mockCreateWard,
+        },
+    }),
+}));
+
+vi.mock('@/shared/api', async () => {
+    const actual = (await vi.importActual('@/shared/api')) as typeof SharedApiModule;
+
+    return {
+        ...actual,
+        FileAPI: {
+            ...actual.FileAPI,
+            parseOnboardingWardExcel: (...args: unknown[]) => mockParseOnboardingWardExcel(...args),
+        },
+    };
+});
+
+const uploadFile = async (applyUploadedFile: (file: File) => Promise<void>, file: File) => {
+    await act(async () => {
+        await applyUploadedFile(file);
+    });
+};
+
+describe('useOnboardingWardWizard upload flow', () => {
+    beforeEach(() => {
+        mockCreateWard.mockReset();
+        mockParseOnboardingWardExcel.mockReset();
+        toastSuccess.mockReset();
+        toastError.mockReset();
+    });
+
+    it('stores parsed draft data and success feedback when the upload succeeds without warnings', async () => {
+        mockParseOnboardingWardExcel.mockResolvedValue({
+            wardName: '중환자실',
+            hospitalName: '듀팅병원',
+            shiftTypes: [
+                {name: '데이', shortName: 'D'},
+                {name: '오프', shortName: 'O', isOff: true},
+            ],
+            teams: [{name: 'A팀'}],
+            nurses: [
+                {
+                    name: '신규 간호사',
+                    teamName: 'A팀',
+                    possibleShiftShortNames: ['D'],
+                    employmentDate: '2025-01-01',
+                },
+            ],
+        });
+
+        const {result} = renderHook(() => useOnboardingWardWizard());
+
+        await uploadFile(
+            result.current.applyUploadedFile,
+            new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}),
+        );
+
+        expect(result.current.uploadStatus).toBe('success');
+        expect(result.current.uploadError).toBeNull();
+        expect(result.current.uploadWarnings).toEqual([]);
+        expect(result.current.draft.uploadedFileName).toBe('march-duty.xlsx');
+        expect(result.current.draft.wardName).toBe('중환자실');
+        expect(result.current.draft.hospitalName).toBe('듀팅병원');
+        expect(result.current.draft.shiftTypes.map((shiftType) => shiftType.name)).toEqual(['데이', '오프']);
+        expect(result.current.draft.teams.map((team) => team.name)).toEqual(['A팀']);
+        expect(result.current.draft.nurses.map((nurse) => nurse.name)).toEqual(['신규 간호사']);
+        expect(toastSuccess).toHaveBeenCalledWith('엑셀 데이터를 불러왔어요.');
+        expect(toastError).not.toHaveBeenCalled();
+    });
+
+    it('stores partial draft data and warning feedback when the upload succeeds with warnings', async () => {
+        mockParseOnboardingWardExcel.mockResolvedValue({
+            nurses: [{name: '신규 간호사', teamName: 'A팀'}],
+            warnings: ['2행 데이터를 해석하지 못했어요.'],
+        });
+
+        const {result} = renderHook(() => useOnboardingWardWizard());
+
+        await uploadFile(
+            result.current.applyUploadedFile,
+            new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}),
+        );
+
+        expect(result.current.uploadStatus).toBe('warning');
+        expect(result.current.uploadError).toBeNull();
+        expect(result.current.uploadWarnings).toEqual(['2행 데이터를 해석하지 못했어요.']);
+        expect(result.current.draft.uploadedFileName).toBe('march-duty.xlsx');
+        expect(result.current.draft.teams.map((team) => team.name)).toEqual(['A팀']);
+        expect(result.current.draft.nurses.map((nurse) => nurse.name)).toEqual(['신규 간호사']);
+        expect(toastError).toHaveBeenCalledWith('일부 데이터만 반영했어요. 누락된 항목을 확인해 주세요.');
+        expect(toastSuccess).not.toHaveBeenCalled();
+    });
+
+    it('preserves the draft and stores failure feedback when the parse request fails', async () => {
+        mockParseOnboardingWardExcel.mockRejectedValue(new Error('업로드한 파일 형식이 올바르지 않습니다.'));
+
+        const {result} = renderHook(() => useOnboardingWardWizard());
+        const initialDraft = result.current.draft;
+
+        await uploadFile(
+            result.current.applyUploadedFile,
+            new File(['mock'], 'march-duty.xlsx', {type: 'application/vnd.ms-excel'}),
+        );
+
+        expect(result.current.uploadStatus).toBe('error');
+        expect(result.current.uploadError).toBe('업로드한 파일 형식이 올바르지 않습니다.');
+        expect(result.current.uploadWarnings).toEqual([]);
+        expect(result.current.draft).toEqual(initialDraft);
+        expect(toastError).toHaveBeenCalledWith('업로드한 파일 형식이 올바르지 않습니다.');
+        expect(toastSuccess).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits with the unsupported file message before calling the parse api', async () => {
+        const {result} = renderHook(() => useOnboardingWardWizard());
+        const initialDraft = result.current.draft;
+
+        await uploadFile(result.current.applyUploadedFile, new File(['mock'], 'march-duty.txt', {type: 'text/plain'}));
+
+        expect(mockParseOnboardingWardExcel).not.toHaveBeenCalled();
+        expect(result.current.uploadStatus).toBe('error');
+        expect(result.current.uploadError).toBe('엑셀 파일(.xlsx, .xls, .csv)만 업로드할 수 있어요.');
+        expect(result.current.uploadWarnings).toEqual([]);
+        expect(result.current.draft).toEqual(initialDraft);
+        expect(toastError).toHaveBeenCalledWith('엑셀 파일(.xlsx, .xls, .csv)만 업로드할 수 있어요.');
+        expect(toastSuccess).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-899](https://gom3.atlassian.net/browse/DUT-899)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `useOnboardingWardWizard` 훅 전용 테스트를 추가해 업로드 성공 시 draft 반영과 success toast 호출을 고정했습니다.
- 업로드 warning 포함 성공 시 partial draft 반영, warning 상태, warning toast 메시지 경계를 검증했습니다.
- 업로드 실패와 지원하지 않는 파일 형식 경로에서 draft 보존, error 상태, error toast 호출을 검증했습니다.

<br>

## To Reviewers

- 기존 페이지 통합 테스트는 유지하고, 회귀 위험이 높은 업로드 결과 해석 경계만 훅 테스트로 직접 고정했습니다.
- 새 worktree에서 의존성 링크를 잡아 검증했고, 커밋에는 추적 파일 변경만 포함했습니다.
- 실행 검증: `pnpm --dir apps/app test:run -- src/pages/OnboardingWardCreatePage/hooks/useOnboardingWardWizard.test.ts src/pages/OnboardingWardCreatePage/index.test.tsx`, `pnpm --dir apps/app type-check`

[DUT-899]: https://gom3.atlassian.net/browse/DUT-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ