### PR TITLE
[DUT-901]: controller 상호작용 및 실패 분기 테스트 보강

### DIFF
--- a/apps/app/src/features/ward/useEditShiftTeam/index.test.tsx
+++ b/apps/app/src/features/ward/useEditShiftTeam/index.test.tsx
@@ -1,0 +1,153 @@
+import {act} from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@/shared/util/test-utils';
+import useEditNurseStore from './store';
+import useEditShiftTeam from '.';
+
+const ward = {
+    shiftTeams: [
+        {
+            shiftTeamId: 10,
+            name: 'A팀',
+            nurses: [{nurseId: 11, name: '김하나', divisionNum: 1, priority: 1000}],
+        },
+    ],
+} as any;
+
+const {
+    mockInvalidateQueries,
+    mockCancelQueries,
+    mockGetQueryData,
+    mockSetQueryData,
+    mockUpdateNurse,
+    mockAddNurseIntoShiftTeam,
+    mockRemoveNurseFromShiftTeam,
+    mockToastSuccess,
+    mockToastError,
+} = vi.hoisted(() => ({
+    mockInvalidateQueries: vi.fn(),
+    mockCancelQueries: vi.fn(),
+    mockGetQueryData: vi.fn(),
+    mockSetQueryData: vi.fn(),
+    mockUpdateNurse: vi.fn(),
+    mockAddNurseIntoShiftTeam: vi.fn(),
+    mockRemoveNurseFromShiftTeam: vi.fn(),
+    mockToastSuccess: vi.fn(),
+    mockToastError: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+    const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+
+    return {
+        ...actual,
+        useQuery: vi.fn(() => ({data: ward})),
+        useQueryClient: vi.fn(() => ({
+            invalidateQueries: mockInvalidateQueries,
+            cancelQueries: mockCancelQueries,
+            getQueryData: mockGetQueryData,
+            setQueryData: mockSetQueryData,
+        })),
+    };
+});
+
+vi.mock('@/features/auth/useAuth', () => ({
+    default: () => ({
+        state: {
+            wardId: 1,
+        },
+    }),
+}));
+
+vi.mock('@/features/shift/useRequestShift', () => ({
+    default: () => ({
+        queryKey: {
+            requestShiftQueryKey: ['ward', 'requestShift'],
+        },
+    }),
+}));
+
+vi.mock('@/shared/api', () => ({
+    NurseAPI: {
+        updateNurse: mockUpdateNurse,
+    },
+    WardAPI: {
+        addNurseIntoShiftTeam: mockAddNurseIntoShiftTeam,
+        removeNurseFromShiftTeam: mockRemoveNurseFromShiftTeam,
+    },
+}));
+
+vi.mock('react-hot-toast', () => ({
+    default: {
+        success: mockToastSuccess,
+        error: mockToastError,
+    },
+}));
+
+describe('useEditShiftTeam', () => {
+    beforeEach(() => {
+        useEditNurseStore.getState().reset();
+        mockInvalidateQueries.mockReset();
+        mockCancelQueries.mockReset();
+        mockGetQueryData.mockReset();
+        mockSetQueryData.mockReset();
+        mockUpdateNurse.mockReset();
+        mockAddNurseIntoShiftTeam.mockReset();
+        mockRemoveNurseFromShiftTeam.mockReset();
+        mockToastSuccess.mockReset();
+        mockToastError.mockReset();
+    });
+
+    it('keeps the draft dirty and exposes an error save status when updateNurse fails with an unknown error shape', async () => {
+        useEditNurseStore.getState().patch({
+            selectedNurseId: 11,
+            selectedNurseDrawerMode: 'create',
+            isNurseDraftDirty: true,
+        });
+        mockUpdateNurse.mockRejectedValue({response: {status: 500}});
+        const {result} = renderHook(() => useEditShiftTeam());
+        let isSuccess: boolean | undefined;
+
+        await act(async () => {
+            isSuccess = await result.current.actions.updateNurse(11, {name: '김하나'} as any);
+        });
+
+        expect(isSuccess).toBe(false);
+        expect(result.current.state.nurseSaveStatus).toBe('error');
+        expect(result.current.state.isNurseDraftDirty).toBe(true);
+        expect(result.current.state.selectedNurseDrawerMode).toBe('create');
+        expect(mockToastError).toHaveBeenCalledWith('간호사 정보 수정에 실패했습니다.');
+        expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    });
+
+    it('resets the adding flag after addNurse fails', async () => {
+        mockAddNurseIntoShiftTeam.mockRejectedValue(new Error('network'));
+        const {result} = renderHook(() => useEditShiftTeam());
+
+        await act(async () => {
+            await result.current.actions.addNurse(10);
+        });
+
+        expect(result.current.state.isAddingNurse).toBe(false);
+        expect(result.current.state.selectedNurse).toBeUndefined();
+        expect(mockToastError).toHaveBeenCalledWith('간호사 추가에 실패했습니다.');
+        expect(mockToastSuccess).not.toHaveBeenCalled();
+    });
+
+    it('resets the deleting flag and preserves the current selection after deleteNurse fails', async () => {
+        useEditNurseStore.getState().patch({
+            selectedNurseId: 11,
+        });
+        mockRemoveNurseFromShiftTeam.mockRejectedValue({message: 'server error'});
+        const {result} = renderHook(() => useEditShiftTeam());
+
+        await act(async () => {
+            await result.current.actions.deleteNurse(10, 11);
+        });
+
+        expect(result.current.state.isDeletingNurse).toBe(false);
+        expect(result.current.state.selectedNurse?.nurseId).toBe(11);
+        expect(mockToastError).toHaveBeenCalledWith('간호사 삭제에 실패했습니다.');
+        expect(mockToastSuccess).not.toHaveBeenCalled();
+    });
+});

--- a/apps/app/src/features/ward/useEditWard/index.test.tsx
+++ b/apps/app/src/features/ward/useEditWard/index.test.tsx
@@ -1,0 +1,111 @@
+import {act} from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {wardQueryKeys} from '@/entities/ward/model/queries';
+import {renderHook} from '@/shared/util/test-utils';
+import useEditWard from '.';
+
+const {
+    mockInvalidateQueries,
+    mockApproveWaitingNurses,
+    mockConnectWaitingNurses,
+    mockToastSuccess,
+    mockToastError,
+} = vi.hoisted(() => ({
+    mockInvalidateQueries: vi.fn(),
+    mockApproveWaitingNurses: vi.fn(),
+    mockConnectWaitingNurses: vi.fn(),
+    mockToastSuccess: vi.fn(),
+    mockToastError: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+    const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+
+    return {
+        ...actual,
+        useQuery: vi.fn(() => ({data: undefined})),
+        useQueryClient: vi.fn(() => ({
+            invalidateQueries: mockInvalidateQueries,
+        })),
+    };
+});
+
+vi.mock('@/features/auth/useAuth', () => ({
+    default: () => ({
+        state: {
+            wardId: 1,
+        },
+    }),
+}));
+
+vi.mock('@/shared/api', () => ({
+    WardAPI: {
+        approveWaitingNurses: mockApproveWaitingNurses,
+        connectWaitingNurses: mockConnectWaitingNurses,
+    },
+}));
+
+vi.mock('react-hot-toast', () => ({
+    default: {
+        success: mockToastSuccess,
+        error: mockToastError,
+    },
+}));
+
+describe('useEditWard', () => {
+    beforeEach(() => {
+        mockInvalidateQueries.mockReset();
+        mockApproveWaitingNurses.mockReset();
+        mockConnectWaitingNurses.mockReset();
+        mockToastSuccess.mockReset();
+        mockToastError.mockReset();
+    });
+
+    it('returns true and invalidates ward queries after approving a waiting nurse', async () => {
+        mockApproveWaitingNurses.mockResolvedValue(undefined);
+        const {result} = renderHook(() => useEditWard());
+        let isSuccess: boolean | undefined;
+
+        await act(async () => {
+            isSuccess = await result.current.actions.approveWaitingNurses(7, 20);
+        });
+
+        expect(isSuccess).toBe(true);
+        expect(mockApproveWaitingNurses).toHaveBeenCalledWith(1, 7, 20);
+        expect(mockInvalidateQueries).toHaveBeenNthCalledWith(1, {queryKey: wardQueryKeys.id(1)});
+        expect(mockInvalidateQueries).toHaveBeenNthCalledWith(2, {queryKey: wardQueryKeys.waitingNurses(1)});
+        expect(mockToastSuccess).toHaveBeenCalledWith('선택한 팀에 간호사를 추가했어요.');
+        expect(mockToastError).not.toHaveBeenCalled();
+    });
+
+    it('returns false without showing an error toast when approveWaitingNurses rejects with a handled API code', async () => {
+        mockApproveWaitingNurses.mockRejectedValue({code: 400});
+        const {result} = renderHook(() => useEditWard());
+        let isSuccess: boolean | undefined;
+
+        await act(async () => {
+            isSuccess = await result.current.actions.approveWaitingNurses(7, 20);
+        });
+
+        expect(isSuccess).toBe(false);
+        expect(mockInvalidateQueries).not.toHaveBeenCalled();
+        expect(mockToastSuccess).not.toHaveBeenCalled();
+        expect(mockToastError).not.toHaveBeenCalled();
+    });
+
+    it('returns false and surfaces a generic feedback toast when connectWaitingNurses rejects with an unknown error shape', async () => {
+        mockConnectWaitingNurses.mockRejectedValue({response: {status: 500}});
+        const {result} = renderHook(() => useEditWard());
+        let isSuccess: boolean | undefined;
+
+        await act(async () => {
+            isSuccess = await result.current.actions.connectWaitingNurses(7, 99);
+        });
+
+        expect(isSuccess).toBe(false);
+        expect(mockConnectWaitingNurses).toHaveBeenCalledWith(1, 7, 99);
+        expect(mockInvalidateQueries).not.toHaveBeenCalled();
+        expect(mockToastSuccess).not.toHaveBeenCalled();
+        expect(mockToastError).toHaveBeenCalledWith('기존 간호사 계정 연결에 실패했습니다.');
+    });
+});

--- a/apps/app/src/pages/MemberPage/model/useConnectionManageController.test.tsx
+++ b/apps/app/src/pages/MemberPage/model/useConnectionManageController.test.tsx
@@ -1,6 +1,6 @@
 import {act} from 'react';
 import {describe, expect, it, vi} from 'vitest';
-import {renderHook} from '@/shared/util/test-utils';
+import {renderHook, waitFor} from '@/shared/util/test-utils';
 import useConnectionManageController from './useConnectionManageController';
 
 const waitingNurse = {
@@ -238,6 +238,9 @@ describe('useConnectionManageController', () => {
 
         expect(connectWaitingNurses).toHaveBeenNthCalledWith(1, 1, 99);
         expect(connectWaitingNurses).toHaveBeenNthCalledWith(2, 1, 99);
-        expect(result.current.state.submitStatus).toBe('success');
+
+        await waitFor(() => {
+            expect(result.current.state.submitStatus).toBe('success');
+        });
     });
 });

--- a/apps/app/src/pages/MemberPage/model/useConnectionManageController.test.tsx
+++ b/apps/app/src/pages/MemberPage/model/useConnectionManageController.test.tsx
@@ -184,4 +184,60 @@ describe('useConnectionManageController', () => {
         expect(result.current.state.step).toBe(0);
         expect(result.current.state.submitStatus).toBe('idle');
     });
+
+    it('stores an error result when connectWaitingNurses resolves false in link mode', async () => {
+        const connectWaitingNurses = vi.fn().mockResolvedValue(false);
+        const approveWaitingNurses = vi.fn();
+        const {result} = renderHook(() =>
+            useConnectionManageController({
+                open: true,
+                approveWaitingNurses,
+                connectWaitingNurses,
+            }),
+        );
+
+        act(() => {
+            result.current.actions.handleSelectWaitingNurse(waitingNurse);
+            result.current.actions.setToLinkNurseId(99);
+        });
+
+        await act(async () => {
+            await result.current.actions.handleCompleteSelection();
+        });
+
+        expect(connectWaitingNurses).toHaveBeenCalledWith(1, 99);
+        expect(approveWaitingNurses).not.toHaveBeenCalled();
+        expect(result.current.state.step).toBe(3);
+        expect(result.current.state.submitStatus).toBe('error');
+    });
+
+    it('retries the current selection after a failed submit and stores the later success result', async () => {
+        const connectWaitingNurses = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+        const {result} = renderHook(() =>
+            useConnectionManageController({
+                open: true,
+                approveWaitingNurses: vi.fn(),
+                connectWaitingNurses,
+            }),
+        );
+
+        act(() => {
+            result.current.actions.handleSelectWaitingNurse(waitingNurse);
+            result.current.actions.setToLinkNurseId(99);
+        });
+
+        await act(async () => {
+            await result.current.actions.handleCompleteSelection();
+        });
+
+        expect(result.current.state.submitStatus).toBe('error');
+
+        await act(async () => {
+            result.current.actions.retryCompleteSelection();
+        });
+
+        expect(connectWaitingNurses).toHaveBeenNthCalledWith(1, 1, 99);
+        expect(connectWaitingNurses).toHaveBeenNthCalledWith(2, 1, 99);
+        expect(result.current.state.submitStatus).toBe('success');
+    });
 });

