### PR TITLE
fix: unblock root redirect after auth hydration

### DIFF
--- a/apps/app/src/features/auth/useAuth/store.test.ts
+++ b/apps/app/src/features/auth/useAuth/store.test.ts
@@ -45,4 +45,22 @@ describe('useAuthStore', () => {
             });
         });
     });
+
+    it('marks hydration as loaded and falls back to safe defaults when persisted payload is malformed', async () => {
+        localStorage.setItem('useAuthStore', '{invalid-json');
+
+        const {default: useAuthStore} = await import('./store');
+
+        await vi.waitFor(() => {
+            expect(useAuthStore.getState()).toMatchObject({
+                isAuth: false,
+                accessToken: null,
+                accountId: null,
+                nurseId: null,
+                wardId: null,
+                demoStartDate: null,
+                _loaded: true,
+            });
+        });
+    });
 });

--- a/apps/app/src/features/auth/useAuth/store.test.ts
+++ b/apps/app/src/features/auth/useAuth/store.test.ts
@@ -1,0 +1,48 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+describe('useAuthStore', () => {
+    afterEach(() => {
+        localStorage.clear();
+        vi.resetModules();
+    });
+
+    it('marks hydration as loaded even when persisted auth state is missing', async () => {
+        localStorage.removeItem('useAuthStore');
+
+        const {default: useAuthStore} = await import('./store');
+
+        await vi.waitFor(() => {
+            expect(useAuthStore.getState()._loaded).toBe(true);
+        });
+    });
+
+    it('rehydrates persisted auth state and marks hydration as loaded', async () => {
+        localStorage.setItem(
+            'useAuthStore',
+            JSON.stringify({
+                state: {
+                    isAuth: true,
+                    accessToken: 'token',
+                    accountId: 1,
+                    nurseId: 2,
+                    wardId: 3,
+                    demoStartDate: null,
+                },
+                version: 0,
+            }),
+        );
+
+        const {default: useAuthStore} = await import('./store');
+
+        await vi.waitFor(() => {
+            expect(useAuthStore.getState()).toMatchObject({
+                isAuth: true,
+                accessToken: 'token',
+                accountId: 1,
+                nurseId: 2,
+                wardId: 3,
+                _loaded: true,
+            });
+        });
+    });
+});

--- a/apps/app/src/features/auth/useAuth/store.ts
+++ b/apps/app/src/features/auth/useAuth/store.ts
@@ -1,5 +1,5 @@
 import {create} from 'zustand';
-import {devtools, persist} from 'zustand/middleware';
+import {devtools, persist, type PersistStorage, type StorageValue} from 'zustand/middleware';
 import {type TAccount} from '@/entities/account';
 import {setAccessToken} from '@/shared/api/client';
 import {type TValues} from '@/shared/types/util';
@@ -20,6 +20,8 @@ interface IStore extends IState {
     resetState: () => void;
 }
 
+type TPersistedAuthState = Pick<IState, 'isAuth' | 'accessToken' | 'accountId' | 'nurseId' | 'wardId' | 'demoStartDate'>;
+
 const initialState: IState = {
     accountMe: null,
     isAuth: false,
@@ -30,6 +32,25 @@ const initialState: IState = {
     demoStartDate: null,
     _loaded: false,
 };
+
+const authStoreStorage: PersistStorage<TPersistedAuthState> = {
+    getItem: (name) => {
+        const value = localStorage.getItem(name);
+
+        if (!value) return null;
+
+        try {
+            return JSON.parse(value) as StorageValue<TPersistedAuthState>;
+        } catch {
+            localStorage.removeItem(name);
+
+            return null;
+        }
+    },
+    setItem: (name, value) => localStorage.setItem(name, JSON.stringify(value)),
+    removeItem: (name) => localStorage.removeItem(name),
+};
+
 const useAuthStore = create<IStore>()(
     devtools(
         persist(
@@ -40,7 +61,8 @@ const useAuthStore = create<IStore>()(
             }),
             {
                 name: 'useAuthStore',
-                partialize: ({isAuth, accessToken, accountId, nurseId, wardId, demoStartDate}: IStore) => {
+                storage: authStoreStorage,
+                partialize: ({isAuth, accessToken, accountId, nurseId, wardId, demoStartDate}: IStore): TPersistedAuthState => {
                     if (accessToken) setAccessToken(accessToken);
 
                     return {
@@ -52,8 +74,8 @@ const useAuthStore = create<IStore>()(
                         demoStartDate,
                     };
                 },
-                onRehydrateStorage: () => (state) => {
-                    state?.setState('_loaded', true);
+                onRehydrateStorage: (state) => (rehydratedState) => {
+                    (rehydratedState ?? state).setState('_loaded', true);
                 },
             },
         ),

--- a/apps/app/src/features/auth/useAuth/store.ts
+++ b/apps/app/src/features/auth/useAuth/store.ts
@@ -50,8 +50,10 @@ const useAuthStore = create<IStore>()(
                         nurseId,
                         wardId,
                         demoStartDate,
-                        _loaded: true,
                     };
+                },
+                onRehydrateStorage: () => (state) => {
+                    state?.setState('_loaded', true);
                 },
             },
         ),


### PR DESCRIPTION
## Summary
- mark auth store hydration complete even when no persisted auth state exists
- keep root landing redirect from waiting indefinitely on first visits or in fresh browsers
- add store tests covering both empty and populated persisted auth state

## Testing
- pnpm --dir apps/app test:run -- src/features/auth/useAuth/store.test.ts src/pages/LandingPage/landing-page-redirect.test.tsx
- pnpm --dir apps/app type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 상태 저장/복원 로직 강화 — 손상된 저장 데이터에 대해 안전하게 기본값으로 복원되며 복원 완료가 안정적으로 표시됩니다.
  * 저장되는 인증 데이터가 핵심 항목으로 제한되어 불필요한 항목은 제외됩니다.

* **테스트**
  * 인증 상태 복원 동작(데이터 없음, 정상 데이터, 손상된 JSON)을 검증하는 테스트 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->