### PR TITLE
[DUT-918]: 프로필 이미지 fallback 및 프로필 페이지 정리

### DIFF
--- a/apps/app/src/entities/account/ui/profile-image/__tests__/index.test.tsx
+++ b/apps/app/src/entities/account/ui/profile-image/__tests__/index.test.tsx
@@ -1,0 +1,60 @@
+import {fireEvent} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen} from '@/shared/util/test-utils';
+import {ProfileImage} from '..';
+
+vi.mock('@/shared/config/runtime', () => ({
+    RUNTIME_CONFIG: {
+        profileImageBaseUrl: () => 'https://cdn.example.com',
+    },
+}));
+
+describe('ProfileImage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('업로드 이미지가 실패하면 기본 프로필 이미지로 fallback 한다', () => {
+        render(
+            <ProfileImage
+                name="홍길동"
+                className="h-10 w-10"
+                profileImg={{
+                    profileImgUrl: 'https://cdn.example.com/custom/profile.png',
+                    defaultProfileImgId: 2,
+                }}
+            />,
+        );
+
+        const image = screen.getByRole('img', {name: '홍길동 프로필 이미지'});
+
+        expect(image).toHaveAttribute('src', 'https://cdn.example.com/custom/profile.png');
+
+        fireEvent.error(image);
+
+        expect(screen.getByRole('img', {name: '홍길동 프로필 이미지'})).toHaveAttribute(
+            'src',
+            'https://cdn.example.com/profile_img/default/profile2.png',
+        );
+    });
+
+    it('모든 이미지 소스가 실패하면 이니셜 placeholder를 보여준다', () => {
+        render(
+            <ProfileImage
+                name="홍길동"
+                className="h-10 w-10"
+                profileImg={{
+                    profileImgUrl: 'https://cdn.example.com/custom/profile.png',
+                }}
+            />,
+        );
+
+        fireEvent.error(screen.getByRole('img', {name: '홍길동 프로필 이미지'}));
+        fireEvent.error(screen.getByRole('img', {name: '홍길동 프로필 이미지'}));
+
+        const fallback = screen.getByRole('img', {name: '홍길동 프로필 이미지'});
+
+        expect(fallback.tagName).toBe('DIV');
+        expect(fallback).toHaveTextContent('홍');
+    });
+});

--- a/apps/app/src/entities/account/ui/profile-image/index.tsx
+++ b/apps/app/src/entities/account/ui/profile-image/index.tsx
@@ -1,19 +1,54 @@
 import {cn} from '@dutying/utils/style';
-import {useProfileImageStore} from '@/features/file/store';
+import {useEffect, useState} from 'react';
+import {PersonIcon} from '@/shared/assets/svg';
+import {RUNTIME_CONFIG} from '@/shared/config/runtime';
+import {getProfileImageFallbackText, getProfileImageSources, type TProfileImageValue} from './model';
 
