### PR TITLE
[DUT-903]: duty와 shift-editor 통합 경계 테스트 보강

### DIFF
--- a/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
+++ b/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@tanstack/react-query', async () => {
     const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
     const disabledQueryState = {
         data: undefined,
-        isPending: false,
+        isPending: true,
         isError: false,
         refetch: mockRefetch,
     };

--- a/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
+++ b/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
@@ -1,0 +1,322 @@
+import {act} from 'react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@/shared/util/test-utils';
+import {useShiftEditorCommands, useShiftEditorStore, type TDutyDoc} from '@/features/shift-editor';
+import {useDutyHook} from './dutyHook';
+import {useDutyStore} from './dutyStore';
+
+const SHIFT_EDITOR_STORAGE_KEY = 'shift-editor:draft';
+
+const {mockNavigate, mockInvalidateQueries, mockSetLoading, mockUpdateShifts, mockPostShift, mockRefetch} = vi.hoisted(() => ({
+    mockNavigate: vi.fn(),
+    mockInvalidateQueries: vi.fn(),
+    mockSetLoading: vi.fn(),
+    mockUpdateShifts: vi.fn(),
+    mockPostShift: vi.fn(),
+    mockRefetch: vi.fn(),
+}));
+
+let mockSearchParams = new URLSearchParams();
+let mockQueries: Record<string, any> = {};
+
+vi.mock('@tanstack/react-query', async () => {
+    const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+    const disabledQueryState = {
+        data: undefined,
+        isPending: false,
+        isError: false,
+        refetch: mockRefetch,
+    };
+
+    return {
+        ...actual,
+        useQuery: vi.fn((options: {queryKey: unknown[]; enabled?: boolean}) => {
+            if (options.enabled === false) return disabledQueryState;
+
+            return mockQueries[String(options.queryKey[1])] ?? disabledQueryState;
+        }),
+        useQueryClient: vi.fn(() => ({invalidateQueries: mockInvalidateQueries})),
+    };
+});
+
+vi.mock('react-router', () => ({
+    useNavigate: () => mockNavigate,
+    useSearchParams: () => [mockSearchParams, vi.fn()],
+}));
+
+vi.mock('@/features/auth/useAuth', () => ({
+    default: () => ({
+        state: {
+            wardId: 1,
+        },
+    }),
+}));
+
+vi.mock('@/features/ui/useLoading', () => ({
+    default: () => ({
+        setLoading: mockSetLoading,
+    }),
+}));
+
+vi.mock('@/shared/api/ward', () => ({
+    default: {
+        updateShifts: mockUpdateShifts,
+        postShift: mockPostShift,
+    },
+}));
+
+const shiftTeams = [
+    {shiftTeamId: 10, name: 'A팀'},
+    {shiftTeamId: 20, name: 'B팀'},
+];
+
+const shift = {
+    lastDays: [],
+    days: [
+        {day: 1, dayType: 'workday'},
+        {day: 2, dayType: 'holiday'},
+    ],
+    wardShiftTypes: [
+        {
+            wardShiftTypeId: 1,
+            name: 'Day',
+            shortName: 'D',
+            startTime: '07:00',
+            endTime: '15:00',
+            color: '#fff',
+            isDefault: true,
+            isOff: false,
+            isCounted: true,
+            classification: 'DAY',
+        },
+    ],
+    divisionShiftNurses: [
+        [
+            {
+                shiftNurse: {
+                    shiftNurseId: 1,
+                    name: 'Kim',
+                    carried: 0,
+                    divisionNum: 0,
+                    priority: 0,
+                    isWorker: true,
+                    nurseId: 100,
+                },
+                lastWardShiftList: [],
+                lastWardReqShiftList: [],
+                wardShiftList: [1, null],
+                wardReqShiftList: [],
+            },
+        ],
+    ],
+};
+
+const initializedDoc: TDutyDoc = {
+    columns: ['2025-07-01', '2025-07-02'],
+    rows: [{workerId: '1', cells: ['D', null]}],
+    workerMeta: {'1': {name: 'Kim'}},
+};
+
+function resetDutyStore() {
+    useDutyStore.setState({
+        year: 2026,
+        month: 3,
+        shiftTeams: [],
+        currentShiftTeamId: null,
+        readonly: true,
+        shift: null,
+        status: 'idle',
+    });
+}
+
+function setQueryState(overrides?: Partial<typeof mockQueries>) {
+    mockQueries = {
+        shiftTeams: {data: shiftTeams, isPending: false, isError: false},
+        duty: {data: shift, isPending: false, isError: false, refetch: mockRefetch},
+        constraint: {data: null, isPending: false, isError: false},
+        ...overrides,
+    };
+}
+
+function seedPersistedDraft(doc: TDutyDoc, history = {past: [{id: 'stale'}], future: [], maxDepth: 200}) {
+    window.localStorage.setItem(
+        SHIFT_EDITOR_STORAGE_KEY,
+        JSON.stringify({
+            doc,
+            history: JSON.stringify(history),
+            savedAt: 123,
+        }),
+    );
+}
+
+function readPersistedDraft() {
+    const raw = window.localStorage.getItem(SHIFT_EDITOR_STORAGE_KEY);
+
+    return raw ? JSON.parse(raw) : null;
+}
+
+function advancePersistenceDebounce() {
+    act(() => {
+        vi.advanceTimersByTime(450);
+    });
+}
+
+async function flushHookEffects(cycles = 3) {
+    for (let i = 0; i < cycles; i += 1) {
+        await act(async () => {
+            await Promise.resolve();
+        });
+    }
+}
+
+type TDutyHookRender = {
+    result: {
+        current: ReturnType<typeof useDutyHook>;
+    };
+};
+
+type TEditorCommandsRender = {
+    result: {
+        current: ReturnType<typeof useShiftEditorCommands>;
+    };
+};
+
+describe('useDutyHook integration', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        window.localStorage.clear();
+        resetDutyStore();
+        useShiftEditorStore.getState().reset();
+        mockSearchParams = new URLSearchParams('year=2025&month=7&shiftTeamId=20');
+        setQueryState();
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+        window.localStorage.clear();
+        resetDutyStore();
+        useShiftEditorStore.getState().reset();
+    });
+
+    it('initializes the editor store from fetched duty data and discards any stale persisted draft', async () => {
+        seedPersistedDraft({
+            columns: ['stale'],
+            rows: [{workerId: '99', cells: ['N']}],
+            workerMeta: {'99': {name: 'Stale'}},
+        });
+
+        let duty!: TDutyHookRender;
+
+        await act(async () => {
+            duty = renderHook(() => useDutyHook());
+        });
+        await flushHookEffects();
+
+        expect(duty.result.current.state.status).toBe('success');
+        expect(duty.result.current.state.doc).toEqual(initializedDoc);
+        expect(useShiftEditorStore.getState().doc).toEqual(initializedDoc);
+        expect(window.localStorage.getItem(SHIFT_EDITOR_STORAGE_KEY)).toBeNull();
+
+        advancePersistenceDebounce();
+
+        expect(readPersistedDraft()).toBeNull();
+    });
+
+    it('restores the pre-edit snapshot into the real editor store and clears the persisted draft on cancel', async () => {
+        let duty!: TDutyHookRender;
+        let editor!: TEditorCommandsRender;
+
+        await act(async () => {
+            duty = renderHook(() => useDutyHook());
+            editor = renderHook(() => useShiftEditorCommands());
+        });
+        await flushHookEffects();
+
+        expect(duty.result.current.state.doc).toEqual(initializedDoc);
+
+        act(() => {
+            duty.result.current.handlers.enableEdit();
+            useShiftEditorStore.getState().setSelection({type: 'single', anchor: {row: 0, col: 1}});
+            editor.result.current.setSelectionValue('D');
+        });
+
+        advancePersistenceDebounce();
+
+        expect(useShiftEditorStore.getState().doc.rows[0]?.cells).toEqual(['D', 'D']);
+        expect(readPersistedDraft()?.doc.rows[0]?.cells).toEqual(['D', 'D']);
+
+        act(() => {
+            duty.result.current.handlers.cancelEdit();
+        });
+
+        expect(useShiftEditorStore.getState().doc).toEqual(initializedDoc);
+        expect(window.localStorage.getItem(SHIFT_EDITOR_STORAGE_KEY)).toBeNull();
+        expect(useDutyStore.getState().readonly).toBe(true);
+    });
+
+    it('saves the latest editor store state through the ward api and removes the draft after save', async () => {
+        mockUpdateShifts.mockResolvedValue(undefined);
+
+        let duty!: TDutyHookRender;
+        let editor!: TEditorCommandsRender;
+
+        await act(async () => {
+            duty = renderHook(() => useDutyHook());
+            editor = renderHook(() => useShiftEditorCommands());
+        });
+        await flushHookEffects();
+
+        expect(duty.result.current.state.currentShiftTeamId).toBe(20);
+
+        act(() => {
+            duty.result.current.handlers.enableEdit();
+            useShiftEditorStore.getState().setSelection({type: 'single', anchor: {row: 0, col: 1}});
+            editor.result.current.setSelectionValue('D');
+        });
+
+        advancePersistenceDebounce();
+
+        expect(readPersistedDraft()?.doc.rows[0]?.cells).toEqual(['D', 'D']);
+
+        await act(async () => {
+            await duty.result.current.handlers.saveEdit();
+        });
+
+        expect(mockUpdateShifts).toHaveBeenCalledWith(1, [
+            {shiftNurseId: 1, date: '2025-07-01', wardShiftTypeId: 1},
+            {shiftNurseId: 1, date: '2025-07-02', wardShiftTypeId: 1},
+        ]);
+        expect(mockInvalidateQueries).toHaveBeenCalledWith({
+            queryKey: ['ward', 'duty', 1, 20, 2025, 7],
+        });
+        expect(window.localStorage.getItem(SHIFT_EDITOR_STORAGE_KEY)).toBeNull();
+        expect(useDutyStore.getState().readonly).toBe(true);
+        expect(mockSetLoading).toHaveBeenNthCalledWith(1, true);
+        expect(mockSetLoading).toHaveBeenLastCalledWith(false);
+    });
+
+    it('resets the editor store to empty and drops persisted drafts when the duty query fails', async () => {
+        seedPersistedDraft({
+            columns: ['2025-07-01'],
+            rows: [{workerId: '1', cells: ['D']}],
+            workerMeta: {'1': {name: 'Kim'}},
+        });
+        setQueryState({
+            duty: {data: undefined, isPending: false, isError: true, refetch: mockRefetch},
+        });
+
+        let duty!: TDutyHookRender;
+
+        await act(async () => {
+            duty = renderHook(() => useDutyHook());
+        });
+        await flushHookEffects();
+
+        expect(duty.result.current.state.status).toBe('error');
+        expect(duty.result.current.state.doc).toEqual({columns: [], rows: [], workerMeta: {}});
+        expect(useShiftEditorStore.getState().doc).toEqual({columns: [], rows: [], workerMeta: {}});
+        expect(window.localStorage.getItem(SHIFT_EDITOR_STORAGE_KEY)).toBeNull();
+    });
+});