--- a/apps/app/src/pages/MemberPage/model/useShiftTeamListControllerHook.test.tsx
+++ b/apps/app/src/pages/MemberPage/model/useShiftTeamListControllerHook.test.tsx
@@ -1,0 +1,185 @@
+import {act} from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@/shared/util/test-utils';
+import useShiftTeamListController from './useShiftTeamListControllerHook';
+
+const {mockSendEvent, outsideHandlers} = vi.hoisted(() => ({
+    mockSendEvent: vi.fn(),
+    outsideHandlers: [] as Array<() => void>,
+}));
+
+vi.mock('@/analytics', () => ({
+    events: {
+        memberPage: {
+            moveNurseFocus: 'memberPage.moveNurseFocus',
+            moveNurse: 'memberPage.moveNurse',
+        },
+    },
+    sendEvent: mockSendEvent,
+}));
+
+vi.mock('react-cool-onclickoutside', () => ({
+    default: (handler: () => void) => {
+        outsideHandlers.push(handler);
+
+        return vi.fn();
+    },
+}));
+
+const shiftTeams = [
+    {
+        shiftTeamId: 10,
+        name: 'A팀',
+        nurses: [
+            {nurseId: 1, name: '김하나', divisionNum: 1, priority: 1000},
+            {nurseId: 2, name: '김둘', divisionNum: 2, priority: 1000},
+        ],
+    },
+    {
+        shiftTeamId: 20,
+        name: 'B팀',
+        nurses: [{nurseId: 3, name: '박셋', divisionNum: 1, priority: 1000}],
+    },
+] as any;
+
+describe('useShiftTeamListController', () => {
+    beforeEach(() => {
+        outsideHandlers.length = 0;
+        mockSendEvent.mockReset();
+    });
+
+    it('moves focus to the first nurse in the next team when ArrowDown is pressed at the end of a team', () => {
+        const selectNurse = vi.fn();
+        const {unmount} = renderHook(() =>
+            useShiftTeamListController({
+                shiftTeams,
+                selectedNurse: shiftTeams[0].nurses[1],
+                selectNurse,
+                moveNurseOrder: vi.fn(),
+                updateShiftTeam: vi.fn(),
+            }),
+        );
+        const event = new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: true});
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+        document.dispatchEvent(event);
+
+        expect(selectNurse).toHaveBeenCalledWith(3);
+        expect(preventDefaultSpy).toHaveBeenCalledOnce();
+        expect(mockSendEvent).toHaveBeenCalledWith('memberPage.moveNurseFocus');
+
+        unmount();
+    });
+
+    it('moves focus to the last nurse in the previous team when ArrowUp is pressed at the start of a team', () => {
+        const selectNurse = vi.fn();
+        const {unmount} = renderHook(() =>
+            useShiftTeamListController({
+                shiftTeams,
+                selectedNurse: shiftTeams[1].nurses[0],
+                selectNurse,
+                moveNurseOrder: vi.fn(),
+                updateShiftTeam: vi.fn(),
+            }),
+        );
+
+        document.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp', bubbles: true}));
+
+        expect(selectNurse).toHaveBeenCalledWith(2);
+        expect(mockSendEvent).toHaveBeenCalledWith('memberPage.moveNurseFocus');
+
+        unmount();
+    });
+
+    it('ignores keyboard focus movement while the event target is an editable input', () => {
+        const selectNurse = vi.fn();
+        const {unmount} = renderHook(() =>
+            useShiftTeamListController({
+                shiftTeams,
+                selectedNurse: shiftTeams[0].nurses[0],
+                selectNurse,
+                moveNurseOrder: vi.fn(),
+                updateShiftTeam: vi.fn(),
+            }),
+        );
+        const input = document.createElement('input');
+
+        document.body.append(input);
+        input.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: true}));
+
+        expect(selectNurse).not.toHaveBeenCalled();
+        expect(mockSendEvent).not.toHaveBeenCalled();
+
+        input.remove();
+        unmount();
+    });
+
+    it('clears the selected nurse when the list click-away handler runs', () => {
+        const selectNurse = vi.fn();
+
+        renderHook(() =>
+            useShiftTeamListController({
+                shiftTeams,
+                selectedNurse: shiftTeams[0].nurses[0],
+                selectNurse,
+                moveNurseOrder: vi.fn(),
+                updateShiftTeam: vi.fn(),
+            }),
+        );
+
+        act(() => {
+            outsideHandlers[0]?.();
+        });
+
+        expect(selectNurse).toHaveBeenCalledWith(null);
+    });
+
+    it('closes the open shift team menu when the menu click-away handler runs', () => {
+        const {result} = renderHook(() =>
+            useShiftTeamListController({
+                shiftTeams,
+                selectedNurse: shiftTeams[0].nurses[0],
+                selectNurse: vi.fn(),
+                moveNurseOrder: vi.fn(),
+                updateShiftTeam: vi.fn(),
+            }),
+        );
+
+        act(() => {
+            result.current.actions.setOpenMenuShiftTeamId(10);
+        });
+
+        expect(result.current.state.openMenuShiftTeamId).toBe(10);
+
+        act(() => {
+            outsideHandlers[1]?.();
+        });
+
+        expect(result.current.state.openMenuShiftTeamId).toBeNull();
+    });
+
+    it('submits the pending shift team name edit when the name click-away handler runs', () => {
+        const updateShiftTeam = vi.fn();
+        const {result} = renderHook(() =>
+            useShiftTeamListController({
+                shiftTeams,
+                selectedNurse: shiftTeams[0].nurses[0],
+                selectNurse: vi.fn(),
+                moveNurseOrder: vi.fn(),
+                updateShiftTeam,
+            }),
+        );
+
+        act(() => {
+            result.current.actions.startEditingShiftTeam(10, 'A팀');
+            result.current.actions.changeEditShiftTeamName('A팀 수정');
+        });
+
+        act(() => {
+            outsideHandlers[outsideHandlers.length - 1]?.();
+        });
+
+        expect(updateShiftTeam).toHaveBeenCalledWith(10, {name: 'A팀 수정'});
+        expect(result.current.state.editShiftTeam).toBeNull();
+    });
+});


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-901](https://gom3.atlassian.net/browse/DUT-901)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `useShiftTeamListControllerHook`의 방향키 포커스 이동과 click-away 동작을 hook 테스트로 보강했습니다.
- `useConnectionManageController`에 연결 실패 및 재시도 전이를 검증하는 테스트를 추가했습니다.
- `useEditWard`와 `useEditShiftTeam`에 mutation 실패 shape별 반환값, 상태, feedback 검증 테스트를 추가했습니다.
- `useConnectionManageController`의 재시도 테스트가 즉시 resolve 타이밍에 덜 민감하도록 대기 로직을 보강했습니다.

<br>

## To Reviewers

- Vitest 실행 시 일부 기존 테스트까지 함께 수행되지만, 전체 실행은 통과했습니다.
- `react-cool-onclickoutside`는 라이브러리 자체보다 controller 반응을 검증하도록 mock 기반으로 테스트했습니다.

<br>

## Follow-up

- `react-cool-onclickoutside` 실제 ref wiring까지 보장하려면, 이후 `ShiftTeamList` 또는 `ShiftTeamCard` 수준의 얇은 통합 테스트 1건을 추가해 DOM 연결 회귀를 한 번 더 막는 것이 좋습니다.


[DUT-901]: https://gom3.atlassian.net/browse/DUT-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