-interface IProfileImageProps extends Omit<React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>, 'type'> {
-    profileImg: {profileImgUrl?: string; defaultProfileImgId?: number};
+interface IProfileImageProps
+    extends Omit<React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>, 'src' | 'type'> {
+    profileImg?: TProfileImageValue;
+    name?: string;
 }
 
-export const ProfileImage = ({profileImg, ...props}: IProfileImageProps) => {
-    const {imageBaseUrl} = useProfileImageStore();
+export const ProfileImage = ({profileImg, name, className, alt, onError, ...props}: IProfileImageProps) => {
+    const imageBaseUrl = RUNTIME_CONFIG.profileImageBaseUrl();
+    const [failedSources, setFailedSources] = useState<string[]>([]);
+    const imageSources = getProfileImageSources({profileImg, imageBaseUrl});
+    const currentSource = imageSources.find((source) => !failedSources.includes(source));
+    const accessibleAlt = alt ?? `${name?.trim() ?? '사용자'} 프로필 이미지`;
+    const fallbackText = getProfileImageFallbackText(name);
+
+    useEffect(() => {
+        setFailedSources([]);
+    }, [imageBaseUrl, profileImg?.defaultProfileImgId, profileImg?.profileImgUrl]);
+
+    if (!currentSource) {
+        return (
+            <div
+                role="img"
+                aria-label={accessibleAlt}
+                className={cn('flex items-center justify-center rounded-full bg-sub-3 text-white', className)}
+            >
+                {fallbackText ? (
+                    <span className="font-apple text-[clamp(1.125rem,3vw,2.5rem)] font-semibold">{fallbackText}</span>
+                ) : (
+                    <PersonIcon className="h-[46%] w-[46%]" aria-hidden="true" />
+                )}
+            </div>
+        );
+    }
 
     return (
         <img
-            className={cn('rounded-full object-cover object-center', props.className)}
-            alt="profile image"
-            // TODO: 추후 fallback 추가 필요
-            src={profileImg.profileImgUrl ?? `${imageBaseUrl}/profile_img/default/profile${profileImg.defaultProfileImgId}.png`}
+            className={cn('rounded-full object-cover object-center', className)}
+            alt={accessibleAlt}
+            src={currentSource}
+            onError={(event) => {
+                onError?.(event);
+                setFailedSources((prevFailedSources) =>
+                    prevFailedSources.includes(currentSource) ? prevFailedSources : [...prevFailedSources, currentSource],
+                );
+            }}
             {...props}
         />
     );

--- a/apps/app/src/entities/account/ui/profile-image/model.ts
+++ b/apps/app/src/entities/account/ui/profile-image/model.ts
@@ -1,0 +1,49 @@
+export type TProfileImageValue = {
+    profileImgUrl?: string;
+    defaultProfileImgId?: number;
+};
+
+type TGetProfileImageSourcesArgs = {
+    profileImg?: TProfileImageValue;
+    imageBaseUrl?: string;
+};
+
+const DEFAULT_PROFILE_IMG_ID = 1;
+const normalizeSource = (source?: string) => {
+    const trimmedSource = source?.trim();
+
+    return trimmedSource === '' ? undefined : trimmedSource;
+};
+const getDefaultProfileImageSource = ({defaultProfileImgId, imageBaseUrl}: {defaultProfileImgId?: number; imageBaseUrl?: string}) => {
+    if (defaultProfileImgId === undefined || defaultProfileImgId < 1) return undefined;
+
+    const normalizedImageBaseUrl = normalizeSource(imageBaseUrl);
+
+    if (!normalizedImageBaseUrl) return undefined;
+
+    return `${normalizedImageBaseUrl}/profile_img/default/profile${defaultProfileImgId}.png`;
+};
+
+export const getProfileImageSources = ({profileImg, imageBaseUrl}: TGetProfileImageSourcesArgs): string[] => {
+    const explicitProfileImage = normalizeSource(profileImg?.profileImgUrl);
+    const selectedDefaultImage = getDefaultProfileImageSource({
+        defaultProfileImgId: profileImg?.defaultProfileImgId,
+        imageBaseUrl,
+    });
+    const fallbackDefaultImage = getDefaultProfileImageSource({
+        defaultProfileImgId: DEFAULT_PROFILE_IMG_ID,
+        imageBaseUrl,
+    });
+
+    return [explicitProfileImage, selectedDefaultImage, fallbackDefaultImage].filter((source, index, sources): source is string => {
+        return Boolean(source) && sources.indexOf(source) === index;
+    });
+};
+
+export const getProfileImageFallbackText = (name?: string) => {
+    const firstCharacter = Array.from(name?.trim() ?? '')[0];
+
+    if (!firstCharacter) return '';
+
+    return /^[a-z]$/i.test(firstCharacter) ? firstCharacter.toUpperCase() : firstCharacter;
+};

--- a/apps/app/src/features/account/useEditAccount.ts
+++ b/apps/app/src/features/account/useEditAccount.ts
@@ -18,7 +18,7 @@ const useEditAccount = () => {
     const {setLoading} = useLoadingUseCase();
     const queryClient = useQueryClient();
     const handleEditProfile = async (nurse: TNurse, profileImg: {profileImgUrl?: string; defaultProfileImgId?: number}) => {
-        if (!accountMe) return;
+        if (!accountMe) return false;
 
         try {
             setLoading(true);
@@ -28,14 +28,20 @@ const useEditAccount = () => {
                 name: nurse.name,
                 ...profileImg,
             });
+
             await queryClient.invalidateQueries({queryKey: getWardQueryKey});
             await handleGetAccountMe();
+
+            return true;
         } catch (e) {
             Sentry.captureException(e, {
                 tags: {feature: 'account', action: 'edit-profile'},
                 extra: {nurseId: nurse.nurseId, accountId: accountMe.accountId},
             });
-            toast.error('프로필 업데이트에 실패했습니다..');
+
+            toast.error('프로필 업데이트에 실패했습니다.');
+
+            return false;
         } finally {
             setLoading(false);
         }

--- a/apps/app/src/features/file/useProfileImage.ts
+++ b/apps/app/src/features/file/useProfileImage.ts
@@ -33,12 +33,16 @@ const useProfileImage = (initialImg?: {profileImgUrl?: string; defaultProfileImg
             setIsLoading(false);
         }
     };
+    const resetProfileImage = (nextProfileImg?: {profileImgUrl?: string; defaultProfileImgId?: number}) => {
+        setProfileImg(nextProfileImg);
+    };
 
     return {
         profileImg,
         isLoading,
         setRandomImage,
         setPhotoImage,
+        resetProfileImage,
     };
 };
 

--- a/apps/app/src/pages/OnboardingWardCreatePage/__tests__/index.test.tsx
+++ b/apps/app/src/pages/OnboardingWardCreatePage/__tests__/index.test.tsx
@@ -295,7 +295,7 @@ describe('OnboardingWardCreatePage', () => {
         await user.click(screen.getByRole('button', {name: '근무표 만들러 가기'}));
 
         expect(mockNavigate).toHaveBeenCalledWith('/make');
-    });
+    }, 10_000);
 
     it('shows retryable error UI when ward creation fails', async () => {
         const user = userEvent.setup();

--- a/apps/app/src/pages/ProfilePage/__tests__/model.test.ts
+++ b/apps/app/src/pages/ProfilePage/__tests__/model.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it} from 'vitest';
+import type {TAccount} from '@/entities/account';
+import type {TNurse} from '@/entities/nurse';
+import type {TWard} from '@/entities/ward';
+import {findProfileNurse, getCurrentProfileImage, getProfileDisplayName, isProfileFormDirty} from '../model';
+
+const baseNurse: TNurse = {
+    nurseId: 11,
+    accountId: 7,
+    shiftTeamId: 3,
+    wardId: 1,
+    name: '홍길동',
+    phoneNum: '01012341234',
+    isConnected: true,
+    nurseShiftTypes: [],
+    isWorker: true,
+    isDutyManager: false,
+    isWardManager: false,
+    gender: '여',
+    employmentDate: '2023-03-01',
+    memo: '',
+    isDeleted: false,
+    divisionNum: 1,
+    priority: 1,
+};
+
+describe('ProfilePage model', () => {
+    it('현재 로그인한 accountId로 내 nurse 정보를 찾는다', () => {
+        const ward: TWard = {
+            wardId: 1,
+            name: '중환자실',
+            hospitalName: '듀티병원',
+            code: 'WARD123',
+            nurseCnt: 1,
+            wardShiftTypes: [],
+            shiftTeams: [{shiftTeamId: 3, name: 'A팀', nurseCnt: 1, nurses: [baseNurse]}],
+        };
+
+        expect(findProfileNurse(ward, 7)?.nurseId).toBe(11);
+        expect(findProfileNurse(ward, 99)).toBeNull();
+    });
+
+    it('성별 변경도 저장 가능 상태로 판단한다', () => {
+        const draftNurse = {...baseNurse, gender: '남'};
+
+        expect(
+            isProfileFormDirty({
+                originalNurse: baseNurse,
+                draftNurse,
+            }),
+        ).toBe(true);
+    });
+
+    it('새 프로필 이미지가 있으면 폼 변경으로 판단한다', () => {
+        expect(
+            isProfileFormDirty({
+                originalNurse: baseNurse,
+                draftNurse: baseNurse,
+                profileImg: {defaultProfileImgId: 2},
+            }),
+        ).toBe(true);
+    });
+
+    it('계정 이미지가 없으면 빈 프로필 이미지 값을 돌려준다', () => {
+        expect(getCurrentProfileImage(null)).toEqual({});
+    });
+
+    it('표시 이름은 nurse 초안, 계정 이름 순으로 fallback 한다', () => {
+        const account = {name: '계정 이름'} as TAccount;
+
+        expect(getProfileDisplayName(baseNurse, account)).toBe('홍길동');
+        expect(getProfileDisplayName(null, account)).toBe('계정 이름');
+        expect(getProfileDisplayName(null, null)).toBe('이름 미등록');
+    });
+});

--- a/apps/app/src/pages/ProfilePage/__tests__/model.test.ts
+++ b/apps/app/src/pages/ProfilePage/__tests__/model.test.ts
@@ -72,4 +72,11 @@ describe('ProfilePage model', () => {
         expect(getProfileDisplayName(null, account)).toBe('계정 이름');
         expect(getProfileDisplayName(null, null)).toBe('이름 미등록');
     });
+
+    it('공백 이름은 비어 있는 값으로 보고 다음 fallback 으로 넘긴다', () => {
+        const account = {name: '  계정 이름  '} as TAccount;
+
+        expect(getProfileDisplayName({...baseNurse, name: '   '}, account)).toBe('계정 이름');
+        expect(getProfileDisplayName({...baseNurse, name: '   '}, {name: '   '} as TAccount)).toBe('이름 미등록');
+    });
 });

