### PR TITLE
[-] request, duty, register 페이지의 인증 초기화 로딩 상태 분리

### DIFF
--- a/apps/app/src/features/auth/useAuth/index.test.tsx
+++ b/apps/app/src/features/auth/useAuth/index.test.tsx
@@ -112,6 +112,25 @@ describe('useAuth', () => {
         });
     });
 
+    it('preserves demoStartDate when login is used for token refresh', () => {
+        const {result} = renderHook(() => useAuth());
+
+        act(() => {
+            result.current.actions.handleLogin('refreshed-token', null, {preserveDemoStartDate: true});
+        });
+
+        expect(useAuthStore.getState()).toMatchObject({
+            accountMe: null,
+            accountMeStatus: 'loading',
+            accessToken: 'refreshed-token',
+            accountId: null,
+            nurseId: null,
+            wardId: null,
+            demoStartDate: '2026-03-01T00:00:00.000Z',
+            isAuth: true,
+        });
+    });
+
     it('drops stale identity fields and rethrows when account bootstrap fails', async () => {
         vi.mocked(AccountAPI.getAccountMe).mockRejectedValueOnce(new Error('boom'));
         const {result} = renderHook(() => useAuth());

--- a/apps/app/src/features/auth/useAuth/index.test.tsx
+++ b/apps/app/src/features/auth/useAuth/index.test.tsx
@@ -1,0 +1,131 @@
+import {act, renderHook} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {AccountAPI} from '@/shared/api';
+import useAuth from './index';
+import useAuthStore from './store';
+
+const {
+    mockNavigate,
+    mockResetRequestShiftState,
+    mockSetLoading,
+    mockInitTutorial,
+    mockSendEvent,
+    mockExecuteLoginRedirect,
+    mockGetLoginRedirectDecision,
+    setAccessTokenMock,
+} = vi.hoisted(() => ({
+    mockNavigate: vi.fn(),
+    mockResetRequestShiftState: vi.fn(),
+    mockSetLoading: vi.fn(),
+    mockInitTutorial: vi.fn(),
+    mockSendEvent: vi.fn(),
+    mockExecuteLoginRedirect: vi.fn(),
+    mockGetLoginRedirectDecision: vi.fn(() => ({type: 'none'})),
+    setAccessTokenMock: vi.fn(),
+}));
+
+vi.mock('react-router', () => ({
+    useLocation: () => ({pathname: '/request'}),
+    useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/analytics', () => ({
+    events: {
+        auth: {
+            login: 'login',
+            logut: 'logout',
+        },
+    },
+    sendEvent: (...args: unknown[]) => mockSendEvent(...args),
+}));
+
+vi.mock('@/features/shift/useRequestShift/store', () => ({
+    useRequestShiftStore: (selector: (state: {resetState: () => void}) => unknown) =>
+        selector({
+            resetState: mockResetRequestShiftState,
+        }),
+}));
+
+vi.mock('@/features/ui/useLoading', () => ({
+    default: () => ({
+        setLoading: mockSetLoading,
+    }),
+}));
+
+vi.mock('@/features/ui/useTutorial', () => ({
+    default: () => ({
+        initTutorial: mockInitTutorial,
+    }),
+}));
+
+vi.mock('@/shared/api/client', () => ({
+    setAccessToken: (...args: unknown[]) => setAccessTokenMock(...args),
+}));
+
+vi.mock('@/shared/api', () => ({
+    AccountAPI: {
+        getAccountMe: vi.fn(),
+    },
+    AuthAPI: {
+        demoStart: vi.fn(),
+    },
+}));
+
+vi.mock('./loginRedirect', () => ({
+    executeLoginRedirect: mockExecuteLoginRedirect,
+    getLoginRedirectDecision: mockGetLoginRedirectDecision,
+}));
+
+describe('useAuth', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        useAuthStore.setState({
+            accountMe: {accountId: 9, wardId: 99, nurseId: 19} as never,
+            accountMeStatus: 'success',
+            isAuth: true,
+            accessToken: 'old-token',
+            accountId: 9,
+            nurseId: 19,
+            wardId: 99,
+            demoStartDate: '2026-03-01T00:00:00.000Z',
+            _loaded: true,
+        });
+    });
+
+    it('clears stale identity fields when login starts a new bootstrap', () => {
+        const {result} = renderHook(() => useAuth());
+
+        act(() => {
+            result.current.actions.handleLogin('new-token', null);
+        });
+
+        expect(useAuthStore.getState()).toMatchObject({
+            accountMe: null,
+            accountMeStatus: 'loading',
+            accessToken: 'new-token',
+            accountId: null,
+            nurseId: null,
+            wardId: null,
+            demoStartDate: null,
+            isAuth: true,
+        });
+    });
+
+    it('drops stale identity fields when account bootstrap fails', async () => {
+        vi.mocked(AccountAPI.getAccountMe).mockRejectedValueOnce(new Error('boom'));
+        const {result} = renderHook(() => useAuth());
+
+        await act(async () => {
+            await result.current.actions.handleGetAccountMe();
+        });
+
+        expect(useAuthStore.getState()).toMatchObject({
+            accountMe: null,
+            accountMeStatus: 'error',
+            accountId: null,
+            nurseId: null,
+            wardId: null,
+        });
+    });
+});

--- a/apps/app/src/features/auth/useAuth/index.test.tsx
+++ b/apps/app/src/features/auth/useAuth/index.test.tsx
@@ -131,7 +131,7 @@ describe('useAuth', () => {
         });
     });
 