--- a/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
+++ b/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
@@ -19,6 +19,18 @@ const {mockNavigate, mockInvalidateQueries, mockSetLoading, mockUpdateShifts, mo
 let mockSearchParams = new URLSearchParams();
 let mockQueries: Record<string, any> = {};
 
+vi.mock('@/features/shift-editor', async () => {
+    const actual = await vi.importActual<typeof import('@/features/shift-editor')>('@/features/shift-editor');
+
+    return {
+        ...actual,
+        useShiftEditorKeyBindings: () => ({
+            onKeyDown: vi.fn(),
+            onPaste: vi.fn(),
+        }),
+    };
+});
+
 vi.mock('@tanstack/react-query', async () => {
     const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
     const disabledQueryState = {


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-903](https://gom3.atlassian.net/browse/DUT-903)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `useDutyHook`와 실제 `shift-editor` store/persistence를 함께 검증하는 통합 테스트를 추가했습니다.
- 초기화 시 stale draft 제거, 편집 취소 시 snapshot 복원, 저장 시 최신 store 상태 반영, 조회 실패 시 editor reset 경계를 검증했습니다.
- 통합 테스트에서는 keybinding 훅을 분리해 도메인 경계 검증 범위를 더 선명하게 유지했습니다.

<br>

## To Reviewers

- 새 테스트는 `react-query`를 mock하고 실제 `shift-editor` commands/store/localStorage를 연결합니다.
- `vitest run -- src/pages/duty/model/dutyHook.integration.test.tsx`가 현재 설정상 앱 테스트 스위트 전체를 함께 실행합니다.
- 타입 체크와 테스트는 모두 통과했습니다.

<br>

## Follow-up

- `useDutyHook` 통합 테스트 실행 시 React `act(...)` 경고 로그가 일부 남아 있습니다. 동작 실패는 아니지만, 테스트 드라이버와 비동기 flush 방식을 더 정리하면 로그 품질을 개선할 수 있습니다.
- Vitest 파일 필터링이 기대보다 넓게 동작해 대상 파일만 좁게 실행되지 않는 설정도 별도로 점검할 가치가 있습니다.


[DUT-903]: https://gom3.atlassian.net/browse/DUT-903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