--- a/apps/app/src/pages/ProfilePage/index.tsx
+++ b/apps/app/src/pages/ProfilePage/index.tsx
@@ -1,58 +1,93 @@
+import {useQuery} from '@tanstack/react-query';
 import imageCompression from 'browser-image-compression';
 import {type ChangeEvent, useEffect, useRef, useState} from 'react';
 import toast from 'react-hot-toast';
 import {ProfileImage} from '@/entities/account/ui/profile-image';
 import {type TNurse} from '@/entities/nurse';
+import {wardQueryOptions} from '@/entities/ward';
 import useEditAccount from '@/features/account/useEditAccount';
 import useAuth from '@/features/auth/useAuth';
 import useProfileImage from '@/features/file/useProfileImage';
-import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
 import {CameraIcon, CheckedIcon, RandomIcon, UncheckedIcon} from '@/shared/assets/svg';
 import ROUTE from '@/shared/constant/path';
 import Button from '@/shared/ui/form-controls/Button';
 import Select from '@/shared/ui/form-controls/Select';
 import TextField from '@/shared/ui/form-controls/TextField';
+import PageState from '@/shared/ui/PageState';
+import {findProfileNurse, getCurrentProfileImage, getProfileDisplayName, isProfileFormDirty} from './model';
 
 function ProfilePage() {
     const {
-        state: {shiftTeams, selectedNurse},
-        actions: {selectNurse},
-    } = useEditShiftTeam();
-    const {
-        state: {accountMe},
-        actions: {handleLogout},
+        state: {accountMe, accountMeStatus, _loaded},
+        actions: {handleGetAccountMe, handleLogout},
     } = useAuth();
     const {handleEditProfile, deleteAccount, quitWard} = useEditAccount();
     const [writeNurse, setWriteNurse] = useState<TNurse | null>(null);
-    const {profileImg, setRandomImage, setPhotoImage} = useProfileImage();
+    const {profileImg, isLoading: isProfileImageLoading, setRandomImage, setPhotoImage, resetProfileImage} = useProfileImage();
+    const wardQuery = useQuery({
+        ...wardQueryOptions.id(accountMe?.wardId ?? 0),
+        enabled: Boolean(accountMe?.wardId),
+    });
+    const selectedNurse = findProfileNurse(wardQuery.data, accountMe?.accountId);
+    const displayName = getProfileDisplayName(writeNurse, accountMe);
+    const currentProfileImage = getCurrentProfileImage(accountMe, profileImg);
+    const isAccountBootstrapPending = !_loaded || accountMeStatus === 'idle' || accountMeStatus === 'loading';
+    const isAccountBootstrapError = accountMeStatus === 'error';
+    const isWardProfilePending = Boolean(accountMe?.wardId) && wardQuery.isPending && !selectedNurse;
+    const isWardProfileError = Boolean(accountMe?.wardId) && wardQuery.isError && !selectedNurse;
+    const isSaveDisabled =
+        !isProfileFormDirty({
+            originalNurse: selectedNurse,
+            draftNurse: writeNurse,
+            profileImg,
+        }) || isProfileImageLoading;
     const handleChange = <T extends keyof TNurse>(key: T, value: TNurse[T]) => {
         if (!writeNurse) return;
 
         setWriteNurse({...writeNurse, [key]: value});
     };
-    const save = () => {
-        if (!writeNurse || !profileImg) return;
+    const save = async () => {
+        if (!writeNurse) return;
 
-        handleEditProfile(writeNurse, profileImg);
+        const isSaved = await handleEditProfile(writeNurse, currentProfileImage);
+
+        if (isSaved) {
+            resetProfileImage();
+        }
     };
 
     useEffect(() => {
-        if (shiftTeams && accountMe)
-            selectNurse(shiftTeams.flatMap((x) => x.nurses).find((x) => x.accountId === accountMe.accountId)?.nurseId ?? null);
-    }, [accountMe, selectNurse, shiftTeams]);
+        if (!selectedNurse) {
+            setWriteNurse(null);
 
-    useEffect(() => {
-        if (selectedNurse && accountMe && selectedNurse?.accountId === accountMe?.accountId) {
-            setWriteNurse(selectedNurse);
+            return;
         }
-    }, [selectedNurse, accountMe]);
+
+        setWriteNurse((prevWriteNurse) => {
+            if (!prevWriteNurse) return selectedNurse;
+
+            if (prevWriteNurse.nurseId !== selectedNurse.nurseId) return selectedNurse;
+
+            return isProfileFormDirty({
+                originalNurse: selectedNurse,
+                draftNurse: prevWriteNurse,
+                profileImg,
+            })
+                ? prevWriteNurse
+                : selectedNurse;
+        });
+    }, [profileImg, selectedNurse]);
 
     const imageInputRef = useRef<HTMLInputElement>(null);
-    const handleUploadImgae = () => {
+    const handleUploadImage = () => {
         imageInputRef.current?.click();
     };
     const handleChangeImage = async (e: ChangeEvent<HTMLInputElement>) => {
-        if (!e.target.files || e.target.files.length < 1) return;
+        if (!e.target.files || e.target.files.length < 1) {
+            e.target.value = '';
+
+            return;
+        }
 
         const options = {
             maxSizeMB: 1,
@@ -63,17 +98,83 @@ function ProfilePage() {
         try {
             const compressedFile = await imageCompression(e.target.files[0], options);
 
-            setPhotoImage(compressedFile);
+            await setPhotoImage(compressedFile);
         } catch (_error) {
             toast.error('프로필 이미지 처리에 실패했습니다.');
+        } finally {
+            e.target.value = '';
+        }
+    };
+    const retryProfilePage = () => {
+        void handleGetAccountMe().catch(() => undefined);
+
+        if (accountMe?.wardId) {
+            void wardQuery.refetch();
         }
     };
 
+    if (isAccountBootstrapPending || isWardProfilePending) {
+        return (
+            <div className="mx-auto flex h-full w-full max-w-306 items-center justify-center px-8">
+                <PageState
+                    tone="loading"
+                    title="프로필 정보를 준비하고 있어요"
+                    description="내 계정과 병동 정보를 순서대로 확인하고 있어요."
+                    className="py-0"
+                />
+            </div>
+        );
+    }
+
+    if (isAccountBootstrapError || isWardProfileError || !accountMe) {
+        return (
+            <div className="mx-auto flex h-full w-full max-w-306 items-center justify-center px-8">
+                <PageState
+                    tone="error"
+                    title="프로필 정보를 불러오지 못했어요"
+                    description="잠시 후 다시 시도해 주세요. 문제가 계속되면 다시 로그인해 주세요."
+                    action={{label: '다시 시도', onClick: retryProfilePage}}
+                    className="py-0"
+                />
+            </div>
+        );
+    }
+
+    if (!accountMe.wardId || !selectedNurse || !writeNurse) {
+        return (
+            <div className="mx-auto flex h-full w-full max-w-306 items-center justify-center px-8">
+                <PageState
+                    tone="empty"
+                    title={!accountMe.wardId ? '소속 병동 정보가 아직 없어요' : '내 프로필 정보를 아직 연결하지 못했어요'}
+                    description={
+                        !accountMe.wardId
+                            ? '병동 연결이 완료되면 프로필 설정을 계속할 수 있어요.'
+                            : '병동에 연결된 내 nurse 정보를 찾지 못했어요. 계정 연결 상태를 확인해 주세요.'
+                    }
+                    action={{label: '다시 불러오기', onClick: retryProfilePage}}
+                    className="py-0"
+                >
+                    <div className="rounded-[20px] border border-gray-6 bg-white px-6 py-5">
+                        <div className="mx-auto h-20 w-20 rounded-full border-[.375rem] border-sub-4">
+                            <ProfileImage className="h-full w-full" name={accountMe.name} profileImg={currentProfileImage} />
+                        </div>
+                        <p className="mt-4 font-apple text-[1.25rem] font-semibold text-sub-1">{accountMe.name || '이름 미등록'}</p>
+                        <p className="mt-1 font-apple text-[0.9375rem] text-gray-3">{accountMe.email}</p>
+                    </div>
+                </PageState>
+            </div>
+        );
+    }
+
     return (
         <div className="mx-auto flex h-full w-full max-w-306 flex-col items-center justify-center px-8">
-            <div className="flex w-full items-center justify-between">
-                <h1 className="font-apple text-[2rem] font-semibold text-text-1">프로필 설정</h1>
+            <div className="flex w-full items-start justify-between gap-6">
+                <div>
+                    <h1 className="font-apple text-[2rem] font-semibold text-text-1">프로필 설정</h1>
+                    <p className="mt-2 font-apple text-[1rem] leading-6 text-gray-3">프로필 이미지와 기본 정보를 확인하고 저장해 주세요.</p>
+                </div>
                 <button
+                    type="button"
                     className="flex h-10 items-center justify-center rounded-[1.875rem] border-[.0625rem] border-sub-3 bg-white px-4 font-apple text-[1.4375rem] font-medium text-sub-3"
                     onClick={() => handleLogout(ROUTE.ROOT)}
                 >
@@ -84,25 +185,38 @@ function ProfilePage() {
                 <div className="flex flex-col items-center gap-7.5">
                     <div className="self-start font-apple text-[1.25rem] text-sub-3">프로필 이미지</div>
                     <div className="h-35 w-35 rounded-full border-[.625rem] border-sub-4">
-                        <ProfileImage className="h-full w-full" profileImg={profileImg ?? {profileImgUrl: accountMe?.profileImgUrl}} />
+                        <ProfileImage className="h-full w-full" name={displayName} profileImg={currentProfileImage} />
                     </div>
-                    <div className="flex h-10.5 w-67.5 cursor-pointer">
-                        <div
-                            className="flex flex-1 items-center justify-center gap-[.25rem] rounded-l-[.3125rem] border-[.0625rem] border-r-0 border-sub-3"
+                    <div className="text-center">
+                        <p className="font-apple text-[1.5rem] font-semibold text-sub-1">{displayName}</p>
+                        <p className="mt-1 font-apple text-[1rem] text-gray-3">{accountMe.email}</p>
+                    </div>
+                    <div className="flex h-10.5 w-67.5">
+                        <button
+                            type="button"
+                            className="flex flex-1 items-center justify-center gap-[.25rem] rounded-l-[.3125rem] border-[.0625rem] border-r-0 border-sub-3 disabled:cursor-not-allowed disabled:opacity-50"
                             onClick={setRandomImage}
+                            disabled={isProfileImageLoading}
                         >
                             <RandomIcon className="h-5 w-5" />
                             <p className="font-apple text-[1.25rem] font-medium text-sub-2.5">랜덤 변경</p>
-                        </div>
-                        <div
-                            className="flex flex-1 items-center justify-center gap-[.25rem] rounded-r-[.3125rem] border-[.0625rem] border-sub-3"
-                            onClick={handleUploadImgae}
+                        </button>
+                        <button
+                            type="button"
+                            className="flex flex-1 items-center justify-center gap-[.25rem] rounded-r-[.3125rem] border-[.0625rem] border-sub-3 disabled:cursor-not-allowed disabled:opacity-50"
+                            onClick={handleUploadImage}
+                            disabled={isProfileImageLoading}
                         >
                             <CameraIcon className="h-5" />
                             <p className="font-apple text-[1.25rem] font-medium text-sub-2.5">사진 등록</p>
                             <input ref={imageInputRef} type="file" className="hidden" onChange={handleChangeImage} accept="image/*" />
-                        </div>
+                        </button>
                     </div>
+                    <p className="max-w-67.5 text-center font-apple text-[0.875rem] leading-6 text-gray-3">
+                        {isProfileImageLoading
+                            ? '새 이미지를 업로드하고 있어요. 완료되면 미리보기에 바로 반영돼요.'
+                            : '이미지가 없거나 불러오지 못하면 기본 프로필 이미지 또는 이니셜을 보여드려요.'}
+                    </p>
                 </div>
                 <div className="ml-21 flex flex-col justify-between">
                     <div>
@@ -112,7 +226,7 @@ function ProfilePage() {
                         <TextField
                             id="name"
                             className="h-15 py-4.25 font-apple text-[1.5rem] font-medium text-sub-1"
-                            value={writeNurse?.name}
+                            value={writeNurse.name ?? ''}
                             onChange={(e) => handleChange('name', e.target.value)}
                             // error={match(errors.name?.type)
                             //   .with(
@@ -131,7 +245,7 @@ function ProfilePage() {
                                 id="gender"
                                 className="h-15 w-full font-apple text-[1.5rem] font-medium text-sub-1"
                                 selectClassName="outline-sub-4 focus:outline-main-1"
-                                value={writeNurse?.gender}
+                                value={writeNurse.gender ?? '여'}
                                 onChange={(e) => handleChange('gender', e.target.value)}
                                 options={[
                                     {label: '여', value: '여'},
@@ -146,7 +260,7 @@ function ProfilePage() {
                             <TextField
                                 id="phoneNum"
                                 className="h-15 py-4.25 font-apple text-[1.5rem] font-medium text-sub-1"
-                                value={writeNurse?.phoneNum}
+                                value={writeNurse.phoneNum ?? ''}
                                 onChange={(e) => handleChange('phoneNum', e.target.value)}
                                 // error={match(errors.phoneNum?.type)
                                 //   .with('matches', () => '전화번호 형식을 지켜주세요.')
@@ -167,7 +281,7 @@ function ProfilePage() {
                         id="employmentDate"
                         placeholder="YYYY-MM-DD"
                         className="h-15 py-4.25 font-apple text-[1.5rem] font-medium text-sub-1 placeholder:text-center"
-                        value={writeNurse?.employmentDate}
+                        value={writeNurse.employmentDate ?? ''}
                         onChange={(e) => handleChange('employmentDate', e.target.value)}
                         // error={match(errors.employmentDate?.type)
                         //   .with('matches', () => 'YYYY.MM.DD 형식으로 입력해주세요.')
@@ -181,48 +295,56 @@ function ProfilePage() {
                         <p className="font-apple text-[.875rem] text-main-2">* 근무표에 본인이 표시되나요?</p>
                     </div>
                     <div className="ml-21 flex gap-7.5">
-                        <div className="flex cursor-pointer items-center justify-center" onClick={() => handleChange('isWorker', true)}>
-                            {writeNurse?.isWorker ? <CheckedIcon className="h-7.5 w-7.5" /> : <UncheckedIcon className="h-7.5 w-7.5" />}
+                        <button
+                            type="button"
+                            className="flex cursor-pointer items-center justify-center"
+                            onClick={() => handleChange('isWorker', true)}
+                            aria-pressed={writeNurse.isWorker}
+                        >
+                            {writeNurse.isWorker ? <CheckedIcon className="h-7.5 w-7.5" /> : <UncheckedIcon className="h-7.5 w-7.5" />}
                             <div className="ml-[.625rem] flex items-center font-apple text-[1.25rem] font-normal text-sub-3">네</div>
-                        </div>
-                        <div className="flex cursor-pointer items-center justify-center" onClick={() => handleChange('isWorker', false)}>
-                            {!writeNurse?.isWorker ? <CheckedIcon className="h-7.5 w-7.5" /> : <UncheckedIcon className="h-7.5 w-7.5" />}
+                        </button>
+                        <button
+                            type="button"
+                            className="flex cursor-pointer items-center justify-center"
+                            onClick={() => handleChange('isWorker', false)}
+                            aria-pressed={!writeNurse.isWorker}
+                        >
+                            {!writeNurse.isWorker ? <CheckedIcon className="h-7.5 w-7.5" /> : <UncheckedIcon className="h-7.5 w-7.5" />}
                             <div className="ml-[.625rem] flex items-center font-apple text-[1.25rem] font-normal text-sub-3">아니오</div>
-                        </div>
+                        </button>
                     </div>
                 </div>
             </div>
             <div className="mt-10 flex w-full items-start justify-between">
                 <div className="flex flex-col gap-4">
-                    <div
+                    <button
+                        type="button"
                         className="cursor-pointer font-apple text-[1.25rem] font-medium text-sub-2.5 underline underline-offset-2"
                         onClick={deleteAccount}
                     >
                         회원 탈퇴
-                    </div>
-                    <div
+                    </button>
+                    <button
+                        type="button"
                         className="cursor-pointer font-apple text-[1.25rem] font-medium text-sub-2.5 underline underline-offset-2"
                         onClick={quitWard}
                     >
                         병동 나가기
-                    </div>
+                    </button>
                 </div>
-                <Button
-                    onClick={() => save()}
-                    className="h-15 w-30 text-center text-[2rem] font-semibold"
-                    disabled={
-                        selectedNurse?.name === writeNurse?.name &&
-                        selectedNurse?.employmentDate === writeNurse?.employmentDate &&
-                        selectedNurse?.phoneNum === writeNurse?.phoneNum &&
-                        selectedNurse?.isWorker === writeNurse?.isWorker &&
-                        selectedNurse?.isDutyManager === writeNurse?.isDutyManager &&
-                        selectedNurse?.memo === writeNurse?.memo &&
-                        selectedNurse?.nurseShiftTypes.length === writeNurse?.nurseShiftTypes.length &&
-                        !profileImg
-                    }
-                >
-                    저장
-                </Button>
+                <div className="flex flex-col items-end gap-3">
+                    {isProfileImageLoading ? (
+                        <p className="font-apple text-[0.9375rem] text-gray-3">이미지 업로드가 끝나면 저장할 수 있어요.</p>
+                    ) : null}
+                    <Button
+                        onClick={() => void save()}
+                        className="h-15 w-30 text-center text-[2rem] font-semibold"
+                        disabled={isSaveDisabled}
+                    >
+                        저장
+                    </Button>
+                </div>
             </div>
         </div>
     );

--- a/apps/app/src/pages/ProfilePage/model.ts
+++ b/apps/app/src/pages/ProfilePage/model.ts
@@ -4,6 +4,11 @@ import type {TNurse} from '@/entities/nurse';
 import type {TWard} from '@/entities/ward';
 
 const editableProfileFields = ['name', 'gender', 'phoneNum', 'employmentDate', 'isWorker'] as const;
+const getMeaningfulDisplayName = (name?: string | null) => {
+    const trimmedName = name?.trim();
+
+    return trimmedName === '' ? undefined : trimmedName;
+};
 
 export const findProfileNurse = (ward: TWard | undefined, accountId: number | null | undefined) => {
     if (!ward || !accountId) return null;
@@ -34,8 +39,8 @@ export const getCurrentProfileImage = (account: TAccount | null, profileImg?: TP
 };
 
 export const getProfileDisplayName = (draftNurse: TNurse | null, account: TAccount | null) => {
-    const draftName = draftNurse?.name?.trim();
-    const accountName = account?.name?.trim();
+    const draftName = getMeaningfulDisplayName(draftNurse?.name);
+    const accountName = getMeaningfulDisplayName(account?.name);
 
     return draftName ?? accountName ?? '이름 미등록';
 };

--- a/apps/app/src/pages/ProfilePage/model.ts
+++ b/apps/app/src/pages/ProfilePage/model.ts
@@ -1,0 +1,41 @@
+import type {TAccount} from '@/entities/account';
+import type {TProfileImageValue} from '@/entities/account/ui/profile-image/model';
+import type {TNurse} from '@/entities/nurse';
+import type {TWard} from '@/entities/ward';
+
+const editableProfileFields = ['name', 'gender', 'phoneNum', 'employmentDate', 'isWorker'] as const;
+
+export const findProfileNurse = (ward: TWard | undefined, accountId: number | null | undefined) => {
+    if (!ward || !accountId) return null;
+
+    return ward.shiftTeams.flatMap((shiftTeam) => shiftTeam.nurses).find((nurse) => nurse.accountId === accountId) ?? null;
+};
+
+export const isProfileFormDirty = ({
+    originalNurse,
+    draftNurse,
+    profileImg,
+}: {
+    originalNurse: TNurse | null;
+    draftNurse: TNurse | null;
+    profileImg?: TProfileImageValue;
+}) => {
+    if (!originalNurse || !draftNurse) return false;
+
+    return editableProfileFields.some((field) => originalNurse[field] !== draftNurse[field]) || Boolean(profileImg);
+};
+
+export const getCurrentProfileImage = (account: TAccount | null, profileImg?: TProfileImageValue): TProfileImageValue => {
+    if (profileImg) return profileImg;
+
+    if (account?.profileImgUrl) return {profileImgUrl: account.profileImgUrl};
+
+    return {};
+};
+
+export const getProfileDisplayName = (draftNurse: TNurse | null, account: TAccount | null) => {
+    const draftName = draftNurse?.name?.trim();
+    const accountName = account?.name?.trim();
+
+    return draftName ?? accountName ?? '이름 미등록';
+};


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-918](https://gom3.atlassian.net/browse/DUT-918)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `ProfileImage`에 업로드 이미지 실패 -> 기본 프로필 이미지 -> 이니셜 placeholder 순서의 fallback을 추가했습니다.
- `ProfilePage`를 ward query 기반으로 정리하고 loading/error/empty 상태를 `PageState`로 분리했습니다.
- 프로필 이미지 업로드 중 액션 제어, 저장 가능 조건 계산, 관련 model/unit test를 추가했습니다.

<br>

## To Reviewers

- `accountMe.profileImgUrl`이 기본 이미지 선택 후 최신 URL로 정상 반영되는지 한 번 확인해 주세요.
- ProfilePage는 전면 리디자인 대신 기존 레이아웃 안에서 상태 표현과 예외 처리를 정리한 변경입니다.

[DUT-918]: https://gom3.atlassian.net/browse/DUT-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