-    it('drops stale identity fields and rethrows when account bootstrap fails', async () => {
+    it('preserves stale identity fields and rethrows when account bootstrap fails', async () => {
         vi.mocked(AccountAPI.getAccountMe).mockRejectedValueOnce(new Error('boom'));
         const {result} = renderHook(() => useAuth());
 
@@ -142,11 +142,11 @@ describe('useAuth', () => {
         ).rejects.toThrow('boom');
 
         expect(useAuthStore.getState()).toMatchObject({
-            accountMe: null,
+            accountMe: {accountId: 9, wardId: 99, nurseId: 19},
             accountMeStatus: 'error',
-            accountId: null,
-            nurseId: null,
-            wardId: null,
+            accountId: 9,
+            nurseId: 19,
+            wardId: 99,
         });
     });
 });

--- a/apps/app/src/features/auth/useAuth/index.test.tsx
+++ b/apps/app/src/features/auth/useAuth/index.test.tsx
@@ -112,13 +112,15 @@ describe('useAuth', () => {
         });
     });
 
-    it('drops stale identity fields when account bootstrap fails', async () => {
+    it('drops stale identity fields and rethrows when account bootstrap fails', async () => {
         vi.mocked(AccountAPI.getAccountMe).mockRejectedValueOnce(new Error('boom'));
         const {result} = renderHook(() => useAuth());
 
-        await act(async () => {
-            await result.current.actions.handleGetAccountMe();
-        });
+        await expect(
+            act(async () => {
+                await result.current.actions.handleGetAccountMe();
+            }),
+        ).rejects.toThrow('boom');
 
         expect(useAuthStore.getState()).toMatchObject({
             accountMe: null,

--- a/apps/app/src/features/auth/useAuth/index.ts
+++ b/apps/app/src/features/auth/useAuth/index.ts
@@ -10,6 +10,10 @@ import ROUTE from '@/shared/constant/path';
 import {executeLoginRedirect, getLoginRedirectDecision} from './loginRedirect';
 import useAuthStore from './store';
 
+type THandleLoginOptions = {
+    preserveDemoStartDate?: boolean;
+};
+
 const useAuth = (activeEffect = false) => {
     const {accountMe, accountMeStatus, isAuth, accessToken, nurseId, accountId, wardId, demoStartDate, _loaded, setState, resetState} =
         useAuthStore();
@@ -29,12 +33,14 @@ const useAuth = (activeEffect = false) => {
 
         if (fallBackPath && pathname !== fallBackPath) navigate(fallBackPath);
     };
-    const handleLogin = (accessToken: string, nextPageUrl?: string | null) => {
+    const handleLogin = (accessToken: string, nextPageUrl?: string | null, options?: THandleLoginOptions) => {
         setState('accountMe', null);
         setState('accountId', null);
         setState('nurseId', null);
         setState('wardId', null);
-        setState('demoStartDate', null);
+        if (!options?.preserveDemoStartDate) {
+            setState('demoStartDate', null);
+        }
         setState('isAuth', true);
         setState('accessToken', accessToken);
         setState('accountMeStatus', 'loading');

--- a/apps/app/src/features/auth/useAuth/index.ts
+++ b/apps/app/src/features/auth/useAuth/index.ts
@@ -80,6 +80,7 @@ const useAuth = (activeEffect = false) => {
             setState('accountMeStatus', 'success');
         } catch (error) {
             setState('accountMeStatus', 'error');
+            throw error;
         }
     };
 
@@ -94,7 +95,7 @@ const useAuth = (activeEffect = false) => {
             if (demoStartDate && new Date(demoStartDate).getTime() + 3540000 - new Date().getTime() <= 0) {
                 void handleLogout();
             } else {
-                void handleGetAccountMe();
+                void handleGetAccountMe().catch(() => undefined);
             }
         }
     }, [accessToken, activeEffect, demoStartDate, _loaded]);

--- a/apps/app/src/features/auth/useAuth/index.ts
+++ b/apps/app/src/features/auth/useAuth/index.ts
@@ -30,6 +30,11 @@ const useAuth = (activeEffect = false) => {
         if (fallBackPath && pathname !== fallBackPath) navigate(fallBackPath);
     };
     const handleLogin = (accessToken: string, nextPageUrl?: string | null) => {
+        setState('accountMe', null);
+        setState('accountId', null);
+        setState('nurseId', null);
+        setState('wardId', null);
+        setState('demoStartDate', null);
         setState('isAuth', true);
         setState('accessToken', accessToken);
         setState('accountMeStatus', 'loading');
@@ -58,6 +63,10 @@ const useAuth = (activeEffect = false) => {
         setLoading(false);
     };
     const handleGetAccountMe = async () => {
+        setState('accountMe', null);
+        setState('accountId', null);
+        setState('nurseId', null);
+        setState('wardId', null);
         setState('accountMeStatus', 'loading');
 
         try {

--- a/apps/app/src/features/auth/useAuth/index.ts
+++ b/apps/app/src/features/auth/useAuth/index.ts
@@ -69,10 +69,6 @@ const useAuth = (activeEffect = false) => {
         setLoading(false);
     };
     const handleGetAccountMe = async () => {
-        setState('accountMe', null);
-        setState('accountId', null);
-        setState('nurseId', null);
-        setState('wardId', null);
         setState('accountMeStatus', 'loading');
 
         try {

--- a/apps/app/src/features/auth/useAuth/index.ts
+++ b/apps/app/src/features/auth/useAuth/index.ts
@@ -11,7 +11,8 @@ import {executeLoginRedirect, getLoginRedirectDecision} from './loginRedirect';
 import useAuthStore from './store';
 
 const useAuth = (activeEffect = false) => {
-    const {accountMe, isAuth, accessToken, nurseId, accountId, wardId, demoStartDate, _loaded, setState, resetState} = useAuthStore();
+    const {accountMe, accountMeStatus, isAuth, accessToken, nurseId, accountId, wardId, demoStartDate, _loaded, setState, resetState} =
+        useAuthStore();
     const resetRequestShiftState = useRequestShiftStore((state) => state.resetState);
     const {pathname} = useLocation();
     const {setLoading} = useLoadingUseCase();
@@ -31,6 +32,7 @@ const useAuth = (activeEffect = false) => {
     const handleLogin = (accessToken: string, nextPageUrl?: string | null) => {
         setState('isAuth', true);
         setState('accessToken', accessToken);
+        setState('accountMeStatus', 'loading');
         setAccessToken(accessToken);
 
         const redirectDecision = getLoginRedirectDecision(nextPageUrl);
@@ -50,18 +52,26 @@ const useAuth = (activeEffect = false) => {
         setState('nurseId', data.accountResDto.nurseId);
         setState('wardId', data.accountResDto.wardId);
         setState('isAuth', true);
+        setState('accountMeStatus', 'success');
         setState('demoStartDate', new Date().toISOString());
         navigate(ROUTE.MAKE);
         setLoading(false);
     };
     const handleGetAccountMe = async () => {
-        const account = await AccountAPI.getAccountMe();
+        setState('accountMeStatus', 'loading');
 
-        setState('accountMe', account);
-        setState('wardId', account.wardId);
-        setState('accountId', account.accountId);
-        setState('nurseId', account.nurseId);
-        setState('isAuth', true);
+        try {
+            const account = await AccountAPI.getAccountMe();
+
+            setState('accountMe', account);
+            setState('wardId', account.wardId);
+            setState('accountId', account.accountId);
+            setState('nurseId', account.nurseId);
+            setState('isAuth', true);
+            setState('accountMeStatus', 'success');
+        } catch (error) {
+            setState('accountMeStatus', 'error');
+        }
     };
 
     useEffect(() => {
@@ -72,14 +82,18 @@ const useAuth = (activeEffect = false) => {
 
     useEffect(() => {
         if (_loaded && activeEffect && accessToken) {
-            if (demoStartDate && new Date(demoStartDate).getTime() + 3540000 - new Date().getTime() <= 0) handleLogout();
-            else handleGetAccountMe();
+            if (demoStartDate && new Date(demoStartDate).getTime() + 3540000 - new Date().getTime() <= 0) {
+                void handleLogout();
+            } else {
+                void handleGetAccountMe();
+            }
         }
     }, [accessToken, activeEffect, demoStartDate, _loaded]);
 
     return {
         state: {
             accountMe: accountMe === undefined ? null : accountMe,
+            accountMeStatus,
             isAuth,
             accessToken,
             nurseId,

--- a/apps/app/src/features/auth/useAuth/store.ts
+++ b/apps/app/src/features/auth/useAuth/store.ts
@@ -6,6 +6,7 @@ import {type TValues} from '@/shared/types/util';
 
 interface IState {
     accountMe: TAccount | null;
+    accountMeStatus: 'idle' | 'loading' | 'success' | 'error';
     isAuth: boolean;
     accessToken: string | null;
     accountId: number | null;
@@ -24,6 +25,7 @@ type TPersistedAuthState = Pick<IState, 'isAuth' | 'accessToken' | 'accountId' |
 
 const initialState: IState = {
     accountMe: null,
+    accountMeStatus: 'idle',
     isAuth: false,
     accessToken: null,
     accountId: null,

--- a/apps/app/src/features/auth/useRefresh/index.ts
+++ b/apps/app/src/features/auth/useRefresh/index.ts
@@ -16,7 +16,7 @@ export default function useRefresh() {
             const accessToken = (await axiosInstance.post('/token/refresh')).data.accessToken;
 
             // 여기서는 "세션만 갱신"하고, 이동은 호출자(RefreshPage)가 담당한다.
-            handleLogin(accessToken, null);
+            handleLogin(accessToken, null, {preserveDemoStartDate: true});
 
             return accessToken as string;
         } catch {

--- a/apps/app/src/features/shift/useRequestShift/index.ts
+++ b/apps/app/src/features/shift/useRequestShift/index.ts
@@ -408,7 +408,7 @@ const useRequestShift = (activeEffect = false) => {
     };
     const retry = useCallback(async () => {
         if (wardId === null) {
-            await handleGetAccountMe();
+            await handleGetAccountMe().catch(() => undefined);
 
             return;
         }

--- a/apps/app/src/features/shift/useRequestShift/index.ts
+++ b/apps/app/src/features/shift/useRequestShift/index.ts
@@ -29,7 +29,8 @@ const useRequestShift = (activeEffect = false) => {
         setState,
     } = useRequestShiftStore();
     const {
-        state: {wardId},
+        state: {wardId, isAuth, _loaded, accountMeStatus},
+        actions: {handleGetAccountMe},
     } = useAuth();
     const queryClient = useQueryClient();
     const shiftTeamsQueryOptions = wardQueryOptions.shiftTeams(wardId ?? 0);
@@ -41,6 +42,12 @@ const useRequestShift = (activeEffect = false) => {
     const wardConstraintQueryKey = wardConstraintQueryOptions.queryKey;
     const dutyRequestQueryKey = requestListQueryOptions.queryKey;
     const editAvailability = getRequestShiftEditAvailability(year, month);
+    const bootstrapStatus =
+        !_loaded || (isAuth && wardId === null && (accountMeStatus === 'idle' || accountMeStatus === 'loading'))
+            ? 'pending'
+            : isAuth && wardId === null && accountMeStatus === 'error'
+              ? 'error'
+              : 'success';
     const changeStatusResetTimerRef = useRef<number | null>(null);
     const requestShiftChangeQueueRef = useRef<Array<{focus: TFocus; shiftTypeId: number | null}>>([]);
     const isProcessingRequestShiftQueueRef = useRef(false);
@@ -400,6 +407,12 @@ const useRequestShift = (activeEffect = false) => {
         handleToggleEditMode(nextDate);
     };
     const retry = useCallback(async () => {
+        if (wardId === null) {
+            await handleGetAccountMe();
+
+            return;
+        }
+
         const retryTasks: Promise<unknown>[] = [refetchShiftTeams()];
 
         if (currentShiftTeamId !== null) {
@@ -407,7 +420,7 @@ const useRequestShift = (activeEffect = false) => {
         }
 
         await Promise.all(retryTasks);
-    }, [currentShiftTeamId, refetchDutyRequestList, refetchRequestShift, refetchShiftTeams]);
+    }, [currentShiftTeamId, handleGetAccountMe, refetchDutyRequestList, refetchRequestShift, refetchShiftTeams, wardId]);
 
     useEffect(() => {
         if (activeEffect && requestShift) {
@@ -454,6 +467,7 @@ const useRequestShift = (activeEffect = false) => {
         state: {
             year,
             month,
+            bootstrapStatus,
             requestShift,
             dutyRequestList,
             focus,

--- a/apps/app/src/pages/RegisterPage/index.test.tsx
+++ b/apps/app/src/pages/RegisterPage/index.test.tsx
@@ -1,0 +1,94 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen, userEvent} from '@/shared/util/test-utils';
+import RegisterPage from './index';
+
+const mockHandleGetAccountMe = vi.fn();
+const mockNavigate = vi.fn();
+
+let mockAuthState: {
+    accountMe: {status: 'INITIAL' | 'NURSE_INFO_PENDING' | 'WARD_SELECT_PENDING' | 'WARD_ENTRY_PENDING' | 'LINKED'} | null;
+    accountMeStatus: 'idle' | 'loading' | 'success' | 'error';
+    _loaded: boolean;
+} = {
+    accountMe: null,
+    accountMeStatus: 'loading',
+    _loaded: false,
+};
+
+vi.mock('react-router', () => ({
+    Navigate: ({to}: {to: string}) => <div>navigate:{to}</div>,
+    useNavigate: () => mockNavigate,
+}));
+
+vi.mock('react-loader-spinner', () => ({
+    TailSpin: () => <div>spinner</div>,
+}));
+
+vi.mock('@/features/auth/useAuth', () => ({
+    default: () => ({
+        state: mockAuthState,
+        actions: {
+            handleGetAccountMe: mockHandleGetAccountMe,
+        },
+    }),
+}));
+
+vi.mock('./ui/RegisterNurse', () => ({
+    default: () => <div>register-nurse</div>,
+}));
+
+vi.mock('./ui/SelectEnterOrCreate', () => ({
+    default: () => <div>select-enter-or-create</div>,
+}));
+
+vi.mock('./ui/PendingEnter', () => ({
+    default: () => <div>pending-enter</div>,
+}));
+
+describe('RegisterPage', () => {
+    beforeEach(() => {
+        mockHandleGetAccountMe.mockReset();
+        mockNavigate.mockReset();
+        mockAuthState = {
+            accountMe: null,
+            accountMeStatus: 'loading',
+            _loaded: false,
+        };
+    });
+
+    it('shows a loading spinner while account bootstrap is pending', () => {
+        render(<RegisterPage />);
+
+        expect(screen.getByText('spinner')).toBeInTheDocument();
+    });
+
+    it('shows a retryable error state when account bootstrap fails', async () => {
+        const user = userEvent.setup();
+
+        mockAuthState = {
+            accountMe: null,
+            accountMeStatus: 'error',
+            _loaded: true,
+        };
+
+        render(<RegisterPage />);
+
+        expect(screen.getByText('계정 정보를 불러오지 못했어요')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', {name: '다시 시도'}));
+
+        expect(mockHandleGetAccountMe).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the matching registration step when account status is available', () => {
+        mockAuthState = {
+            accountMe: {status: 'WARD_SELECT_PENDING'},
+            accountMeStatus: 'success',
+            _loaded: true,
+        };
+
+        render(<RegisterPage />);
+
+        expect(screen.getByText('select-enter-or-create')).toBeInTheDocument();
+    });
+});

--- a/apps/app/src/pages/RegisterPage/index.test.tsx
+++ b/apps/app/src/pages/RegisterPage/index.test.tsx
@@ -48,6 +48,7 @@ vi.mock('./ui/PendingEnter', () => ({
 describe('RegisterPage', () => {
     beforeEach(() => {
         mockHandleGetAccountMe.mockReset();
+        mockHandleGetAccountMe.mockResolvedValue(undefined);
         mockNavigate.mockReset();
         mockAuthState = {
             accountMe: null,

--- a/apps/app/src/pages/RegisterPage/index.tsx
+++ b/apps/app/src/pages/RegisterPage/index.tsx
@@ -34,7 +34,7 @@ function RegisterPage() {
                         tone="error"
                         title="계정 정보를 불러오지 못했어요"
                         description="잠시 후 다시 시도해 주세요. 문제가 계속되면 다시 로그인해 주세요."
-                        action={{label: '다시 시도', onClick: () => void handleGetAccountMe()}}
+                        action={{label: '다시 시도', onClick: () => void handleGetAccountMe().catch(() => undefined)}}
                         className="py-0"
                     />
                 </div>
@@ -50,7 +50,7 @@ function RegisterPage() {
                                 tone="error"
                                 title="계정 상태를 확인하지 못했어요"
                                 description="계정 정보를 다시 불러온 뒤 등록 절차를 이어가세요."
-                                action={{label: '다시 시도', onClick: () => void handleGetAccountMe()}}
+                                action={{label: '다시 시도', onClick: () => void handleGetAccountMe().catch(() => undefined)}}
                                 className="py-0"
                             />
                         </div>

--- a/apps/app/src/pages/RegisterPage/index.tsx
+++ b/apps/app/src/pages/RegisterPage/index.tsx
@@ -4,15 +4,19 @@ import {match} from 'ts-pattern';
 import useAuth from '@/features/auth/useAuth';
 import {FullLogo, LogoSymbolFill} from '@/shared/assets/svg';
 import ROUTE from '@/shared/constant/path';
+import PageState from '@/shared/ui/PageState';
 import PendingEnter from './ui/PendingEnter';
 import RegisterNurse from './ui/RegisterNurse';
 import SelectEnterOrCreate from './ui/SelectEnterOrCreate';
 
 function RegisterPage() {
     const {
-        state: {accountMe},
+        state: {accountMe, accountMeStatus, _loaded},
+        actions: {handleGetAccountMe},
     } = useAuth();
     const navigate = useNavigate();
+    const isAccountBootstrapPending = !_loaded || accountMeStatus === 'idle' || accountMeStatus === 'loading';
+    const isAccountBootstrapError = accountMeStatus === 'error';
 
     return (
         <div className="relative mx-auto mt-30.75 flex h-[calc(100%-7.6875rem)] w-[52%] flex-col items-center bg-[#FDFCFE]">
@@ -20,16 +24,38 @@ function RegisterPage() {
                 <LogoSymbolFill className="h-7.5 w-7.5" />
                 <FullLogo className="h-7.5 w-27.5" />
             </div>
-            {match(accountMe?.status)
-                .with('INITIAL', 'NURSE_INFO_PENDING', () => <RegisterNurse />)
-                .with('WARD_SELECT_PENDING', () => <SelectEnterOrCreate />)
-                .with('WARD_ENTRY_PENDING', () => <PendingEnter />)
-                .with('LINKED', () => <Navigate to={ROUTE.MAKE} />)
-                .otherwise(() => (
-                    <div className="flex h-screen w-screen flex-col items-center justify-center">
-                        <TailSpin color="#844AFF" />
-                    </div>
-                ))}
+            {isAccountBootstrapPending ? (
+                <div className="flex h-screen w-screen flex-col items-center justify-center">
+                    <TailSpin color="#844AFF" />
+                </div>
+            ) : isAccountBootstrapError ? (
+                <div className="flex h-screen w-screen items-center justify-center px-8">
+                    <PageState
+                        tone="error"
+                        title="계정 정보를 불러오지 못했어요"
+                        description="잠시 후 다시 시도해 주세요. 문제가 계속되면 다시 로그인해 주세요."
+                        action={{label: '다시 시도', onClick: () => void handleGetAccountMe()}}
+                        className="py-0"
+                    />
+                </div>
+            ) : (
+                match(accountMe?.status)
+                    .with('INITIAL', 'NURSE_INFO_PENDING', () => <RegisterNurse />)
+                    .with('WARD_SELECT_PENDING', () => <SelectEnterOrCreate />)
+                    .with('WARD_ENTRY_PENDING', () => <PendingEnter />)
+                    .with('LINKED', () => <Navigate to={ROUTE.MAKE} />)
+                    .otherwise(() => (
+                        <div className="flex h-screen w-screen items-center justify-center px-8">
+                            <PageState
+                                tone="error"
+                                title="계정 상태를 확인하지 못했어요"
+                                description="계정 정보를 다시 불러온 뒤 등록 절차를 이어가세요."
+                                action={{label: '다시 시도', onClick: () => void handleGetAccountMe()}}
+                                className="py-0"
+                            />
+                        </div>
+                    ))
+            )}
         </div>
     );
 }

--- a/apps/app/src/pages/RequestShiftPage/index.test.tsx
+++ b/apps/app/src/pages/RequestShiftPage/index.test.tsx
@@ -19,6 +19,7 @@ vi.mock('./ui/RequestCalendar', () => ({
 type TMockUseRequestShiftValue = {
     state: {
         readonly: boolean;
+        bootstrapStatus: 'pending' | 'error' | 'success';
         editAvailability: {
             canEdit: boolean;
             status: 'editable' | 'lockedPast' | 'lockedFuture';
@@ -62,6 +63,7 @@ function baseUseRequestShiftValue(): TMockUseRequestShiftValue {
     return {
         state: {
             readonly: true,
+            bootstrapStatus: 'success',
             editAvailability: {
                 canEdit: true,
                 status: 'editable',
@@ -100,6 +102,21 @@ describe('RequestShiftPage', () => {
 
         expect(screen.getByText('신청 근무 화면을 준비하고 있어요')).toBeInTheDocument();
         expect(screen.getByText('근무 팀과 신청 근무표를 순서대로 불러오고 있어요.')).toBeInTheDocument();
+    });
+
+    it('계정 정보를 확인하는 중이면 부트스트랩 로딩 상태를 보여준다', () => {
+        mockUseRequestShift.mockReturnValue(
+            createUseRequestShiftValue({
+                state: {
+                    bootstrapStatus: 'pending',
+                },
+            }),
+        );
+
+        render(<RequestShiftPage />);
+
+        expect(screen.getByText('계정 정보를 확인하고 있어요')).toBeInTheDocument();
+        expect(screen.getByText('병동 정보를 확인한 뒤 신청 근무 화면을 준비하고 있어요.')).toBeInTheDocument();
     });
 
     it('신청 근무표 조회 실패 시 재시도를 노출하고 실행한다', async () => {

--- a/apps/app/src/pages/RequestShiftPage/index.tsx
+++ b/apps/app/src/pages/RequestShiftPage/index.tsx
@@ -7,7 +7,7 @@ import Toolbar from './ui/Toolbar';
 
 const RequestShiftPage = () => {
     const {
-        state: {readonly, requestShift, shiftStatus, shiftTeams, shiftTeamsStatus, editAvailability},
+        state: {readonly, requestShift, shiftStatus, shiftTeams, shiftTeamsStatus, editAvailability, bootstrapStatus},
         actions: {retry, createNextMonthShift},
     } = useRequestShift(true);
     const shiftTeamCount = shiftTeams?.length ?? 0;
@@ -22,7 +22,20 @@ const RequestShiftPage = () => {
             : editAvailability.description
         : '셀을 선택한 뒤 단축키로 근무를 입력할 수 있고, 변경 내용은 자동 저장돼요.';
     const pageState =
-        shiftTeamsStatus === 'pending'
+        bootstrapStatus === 'pending'
+            ? {
+                  tone: 'loading' as const,
+                  title: '계정 정보를 확인하고 있어요',
+                  description: '병동 정보를 확인한 뒤 신청 근무 화면을 준비하고 있어요.',
+              }
+            : bootstrapStatus === 'error'
+              ? {
+                    tone: 'error' as const,
+                    title: '병동 정보를 불러오지 못했어요',
+                    description: '계정 정보를 다시 확인해 주세요. 문제가 계속되면 다시 로그인해 주세요.',
+                    action: {label: '다시 시도', onClick: () => void retry()},
+                }
+              : shiftTeamsStatus === 'pending'
             ? {
                   tone: 'loading' as const,
                   title: '신청 근무 화면을 준비하고 있어요',

--- a/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
+++ b/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
@@ -7,16 +7,23 @@ import {useDutyHook} from './dutyHook';
 import {useDutyStore} from './dutyStore';
 
 const SHIFT_EDITOR_STORAGE_KEY = 'shift-editor:draft';
-const {mockNavigate, mockInvalidateQueries, mockSetLoading, mockUpdateShifts, mockPostShift, mockRefetch} = vi.hoisted(() => ({
+const {mockNavigate, mockInvalidateQueries, mockSetLoading, mockUpdateShifts, mockPostShift, mockRefetch, mockHandleGetAccountMe} = vi.hoisted(() => ({
     mockNavigate: vi.fn(),
     mockInvalidateQueries: vi.fn(),
     mockSetLoading: vi.fn(),
     mockUpdateShifts: vi.fn(),
     mockPostShift: vi.fn(),
     mockRefetch: vi.fn(),
+    mockHandleGetAccountMe: vi.fn(),
 }));
 
 let mockSearchParams = new URLSearchParams();
+let mockAuthState = {
+    wardId: 1,
+    isAuth: true,
+    _loaded: true,
+    accountMeStatus: 'success' as const,
+};
 let mockQueries: Record<string, any> = {};
 
 vi.mock('@/features/shift-editor', async () => {
@@ -58,8 +65,9 @@ vi.mock('react-router', () => ({
 
 vi.mock('@/features/auth/useAuth', () => ({
     default: () => ({
-        state: {
-            wardId: 1,
+        state: mockAuthState,
+        actions: {
+            handleGetAccountMe: mockHandleGetAccountMe,
         },
     }),
 }));
@@ -198,6 +206,12 @@ describe('useDutyHook integration', () => {
         window.localStorage.clear();
         resetDutyStore();
         useShiftEditorStore.getState().reset();
+        mockAuthState = {
+            wardId: 1,
+            isAuth: true,
+            _loaded: true,
+            accountMeStatus: 'success',
+        };
         mockSearchParams = new URLSearchParams('year=2025&month=7&shiftTeamId=20');
         setQueryState();
     });

--- a/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
+++ b/apps/app/src/pages/duty/model/dutyHook.integration.test.tsx
@@ -203,6 +203,7 @@ describe('useDutyHook integration', () => {
     beforeEach(() => {
         vi.useFakeTimers();
         vi.clearAllMocks();
+        mockHandleGetAccountMe.mockResolvedValue(undefined);
         window.localStorage.clear();
         resetDutyStore();
         useShiftEditorStore.getState().reset();

--- a/apps/app/src/pages/duty/model/dutyHook.test.tsx
+++ b/apps/app/src/pages/duty/model/dutyHook.test.tsx
@@ -189,6 +189,7 @@ function setQueryState(overrides?: Partial<typeof mockQueries>) {
 describe('useDutyHook', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockHandleGetAccountMe.mockResolvedValue(undefined);
         resetDutyStore();
         mockSearchParams = new URLSearchParams();
         mockAuthState = {

--- a/apps/app/src/pages/duty/model/dutyHook.test.tsx
+++ b/apps/app/src/pages/duty/model/dutyHook.test.tsx
@@ -16,6 +16,7 @@ const {
     mockDocToWardShiftsDTO,
     mockBuildWorkKeyMap,
     mockShiftToExcel,
+    mockHandleGetAccountMe,
     mockCommands,
 } = vi.hoisted(() => ({
     mockNavigate: vi.fn(),
@@ -28,6 +29,7 @@ const {
     mockDocToWardShiftsDTO: vi.fn(),
     mockBuildWorkKeyMap: vi.fn(),
     mockShiftToExcel: vi.fn(),
+    mockHandleGetAccountMe: vi.fn(),
     mockCommands: {
         init: vi.fn(),
         discardPersisted: vi.fn(),
@@ -36,6 +38,17 @@ const {
 }));
 
 let mockSearchParams = new URLSearchParams();
+let mockAuthState: {
+    wardId: number | null;
+    isAuth: boolean;
+    _loaded: boolean;
+    accountMeStatus: 'idle' | 'loading' | 'success' | 'error';
+} = {
+    wardId: 1,
+    isAuth: true,
+    _loaded: true,
+    accountMeStatus: 'success',
+};
 let mockEditorState: any = {
     doc: {
         columns: ['2026-03-01'],
@@ -72,8 +85,9 @@ vi.mock('react-router', () => ({
 
 vi.mock('@/features/auth/useAuth', () => ({
     default: () => ({
-        state: {
-            wardId: 1,
+        state: mockAuthState,
+        actions: {
+            handleGetAccountMe: mockHandleGetAccountMe,
         },
     }),
 }));
@@ -177,6 +191,12 @@ describe('useDutyHook', () => {
         vi.clearAllMocks();
         resetDutyStore();
         mockSearchParams = new URLSearchParams();
+        mockAuthState = {
+            wardId: 1,
+            isAuth: true,
+            _loaded: true,
+            accountMeStatus: 'success',
+        };
         mockEditorState = {
             doc: {
                 columns: ['2026-03-01'],
@@ -200,6 +220,36 @@ describe('useDutyHook', () => {
             expect(result.current.state.month).toBe(7);
             expect(result.current.state.currentShiftTeamId).toBe(20);
         });
+    });
+
+    it('exposes bootstrap pending state while auth context is still loading', () => {
+        mockAuthState = {
+            wardId: null,
+            isAuth: true,
+            _loaded: false,
+            accountMeStatus: 'loading',
+        };
+
+        const {result} = renderHook(() => useDutyHook());
+
+        expect(result.current.state.bootstrapStatus).toBe('pending');
+    });
+
+    it('retries auth bootstrap when wardId is missing', async () => {
+        mockAuthState = {
+            wardId: null,
+            isAuth: true,
+            _loaded: true,
+            accountMeStatus: 'error',
+        };
+
+        const {result} = renderHook(() => useDutyHook());
+
+        await act(async () => {
+            result.current.handlers.retry();
+        });
+
+        expect(mockHandleGetAccountMe).toHaveBeenCalledTimes(1);
     });
 
     it('initializes the editor doc from fetched shift data and current month context', async () => {

--- a/apps/app/src/pages/duty/model/dutyHook.ts
+++ b/apps/app/src/pages/duty/model/dutyHook.ts
@@ -48,7 +48,8 @@ export function useDutyHook() {
     const queryClient = useQueryClient();
     const [searchParams] = useSearchParams();
     const {
-        state: {wardId},
+        state: {wardId, isAuth, _loaded, accountMeStatus},
+        actions: {handleGetAccountMe},
     } = useAuth();
     const {setLoading} = useLoadingUseCase();
     const year = useDutyStore((s) => s.year);
@@ -74,6 +75,12 @@ export function useDutyHook() {
     const queryYear = useMemo(() => parsePositiveInt(searchParams.get('year')), [searchParams]);
     const queryMonth = useMemo(() => parsePositiveInt(searchParams.get('month')), [searchParams]);
     const queryShiftTeamId = useMemo(() => parsePositiveInt(searchParams.get('shiftTeamId')), [searchParams]);
+    const bootstrapStatus =
+        !_loaded || (isAuth && wardId === null && (accountMeStatus === 'idle' || accountMeStatus === 'loading'))
+            ? 'pending'
+            : isAuth && wardId === null && accountMeStatus === 'error'
+              ? 'error'
+              : 'success';
     const shiftTeamsQuery = useQuery({
         ...wardQueryOptions.shiftTeams(wardId ?? -1),
         enabled: wardId !== null,
@@ -223,13 +230,24 @@ export function useDutyHook() {
         void shiftToExcel(month, shift);
     };
     const handleRetry = () => {
-        void dutyQuery.refetch();
+        if (wardId === null) {
+            void handleGetAccountMe();
+
+            return;
+        }
+
+        void Promise.all([
+            shiftTeamsQuery.refetch(),
+            currentShiftTeamId !== null ? dutyQuery.refetch() : Promise.resolve(),
+            currentShiftTeamId !== null ? constraintQuery.refetch() : Promise.resolve(),
+        ]);
     };
 
     return {
         state: {
             year,
             month,
+            bootstrapStatus,
             shiftTeams,
             currentShiftTeamId,
             currentShiftTeamName,

--- a/apps/app/src/pages/duty/model/dutyHook.ts
+++ b/apps/app/src/pages/duty/model/dutyHook.ts
@@ -231,7 +231,7 @@ export function useDutyHook() {
     };
     const handleRetry = () => {
         if (wardId === null) {
-            void handleGetAccountMe();
+            void handleGetAccountMe().catch(() => undefined);
 
             return;
         }

--- a/apps/app/src/pages/duty/view/index.tsx
+++ b/apps/app/src/pages/duty/view/index.tsx
@@ -11,6 +11,8 @@ type TDutyPageViewProps = {
 export const DutyPageView = ({duty}: TDutyPageViewProps) => {
     const {state, handlers, refs} = duty;
     const {t} = useTypedTranslation();
+    const showBootstrapLoadingState = state.bootstrapStatus === 'pending';
+    const showBootstrapErrorState = state.bootstrapStatus === 'error';
     const showNoTeamsState = state.shiftTeamsStatus === 'success' && state.shiftTeams.length === 0;
     const showShiftTeamsErrorState = state.shiftTeamsStatus === 'error';
     const showLoadingState =
@@ -71,7 +73,24 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                 </div>
 
                 <div className="mt-6 min-h-0 flex-1 overflow-auto">
-                    {showNoTeamsState && (
+                    {showBootstrapLoadingState && (
+                        <PageState
+                            tone="loading"
+                            title="계정 정보를 확인하고 있어요"
+                            description="병동 정보를 확인한 뒤 확정 근무표 화면을 준비하고 있어요."
+                            className="py-0"
+                        />
+                    )}
+                    {showBootstrapErrorState && (
+                        <PageState
+                            tone="error"
+                            title="병동 정보를 불러오지 못했어요"
+                            description="계정 정보를 다시 확인해 주세요. 문제가 계속되면 다시 로그인해 주세요."
+                            action={{label: t('page.state.retry'), onClick: handlers.retry}}
+                            className="py-0"
+                        />
+                    )}
+                    {!showBootstrapLoadingState && !showBootstrapErrorState && showNoTeamsState && (
                         <PageState
                             tone="empty"
                             title={t('page.duty.noTeamsTitle')}
@@ -79,7 +98,7 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                             className="py-0"
                         />
                     )}
-                    {showShiftTeamsErrorState && (
+                    {!showBootstrapLoadingState && !showBootstrapErrorState && showShiftTeamsErrorState && (
                         <PageState
                             tone="error"
                             title={t('page.duty.teamsError')}
@@ -88,7 +107,7 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                             className="py-0"
                         />
                     )}
-                    {showLoadingState && (
+                    {!showBootstrapLoadingState && !showBootstrapErrorState && showLoadingState && (
                         <PageState
                             tone="loading"
                             title={t('page.duty.loading')}
@@ -96,7 +115,11 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                             className="py-0"
                         />
                     )}
-                    {state.shiftTeamsStatus === 'success' && state.shiftTeams.length > 0 && state.status === 'error' && (
+                    {!showBootstrapLoadingState &&
+                        !showBootstrapErrorState &&
+                        state.shiftTeamsStatus === 'success' &&
+                        state.shiftTeams.length > 0 &&
+                        state.status === 'error' && (
                         <PageState
                             tone="error"
                             title={t('page.duty.error')}
@@ -105,7 +128,12 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                             className="py-0"
                         />
                     )}
-                    {state.shiftTeamsStatus === 'success' && state.shiftTeams.length > 0 && state.status === 'success' && !state.shift && (
+                    {!showBootstrapLoadingState &&
+                        !showBootstrapErrorState &&
+                        state.shiftTeamsStatus === 'success' &&
+                        state.shiftTeams.length > 0 &&
+                        state.status === 'success' &&
+                        !state.shift && (
                         <PageState
                             tone="empty"
                             title={t('page.duty.emptyTitle', {teamName: state.currentShiftTeamName, month: state.month})}
@@ -119,7 +147,7 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                             </div>
                         </PageState>
                     )}
-                    {state.status === 'success' && state.shift && (
+                    {!showBootstrapLoadingState && !showBootstrapErrorState && state.status === 'success' && state.shift && (
                         <div
                             ref={refs.editorRef}
                             className="outline-none"


### PR DESCRIPTION
## 요약
- request, duty 페이지에서 인증 초기화 로딩과 화면 데이터 로딩을 분리했습니다.
- 계정 또는 병동 초기화에 실패하면 무한 로딩 대신 재시도 가능한 에러 상태를 표시하도록 변경했습니다.
- request, duty, register 페이지의 초기화 상태를 검증하는 회귀 테스트를 추가했습니다.

## 테스트
- pnpm --filter @dutying/app test:run -- src/pages/RequestShiftPage/index.test.tsx src/pages/duty/model/dutyHook.test.tsx src/pages/duty/model/dutyHook.integration.test.tsx src/pages/RegisterPage/index.test.tsx
- pnpm --filter @dutying/app type-check