### PR TITLE
[DUT-915]: useRequestShift hook 분리 및 순수화

### DIFF
--- a/apps/app/src/features/shift/useRequestShift/__tests__/model.test.ts
+++ b/apps/app/src/features/shift/useRequestShift/__tests__/model.test.ts
@@ -1,0 +1,204 @@
+import {describe, expect, it} from 'vitest';
+import type {TDutyRequest, TRequestShift} from '@/entities/shift';
+import {
+    createInitialFoldedLevels,
+    createWardShiftTypeMap,
+    findDutyRequestByFocus,
+    getAdjacentRequestShiftDate,
+    getRequestShiftBootstrapStatus,
+    getRequestShiftChangeEventMessage,
+    getRequestShiftMonthChangeDecision,
+    getRequestShiftTypeIdAtFocus,
+    shouldResetFoldedLevelsOnRequestLoad,
+    shouldSyncFoldedLevelsLength,
+} from '../model';
+import {getRequestShiftEditAvailability} from '../utils';
+
+const requestShiftFixture: TRequestShift = {
+    days: [{day: 1, dayType: 'workday'}],
+    wardShiftTypes: [
+        {
+            wardShiftTypeId: 11,
+            name: 'Day',
+            shortName: 'D',
+            startTime: '07:00',
+            endTime: '15:00',
+            color: '#111111',
+            isDefault: true,
+            isOff: false,
+            isCounted: true,
+            classification: 'DAY',
+        },
+        {
+            wardShiftTypeId: 12,
+            name: 'Night',
+            shortName: 'N',
+            startTime: '22:00',
+            endTime: '07:00',
+            color: '#222222',
+            isDefault: false,
+            isOff: false,
+            isCounted: true,
+            classification: 'NIGHT',
+        },
+    ],
+    divisionShiftNurses: [
+        [
+            {
+                shiftNurse: {
+                    shiftNurseId: 101,
+                    nurseId: 1001,
+                    name: '황인서',
+                    carried: 0,
+                    divisionNum: 1,
+                    priority: 1,
+                    isWorker: true,
+                },
+                carry: 0,
+                wardReqShiftList: [11],
+            },
+        ],
+        [
+            {
+                shiftNurse: {
+                    shiftNurseId: 102,
+                    nurseId: 1002,
+                    name: '김간호',
+                    carried: 0,
+                    divisionNum: 2,
+                    priority: 2,
+                    isWorker: true,
+                },
+                carry: 0,
+                wardReqShiftList: [null],
+            },
+        ],
+    ],
+};
+const dutyRequestFixture: TDutyRequest[] = [
+    {
+        wardReqShiftId: 301,
+        nurseId: 1001,
+        nurseName: '황인서',
+        date: 0,
+        requestDate: '2026-03-20T00:00:00.000Z',
+        wardShiftTypeId: 12,
+        wardShiftTypeShortName: 'N',
+        wardShiftTypeColor: '#222222',
+        isRead: true,
+        isAccepted: null,
+    },
+];
+
+describe('useRequestShift model', () => {
+    const now = new Date('2026-03-21T09:00:00+09:00');
+
+    it('bootstrap 상태를 인증/병동 상태에 따라 계산한다', () => {
+        expect(
+            getRequestShiftBootstrapStatus({
+                _loaded: false,
+                isAuth: false,
+                wardId: null,
+                accountMeStatus: 'idle',
+            }),
+        ).toBe('pending');
+
+        expect(
+            getRequestShiftBootstrapStatus({
+                _loaded: true,
+                isAuth: true,
+                wardId: null,
+                accountMeStatus: 'error',
+            }),
+        ).toBe('error');
+
+        expect(
+            getRequestShiftBootstrapStatus({
+                _loaded: true,
+                isAuth: true,
+                wardId: 10,
+                accountMeStatus: 'success',
+            }),
+        ).toBe('success');
+    });
+
+    it('folded level 초기화와 동기화 조건을 계산한다', () => {
+        expect(createInitialFoldedLevels(requestShiftFixture)).toEqual([false, false]);
+        expect(
+            shouldResetFoldedLevelsOnRequestLoad({
+                foldedLevels: [false],
+                previousShiftTeamId: 1,
+                currentShiftTeamId: 2,
+            }),
+        ).toBe(true);
+        expect(
+            shouldSyncFoldedLevelsLength({
+                foldedLevels: [false],
+                requestShift: requestShiftFixture,
+            }),
+        ).toBe(true);
+    });
+
+    it('월 이동 정책을 순수 계산으로 분리한다', () => {
+        expect(getAdjacentRequestShiftDate(2026, 1, 'prev')).toEqual({year: 2025, month: 12});
+        expect(getAdjacentRequestShiftDate(2026, 12, 'next')).toEqual({year: 2027, month: 1});
+
+        expect(
+            getRequestShiftMonthChangeDecision({
+                year: 2026,
+                month: 2,
+                type: 'prev',
+                readonly: false,
+                targetAvailability: getRequestShiftEditAvailability(2026, 1, now),
+            }),
+        ).toMatchObject({
+            year: 2026,
+            month: 1,
+            shouldEnableReadonly: true,
+            shouldBlock: false,
+        });
+
+        expect(
+            getRequestShiftMonthChangeDecision({
+                year: 2026,
+                month: 4,
+                type: 'next',
+                readonly: true,
+                targetAvailability: getRequestShiftEditAvailability(2026, 5, now),
+            }),
+        ).toMatchObject({
+            year: 2026,
+            month: 5,
+            shouldEnableReadonly: false,
+            shouldBlock: true,
+        });
+    });
+
+    it('포커스 기준 현재 신청근무와 duty request를 찾는다', () => {
+        const focus = {
+            shiftNurseId: 101,
+            shiftNurseName: '황인서',
+            day: 0,
+        };
+
+        expect(getRequestShiftTypeIdAtFocus(requestShiftFixture, focus)).toBe(11);
+        expect(findDutyRequestByFocus(dutyRequestFixture, requestShiftFixture, focus)?.wardReqShiftId).toBe(301);
+    });
+
+    it('변경 analytics 문구와 shift type map을 생성한다', () => {
+        const wardShiftTypeMap = createWardShiftTypeMap(requestShiftFixture);
+
+        expect(wardShiftTypeMap.get(11)?.shortName).toBe('D');
+        expect(
+            getRequestShiftChangeEventMessage({
+                focus: {
+                    shiftNurseId: 101,
+                    shiftNurseName: '황인서',
+                    day: 0,
+                },
+                prevShiftType: wardShiftTypeMap.get(11) ?? null,
+                nextShiftType: wardShiftTypeMap.get(12) ?? null,
+            }),
+        ).toBe('황인서 / 1일 | D → N');
+    });
+});

--- a/apps/app/src/features/shift/useRequestShift/index.ts
+++ b/apps/app/src/features/shift/useRequestShift/index.ts
@@ -1,18 +1,27 @@
-import {DateUtil} from '@dutying/utils/date';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
-import {produce} from 'immer';
-import {useCallback, useEffect, useRef} from 'react';
-import {match} from 'ts-pattern';
-import {events, sendEvent} from '@/analytics';
+import {useCallback, useEffect} from 'react';
 import {type TRequestShift} from '@/entities/shift';
-import {type TShiftTeam, type TWardShiftType} from '@/entities/ward';
+import {type TShiftTeam} from '@/entities/ward';
 import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import {WardAPI} from '@/shared/api';
 import {showActionErrorFeedback, showValidationFeedback} from '@/shared/util/feedback';
+import {
+    createInitialFoldedLevels,
+    createWardShiftTypeMap,
+    findDutyRequestByFocus,
+    getAdjacentRequestShiftDate,
+    getRequestShiftBootstrapStatus,
+    getRequestShiftMonthChangeDecision,
+    getRequestShiftTypeIdAtFocus,
+    shouldResetFoldedLevelsOnRequestLoad,
+    shouldSyncFoldedLevelsLength,
+} from './model';
 import {useRequestShiftStore} from './store';
 import {type TFocus} from './type';
-import {findNurse, getRequestShiftEditAvailability, keydownEventMapper, moveFocus} from './utils';
+import {useRequestShiftChangeQueue} from './useRequestShiftChangeQueue';
+import {useRequestShiftKeyboard} from './useRequestShiftKeyboard';
+import {getRequestShiftEditAvailability} from './utils';
 
 const useRequestShift = (activeEffect = false) => {
     const {
@@ -42,118 +51,7 @@ const useRequestShift = (activeEffect = false) => {
     const wardConstraintQueryKey = wardConstraintQueryOptions.queryKey;
     const dutyRequestQueryKey = requestListQueryOptions.queryKey;
     const editAvailability = getRequestShiftEditAvailability(year, month);
-    const bootstrapStatus =
-        !_loaded || (isAuth && wardId === null && (accountMeStatus === 'idle' || accountMeStatus === 'loading'))
-            ? 'pending'
-            : isAuth && wardId === null && accountMeStatus === 'error'
-              ? 'error'
-              : 'success';
-    const changeStatusResetTimerRef = useRef<number | null>(null);
-    const requestShiftChangeQueueRef = useRef<Array<{focus: TFocus; shiftTypeId: number | null}>>([]);
-    const isProcessingRequestShiftQueueRef = useRef(false);
-    const clearChangeStatusResetTimer = useCallback(() => {
-        if (changeStatusResetTimerRef.current !== null) {
-            window.clearTimeout(changeStatusResetTimerRef.current);
-            changeStatusResetTimerRef.current = null;
-        }
-    }, []);
-    const setChangeStatusWithAutoReset = useCallback(
-        (status: 'idle' | 'loading' | 'success' | 'error') => {
-            clearChangeStatusResetTimer();
-            setState('changeStatus', status);
-
-            if (status === 'loading' || status === 'idle') return;
-
-            changeStatusResetTimerRef.current = window.setTimeout(() => {
-                setState('changeStatus', 'idle');
-                changeStatusResetTimerRef.current = null;
-            }, 2400);
-        },
-        [clearChangeStatusResetTimer, setState],
-    );
-    const applyRequestShiftChangeToCache = useCallback(
-        (focus: TFocus, shiftTypeId: number | null) => {
-            const {shiftNurseId, day} = focus;
-            const currentShift = queryClient.getQueryData<TRequestShift>(requestShiftQueryKey);
-
-            if (!currentShift) return;
-
-            const currentShiftTypeId = currentShift.divisionShiftNurses
-                .flatMap((division) => division)
-                .find((row) => row.shiftNurse.shiftNurseId === shiftNurseId)?.wardReqShiftList[focus.day];
-
-            if (currentShiftTypeId === undefined || currentShiftTypeId === shiftTypeId) return;
-
-            if (wardShiftTypeMap) {
-                const edit = {
-                    nurseName: findNurse(currentShift, focus.shiftNurseId)!.name,
-                    focus,
-                    prevShiftType: currentShiftTypeId ? (wardShiftTypeMap.get(currentShiftTypeId) as TWardShiftType) : null,
-                    nextShiftType: shiftTypeId ? (wardShiftTypeMap.get(shiftTypeId) as TWardShiftType) : null,
-                    dateString: DateUtil.getDateString(new Date(), 'yyyy-MM-dd HH:mm:ss'),
-                };
-
-                sendEvent(
-                    events.requestPage.changeShift,
-                    `${focus.shiftNurseName} / ${day + 1}일 | ` +
-                        match(edit)
-                            .with({prevShiftType: null}, () => `추가 → ${edit.nextShiftType?.shortName}`)
-                            .with({nextShiftType: null}, () => `${edit.prevShiftType?.shortName} → 삭제`)
-                            .otherwise(() => `${edit.prevShiftType?.shortName} → ${edit.nextShiftType?.shortName}`),
-                );
-            }
-
-            queryClient.setQueryData<TRequestShift>(
-                requestShiftQueryKey,
-                produce(currentShift, (draft) => {
-                    draft.divisionShiftNurses
-                        .flatMap((division) => division)
-                        .find((row) => row.shiftNurse.shiftNurseId === shiftNurseId)!.wardReqShiftList[focus.day] = shiftTypeId;
-                }),
-            );
-        },
-        [queryClient, requestShiftQueryKey, wardShiftTypeMap],
-    );
-    const flushRequestShiftChangeQueue = useCallback(async () => {
-        if (isProcessingRequestShiftQueueRef.current || !wardId) return;
-
-        isProcessingRequestShiftQueueRef.current = true;
-        setChangeStatusWithAutoReset('loading');
-
-        let hasError = false;
-
-        while (requestShiftChangeQueueRef.current.length > 0) {
-            const nextChange = requestShiftChangeQueueRef.current.shift();
-
-            if (!nextChange) continue;
-
-            try {
-                await WardAPI.updateReqShift(
-                    wardId,
-                    year,
-                    month,
-                    nextChange.focus.day + 1,
-                    nextChange.focus.shiftNurseId,
-                    nextChange.shiftTypeId,
-                );
-            } catch {
-                hasError = true;
-            }
-        }
-
-        if (hasError) {
-            await queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
-            setChangeStatusWithAutoReset('error');
-        } else {
-            setChangeStatusWithAutoReset('success');
-        }
-
-        isProcessingRequestShiftQueueRef.current = false;
-
-        if (requestShiftChangeQueueRef.current.length > 0) {
-            void flushRequestShiftChangeQueue();
-        }
-    }, [month, queryClient, requestShiftQueryKey, setChangeStatusWithAutoReset, wardId, year]);
+    const bootstrapStatus = getRequestShiftBootstrapStatus({_loaded, isAuth, wardId, accountMeStatus});
     const {
         data: shiftTeams,
         status: shiftTeamsStatus,
@@ -170,7 +68,7 @@ const useRequestShift = (activeEffect = false) => {
             }
 
             if (currentShiftTeamId) {
-                if (res.every((x) => x.shiftTeamId !== currentShiftTeamId)) {
+                if (res.every((shiftTeam) => shiftTeam.shiftTeamId !== currentShiftTeamId)) {
                     setState('currentShiftTeamId', res[0].shiftTeamId);
                 }
             } else {
@@ -200,11 +98,14 @@ const useRequestShift = (activeEffect = false) => {
 
             if (res === null) return null as unknown as TRequestShift;
 
-            if (!foldedLevels || !oldCurrentShiftTeamId || (oldCurrentShiftTeamId && oldCurrentShiftTeamId !== currentShiftTeamId)) {
-                setState(
-                    'foldedLevels',
-                    res.divisionShiftNurses.map(() => false),
-                );
+            if (
+                shouldResetFoldedLevelsOnRequestLoad({
+                    foldedLevels,
+                    previousShiftTeamId: oldCurrentShiftTeamId,
+                    currentShiftTeamId,
+                })
+            ) {
+                setState('foldedLevels', createInitialFoldedLevels(res));
                 setState('oldCurrentShiftTeamId', currentShiftTeamId);
             }
 
@@ -212,18 +113,15 @@ const useRequestShift = (activeEffect = false) => {
         },
         enabled: wardId !== null && currentShiftTeamId !== null,
     });
-    const changeRequestShift = useCallback(
-        async (focus: TFocus, shiftTypeId: number | null) => {
-            if (!wardId) return;
-
-            await queryClient.cancelQueries({queryKey: requestShiftQueryKey});
-            applyRequestShiftChangeToCache(focus, shiftTypeId);
-            requestShiftChangeQueueRef.current.push({focus, shiftTypeId});
-
-            void flushRequestShiftChangeQueue();
-        },
-        [applyRequestShiftChangeToCache, flushRequestShiftChangeQueue, queryClient, requestShiftQueryKey, wardId],
-    );
+    const {changeRequestShift} = useRequestShiftChangeQueue({
+        wardId,
+        year,
+        month,
+        requestShiftQueryKey,
+        wardShiftTypeMap,
+        queryClient,
+        setChangeStatus: (status) => setState('changeStatus', status),
+    });
     const acceptRequests = useCallback(
         async (reqShiftIds: number[], isAccepted: boolean | null) => {
             if (!wardId) return false;
@@ -261,64 +159,46 @@ const useRequestShift = (activeEffect = false) => {
         [acceptRequests],
     );
     const changeMonth = (type: 'prev' | 'next') => {
-        const targetYear = type === 'prev' ? (month === 1 ? year - 1 : year) : month === 12 ? year + 1 : year;
-        const targetMonth = type === 'prev' ? (month === 1 ? 12 : month - 1) : month === 12 ? 1 : month + 1;
-        const targetAvailability = getRequestShiftEditAvailability(targetYear, targetMonth);
+        const targetDate = getAdjacentRequestShiftDate(year, month, type);
+        const decision = getRequestShiftMonthChangeDecision({
+            year,
+            month,
+            type,
+            readonly,
+            targetAvailability: getRequestShiftEditAvailability(targetDate.year, targetDate.month),
+        });
 
-        if (type === 'prev') {
-            if (!readonly && targetAvailability.status === 'lockedPast' && targetAvailability.validationMessage) {
-                showValidationFeedback(targetAvailability.validationMessage);
-                setState('readonly', true);
-            }
-
-            if (month === 1) {
-                setState('month', 12);
-                setState('year', year - 1);
-            } else {
-                setState('month', month - 1);
-            }
-        } else if (type === 'next') {
-            if (targetAvailability.status === 'lockedFuture' && targetAvailability.validationMessage) {
-                showValidationFeedback(targetAvailability.validationMessage);
-
-                return;
-            }
-
-            if (month === 12) {
-                setState('month', 1);
-                setState('year', year + 1);
-            } else {
-                setState('month', month + 1);
-            }
+        if (decision.feedbackMessage) {
+            showValidationFeedback(decision.feedbackMessage);
         }
+
+        if (decision.shouldEnableReadonly) {
+            setState('readonly', true);
+        }
+
+        if (decision.shouldBlock) return;
+
+        setState('year', decision.year);
+        setState('month', decision.month);
     };
     const changeFocusedShift = useCallback(
         (shiftTypeId: number | null) => {
             if (!wardId || !focus || !requestShift) return;
 
-            if (
-                requestShift.divisionShiftNurses.flatMap((x) => x).find((x) => x.shiftNurse.shiftNurseId === focus.shiftNurseId)!
-                    .wardReqShiftList[focus.day] === shiftTypeId
-            )
-                return;
+            if (getRequestShiftTypeIdAtFocus(requestShift, focus) === shiftTypeId) return;
 
-            const requestDutyRequest = dutyRequestList?.find(
-                (x) =>
-                    x.nurseId ===
-                        requestShift.divisionShiftNurses.flatMap((x) => x).find((x) => x.shiftNurse.shiftNurseId === focus.shiftNurseId)
-                            ?.shiftNurse.nurseId && x.date === focus.day,
-            );
+            const requestDutyRequest = findDutyRequestByFocus(dutyRequestList, requestShift, focus);
 
             if (requestDutyRequest && requestDutyRequest.wardShiftTypeId !== shiftTypeId && !confirm('신청을 거절하시겠습니까?')) return;
 
             if (requestDutyRequest) {
-                acceptRequest(
+                void acceptRequest(
                     requestDutyRequest.wardReqShiftId,
                     shiftTypeId === null ? null : requestDutyRequest.wardShiftTypeId === shiftTypeId,
                 );
             }
 
-            changeRequestShift(focus, shiftTypeId);
+            void changeRequestShift(focus, shiftTypeId);
         },
         [acceptRequest, changeRequestShift, dutyRequestList, focus, requestShift, wardId],
     );
@@ -327,56 +207,18 @@ const useRequestShift = (activeEffect = false) => {
 
         setState(
             'foldedLevels',
-            foldedLevels.map((x, index) => (index === level ? !x : x)),
+            foldedLevels.map((isFolded, index) => (index === level ? !isFolded : isFolded)),
         );
     };
-    const handleKeyDown = useCallback(
-        (e: KeyboardEvent) => {
-            if (['Ctrl', 'Space', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].indexOf(e.code) != -1) {
-                e.preventDefault(); // Key 입력으로 화면이 이동하는 것을 막습니다.
-            }
 
-            const ctrlKey = e.ctrlKey || e.metaKey;
+    useRequestShiftKeyboard({
+        activeEffect,
+        focus,
+        requestShift,
+        changeFocusedShift,
+        setFocus: (nextFocus) => setState('focus', nextFocus),
+    });
 
-            if (!focus || !requestShift) return;
-
-            if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
-                moveFocus(
-                    e.key.replace('Arrow', '').toLowerCase() as 'left' | 'right' | 'up' | 'down',
-                    ctrlKey,
-                    requestShift,
-                    focus,
-                    (focus: TFocus | null) => setState('focus', focus),
-                );
-            }
-
-            keydownEventMapper(
-                e,
-                ...requestShift.wardShiftTypes.map((shiftType) => ({
-                    keys: [shiftType.shortName],
-                    callback: () => {
-                        changeFocusedShift(shiftType.wardShiftTypeId);
-                        moveFocus('right', ctrlKey, requestShift, focus, (focus: TFocus | null) => {
-                            setState('focus', focus);
-                            sendEvent(ctrlKey ? events.requestPage.moveCellFocus : events.requestPage.moveCellFocus, e.key);
-                        });
-                    },
-                })),
-                {
-                    keys: ['Backspace'],
-                    callback: () => {
-                        changeFocusedShift(null);
-                        moveFocus('left', ctrlKey, requestShift, focus, (focus: TFocus | null) => {
-                            setState('focus', focus);
-                            sendEvent(ctrlKey ? events.requestPage.moveCellFocus : events.requestPage.moveCellFocus, e.key);
-                        });
-                    },
-                },
-                {keys: ['Delete'], callback: () => changeFocusedShift(null)},
-            );
-        },
-        [focus, requestShift, setState, changeFocusedShift],
-    );
     const handleToggleEditMode = (targetDate?: {year: number; month: number}) => {
         const nextEditAvailability = targetDate ? getRequestShiftEditAvailability(targetDate.year, targetDate.month) : editAvailability;
 
@@ -388,16 +230,15 @@ const useRequestShift = (activeEffect = false) => {
             }
 
             setState('readonly', false);
-        } else {
-            setState('readonly', true);
-            setState('focus', null);
 
-            if (requestShift) {
-                setState(
-                    'foldedLevels',
-                    requestShift.divisionShiftNurses.map(() => false),
-                );
-            }
+            return;
+        }
+
+        setState('readonly', true);
+        setState('focus', null);
+
+        if (requestShift) {
+            setState('foldedLevels', createInitialFoldedLevels(requestShift));
         }
     };
     const handleCreateNextMonthShift = () => {
@@ -439,40 +280,21 @@ const useRequestShift = (activeEffect = false) => {
     }, [currentShiftTeamId, handleGetAccountMe, refetchDutyRequestList, refetchRequestShift, refetchShiftTeams, wardId]);
 
     useEffect(() => {
-        if (activeEffect && requestShift) {
-            window.dispatchEvent(new Event('resize'));
+        if (!activeEffect || !requestShift) return;
 
-            const wardShiftTypeMap = new Map<number, TWardShiftType>();
+        window.dispatchEvent(new Event('resize'));
 
-            requestShift.wardShiftTypes.forEach((wardShiftType) => {
-                wardShiftTypeMap.set(wardShiftType.wardShiftTypeId, wardShiftType);
-            });
-
-            if (foldedLevels && foldedLevels?.length !== requestShift.divisionShiftNurses.length) {
-                setState(
-                    'foldedLevels',
-                    requestShift.divisionShiftNurses.map(() => false),
-                );
-            }
-
-            setState('wardShiftTypeMap', wardShiftTypeMap);
+        if (
+            shouldSyncFoldedLevelsLength({
+                foldedLevels,
+                requestShift,
+            })
+        ) {
+            setState('foldedLevels', createInitialFoldedLevels(requestShift));
         }
+
+        setState('wardShiftTypeMap', createWardShiftTypeMap(requestShift));
     }, [activeEffect, foldedLevels, requestShift, setState]);
-
-    useEffect(() => {
-        if (activeEffect) document.addEventListener('keydown', handleKeyDown);
-
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-        };
-    }, [activeEffect, focus, requestShift, handleKeyDown]);
-
-    useEffect(
-        () => () => {
-            clearChangeStatusResetTimer();
-        },
-        [clearChangeStatusResetTimer],
-    );
 
     return {
         queryKey: {
@@ -495,12 +317,12 @@ const useRequestShift = (activeEffect = false) => {
             wardShiftTypeMap,
             readonly,
             updatingRequestId,
-            currentShiftTeam: shiftTeams?.find((x) => x.shiftTeamId === currentShiftTeamId) as TShiftTeam | null,
+            currentShiftTeam: shiftTeams?.find((shiftTeam) => shiftTeam.shiftTeamId === currentShiftTeamId) as TShiftTeam | null,
             shiftTeams,
             editAvailability,
         },
         actions: {
-            changeRequestShift: (focus: TFocus, shiftTypeId: number | null) => changeRequestShift(focus, shiftTypeId),
+            changeRequestShift: (nextFocus: TFocus, shiftTypeId: number | null) => changeRequestShift(nextFocus, shiftTypeId),
             toggleEditMode: handleToggleEditMode,
             createNextMonthShift: handleCreateNextMonthShift,
             acceptRequest: (reqShiftId: number, isAccepted: boolean | null) => acceptRequest(reqShiftId, isAccepted),
@@ -508,7 +330,7 @@ const useRequestShift = (activeEffect = false) => {
             foldLevel,
             changeMonth,
             retry,
-            changeFocus: (focus: TFocus | null) => setState('focus', focus),
+            changeFocus: (nextFocus: TFocus | null) => setState('focus', nextFocus),
             changeShiftTeam: (shiftTeam: TShiftTeam) => setState('currentShiftTeamId', shiftTeam.shiftTeamId),
         },
     };

--- a/apps/app/src/features/shift/useRequestShift/model.ts
+++ b/apps/app/src/features/shift/useRequestShift/model.ts
@@ -1,0 +1,168 @@
+import {type TDutyRequest, type TRequestShift} from '@/entities/shift';
+import {type TWardShiftType} from '@/entities/ward';
+import {type TFocus, type TRequestShiftEditAvailability} from './type';
+
+type TBootstrapStatus = 'pending' | 'error' | 'success';
+type TAccountMeStatus = 'idle' | 'loading' | 'success' | 'error';
+type TMonthChangeType = 'prev' | 'next';
+
+type TBootstrapStatusParams = {
+    _loaded: boolean;
+    isAuth: boolean;
+    wardId: number | null;
+    accountMeStatus: TAccountMeStatus;
+};
+
+type TMonthChangeDecisionParams = {
+    year: number;
+    month: number;
+    type: TMonthChangeType;
+    readonly: boolean;
+    targetAvailability: TRequestShiftEditAvailability;
+};
+
+type TMonthChangeDecision = {
+    year: number;
+    month: number;
+    shouldBlock: boolean;
+    shouldEnableReadonly: boolean;
+    feedbackMessage: string | null;
+};
+
+const flattenRequestShiftRows = (requestShift: TRequestShift) => requestShift.divisionShiftNurses.flatMap((division) => division);
+
+export const getRequestShiftBootstrapStatus = ({_loaded, isAuth, wardId, accountMeStatus}: TBootstrapStatusParams): TBootstrapStatus => {
+    if (!_loaded || (isAuth && wardId === null && (accountMeStatus === 'idle' || accountMeStatus === 'loading'))) {
+        return 'pending';
+    }
+
+    if (isAuth && wardId === null && accountMeStatus === 'error') {
+        return 'error';
+    }
+
+    return 'success';
+};
+
+export const createInitialFoldedLevels = (requestShift: TRequestShift) => requestShift.divisionShiftNurses.map(() => false);
+
+export const shouldResetFoldedLevelsOnRequestLoad = ({
+    foldedLevels,
+    previousShiftTeamId,
+    currentShiftTeamId,
+}: {
+    foldedLevels: boolean[] | null;
+    previousShiftTeamId: number | null;
+    currentShiftTeamId: number | null;
+}) => {
+    return !foldedLevels || !previousShiftTeamId || previousShiftTeamId !== currentShiftTeamId;
+};
+
+export const shouldSyncFoldedLevelsLength = ({
+    foldedLevels,
+    requestShift,
+}: {
+    foldedLevels: boolean[] | null;
+    requestShift: TRequestShift;
+}) => {
+    return foldedLevels !== null && foldedLevels.length !== requestShift.divisionShiftNurses.length;
+};
+
+export const createWardShiftTypeMap = (requestShift: TRequestShift) => {
+    return new Map<number, TWardShiftType>(
+        requestShift.wardShiftTypes.map((wardShiftType) => [wardShiftType.wardShiftTypeId, wardShiftType]),
+    );
+};
+
+export const getAdjacentRequestShiftDate = (year: number, month: number, type: TMonthChangeType) => {
+    if (type === 'prev') {
+        return month === 1
+            ? {
+                  year: year - 1,
+                  month: 12,
+              }
+            : {
+                  year,
+                  month: month - 1,
+              };
+    }
+
+    return month === 12
+        ? {
+              year: year + 1,
+              month: 1,
+          }
+        : {
+              year,
+              month: month + 1,
+          };
+};
+
+export const getRequestShiftMonthChangeDecision = ({
+    year,
+    month,
+    type,
+    readonly,
+    targetAvailability,
+}: TMonthChangeDecisionParams): TMonthChangeDecision => {
+    const nextDate = getAdjacentRequestShiftDate(year, month, type);
+
+    if (type === 'prev' && !readonly && targetAvailability.status === 'lockedPast') {
+        return {
+            ...nextDate,
+            shouldBlock: false,
+            shouldEnableReadonly: true,
+            feedbackMessage: targetAvailability.validationMessage,
+        };
+    }
+
+    if (type === 'next' && targetAvailability.status === 'lockedFuture') {
+        return {
+            ...nextDate,
+            shouldBlock: true,
+            shouldEnableReadonly: false,
+            feedbackMessage: targetAvailability.validationMessage,
+        };
+    }
+
+    return {
+        ...nextDate,
+        shouldBlock: false,
+        shouldEnableReadonly: false,
+        feedbackMessage: null,
+    };
+};
+
+export const findRequestShiftRow = (requestShift: TRequestShift, shiftNurseId: number) => {
+    return flattenRequestShiftRows(requestShift).find((row) => row.shiftNurse.shiftNurseId === shiftNurseId) ?? null;
+};
+
+export const getRequestShiftTypeIdAtFocus = (requestShift: TRequestShift, focus: TFocus) => {
+    return findRequestShiftRow(requestShift, focus.shiftNurseId)?.wardReqShiftList[focus.day];
+};
+
+export const findDutyRequestByFocus = (dutyRequestList: TDutyRequest[] | undefined, requestShift: TRequestShift, focus: TFocus) => {
+    const nurseId = findRequestShiftRow(requestShift, focus.shiftNurseId)?.shiftNurse.nurseId;
+
+    if (nurseId === undefined) return undefined;
+
+    return dutyRequestList?.find((dutyRequest) => dutyRequest.nurseId === nurseId && dutyRequest.date === focus.day);
+};
+
+export const getRequestShiftChangeEventMessage = ({
+    focus,
+    prevShiftType,
+    nextShiftType,
+}: {
+    focus: TFocus;
+    prevShiftType: TWardShiftType | null;
+    nextShiftType: TWardShiftType | null;
+}) => {
+    const changeLabel =
+        prevShiftType === null
+            ? `추가 → ${nextShiftType?.shortName}`
+            : nextShiftType === null
+              ? `${prevShiftType.shortName} → 삭제`
+              : `${prevShiftType.shortName} → ${nextShiftType.shortName}`;
+
+    return `${focus.shiftNurseName} / ${focus.day + 1}일 | ${changeLabel}`;
+};

--- a/apps/app/src/features/shift/useRequestShift/useRequestShiftChangeQueue.ts
+++ b/apps/app/src/features/shift/useRequestShift/useRequestShiftChangeQueue.ts
@@ -1,0 +1,156 @@
+import {type QueryClient} from '@tanstack/react-query';
+import {produce} from 'immer';
+import {useCallback, useEffect, useRef} from 'react';
+import {events, sendEvent} from '@/analytics';
+import {type TRequestShift} from '@/entities/shift';
+import {type TWardShiftType} from '@/entities/ward';
+import {WardAPI} from '@/shared/api';
+import {getRequestShiftChangeEventMessage, getRequestShiftTypeIdAtFocus} from './model';
+import {type TFocus} from './type';
+
+type TChangeStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type TUseRequestShiftChangeQueueParams = {
+    wardId: number | null;
+    year: number;
+    month: number;
+    requestShiftQueryKey: readonly unknown[];
+    wardShiftTypeMap: Map<number, TWardShiftType> | null;
+    queryClient: QueryClient;
+    setChangeStatus: (status: TChangeStatus) => void;
+};
+
+const CHANGE_STATUS_RESET_DELAY = 2400;
+
+export const useRequestShiftChangeQueue = ({
+    wardId,
+    year,
+    month,
+    requestShiftQueryKey,
+    wardShiftTypeMap,
+    queryClient,
+    setChangeStatus,
+}: TUseRequestShiftChangeQueueParams) => {
+    const changeStatusResetTimerRef = useRef<number | null>(null);
+    const requestShiftChangeQueueRef = useRef<Array<{focus: TFocus; shiftTypeId: number | null}>>([]);
+    const isProcessingRequestShiftQueueRef = useRef(false);
+    const clearChangeStatusResetTimer = useCallback(() => {
+        if (changeStatusResetTimerRef.current !== null) {
+            window.clearTimeout(changeStatusResetTimerRef.current);
+            changeStatusResetTimerRef.current = null;
+        }
+    }, []);
+    const setChangeStatusWithAutoReset = useCallback(
+        (status: TChangeStatus) => {
+            clearChangeStatusResetTimer();
+            setChangeStatus(status);
+
+            if (status === 'loading' || status === 'idle') return;
+
+            changeStatusResetTimerRef.current = window.setTimeout(() => {
+                setChangeStatus('idle');
+                changeStatusResetTimerRef.current = null;
+            }, CHANGE_STATUS_RESET_DELAY);
+        },
+        [clearChangeStatusResetTimer, setChangeStatus],
+    );
+    const applyRequestShiftChangeToCache = useCallback(
+        (focus: TFocus, shiftTypeId: number | null) => {
+            const currentShift = queryClient.getQueryData<TRequestShift>(requestShiftQueryKey);
+
+            if (!currentShift) return;
+
+            const currentShiftTypeId = getRequestShiftTypeIdAtFocus(currentShift, focus);
+
+            if (currentShiftTypeId === undefined || currentShiftTypeId === shiftTypeId) return;
+
+            if (wardShiftTypeMap) {
+                sendEvent(
+                    events.requestPage.changeShift,
+                    getRequestShiftChangeEventMessage({
+                        focus,
+                        prevShiftType: currentShiftTypeId ? (wardShiftTypeMap.get(currentShiftTypeId) ?? null) : null,
+                        nextShiftType: shiftTypeId ? (wardShiftTypeMap.get(shiftTypeId) ?? null) : null,
+                    }),
+                );
+            }
+
+            queryClient.setQueryData<TRequestShift>(
+                requestShiftQueryKey,
+                produce(currentShift, (draft) => {
+                    const row = draft.divisionShiftNurses
+                        .flatMap((division) => division)
+                        .find((draftRow) => draftRow.shiftNurse.shiftNurseId === focus.shiftNurseId);
+
+                    if (!row) return;
+
+                    row.wardReqShiftList[focus.day] = shiftTypeId;
+                }),
+            );
+        },
+        [queryClient, requestShiftQueryKey, wardShiftTypeMap],
+    );
+    const flushRequestShiftChangeQueue = useCallback(async () => {
+        if (isProcessingRequestShiftQueueRef.current || !wardId) return;
+
+        isProcessingRequestShiftQueueRef.current = true;
+        setChangeStatusWithAutoReset('loading');
+
+        let hasError = false;
+
+        while (requestShiftChangeQueueRef.current.length > 0) {
+            const nextChange = requestShiftChangeQueueRef.current.shift();
+
+            if (!nextChange) continue;
+
+            try {
+                await WardAPI.updateReqShift(
+                    wardId,
+                    year,
+                    month,
+                    nextChange.focus.day + 1,
+                    nextChange.focus.shiftNurseId,
+                    nextChange.shiftTypeId,
+                );
+            } catch {
+                hasError = true;
+            }
+        }
+
+        if (hasError) {
+            await queryClient.invalidateQueries({queryKey: requestShiftQueryKey});
+            setChangeStatusWithAutoReset('error');
+        } else {
+            setChangeStatusWithAutoReset('success');
+        }
+
+        isProcessingRequestShiftQueueRef.current = false;
+
+        if (requestShiftChangeQueueRef.current.length > 0) {
+            void flushRequestShiftChangeQueue();
+        }
+    }, [month, queryClient, requestShiftQueryKey, setChangeStatusWithAutoReset, wardId, year]);
+    const changeRequestShift = useCallback(
+        async (focus: TFocus, shiftTypeId: number | null) => {
+            if (!wardId) return;
+
+            await queryClient.cancelQueries({queryKey: requestShiftQueryKey});
+            applyRequestShiftChangeToCache(focus, shiftTypeId);
+            requestShiftChangeQueueRef.current.push({focus, shiftTypeId});
+
+            void flushRequestShiftChangeQueue();
+        },
+        [applyRequestShiftChangeToCache, flushRequestShiftChangeQueue, queryClient, requestShiftQueryKey, wardId],
+    );
+
+    useEffect(
+        () => () => {
+            clearChangeStatusResetTimer();
+        },
+        [clearChangeStatusResetTimer],
+    );
+
+    return {
+        changeRequestShift,
+    };
+};

--- a/apps/app/src/features/shift/useRequestShift/useRequestShiftKeyboard.ts
+++ b/apps/app/src/features/shift/useRequestShift/useRequestShiftKeyboard.ts
@@ -1,0 +1,79 @@
+import {useCallback, useEffect} from 'react';
+import {events, sendEvent} from '@/analytics';
+import {type TRequestShift} from '@/entities/shift';
+import {type TFocus} from './type';
+import {keydownEventMapper, moveFocus} from './utils';
+
+type TUseRequestShiftKeyboardParams = {
+    activeEffect: boolean;
+    focus: TFocus | null;
+    requestShift: TRequestShift | null | undefined;
+    changeFocusedShift: (shiftTypeId: number | null) => void;
+    setFocus: (focus: TFocus | null) => void;
+};
+
+export const useRequestShiftKeyboard = ({
+    activeEffect,
+    focus,
+    requestShift,
+    changeFocusedShift,
+    setFocus,
+}: TUseRequestShiftKeyboardParams) => {
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            if (['Ctrl', 'Space', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.code)) {
+                e.preventDefault();
+            }
+
+            const ctrlKey = e.ctrlKey || e.metaKey;
+
+            if (!focus || !requestShift) return;
+
+            if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+                moveFocus(
+                    e.key.replace('Arrow', '').toLowerCase() as 'left' | 'right' | 'up' | 'down',
+                    ctrlKey,
+                    requestShift,
+                    focus,
+                    setFocus,
+                );
+            }
+
+            keydownEventMapper(
+                e,
+                ...requestShift.wardShiftTypes.map((shiftType) => ({
+                    keys: [shiftType.shortName],
+                    callback: () => {
+                        changeFocusedShift(shiftType.wardShiftTypeId);
+                        moveFocus('right', ctrlKey, requestShift, focus, (nextFocus) => {
+                            setFocus(nextFocus);
+                            sendEvent(ctrlKey ? events.requestPage.moveCellFocus : events.requestPage.moveCellFocus, e.key);
+                        });
+                    },
+                })),
+                {
+                    keys: ['Backspace'],
+                    callback: () => {
+                        changeFocusedShift(null);
+                        moveFocus('left', ctrlKey, requestShift, focus, (nextFocus) => {
+                            setFocus(nextFocus);
+                            sendEvent(ctrlKey ? events.requestPage.moveCellFocus : events.requestPage.moveCellFocus, e.key);
+                        });
+                    },
+                },
+                {keys: ['Delete'], callback: () => changeFocusedShift(null)},
+            );
+        },
+        [changeFocusedShift, focus, requestShift, setFocus],
+    );
+
+    useEffect(() => {
+        if (!activeEffect) return;
+
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [activeEffect, handleKeyDown]);
+};


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-915](https://gom3.atlassian.net/browse/DUT-915)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `useRequestShift`에서 상태 계산과 selector 성격의 로직을 `model.ts`로 분리했습니다.
- 신청근무 낙관적 업데이트, change status 타이머, API flush queue를 `useRequestShiftChangeQueue.ts`로 분리했습니다.
- 키보드 이동/입력 처리와 이벤트 바인딩을 `useRequestShiftKeyboard.ts`로 분리했습니다.
- 분리된 순수 모델 로직에 대한 테스트를 추가해 회귀 검증 범위를 넓혔습니다.

<br>

## To Reviewers

- 기능 변경이 아닌 구조 정리가 목적이라 기존 신청근무 편집/신청 승인 흐름이 동일하게 유지되는지 중심으로 봐주세요.
- 검증은 `pnpm --dir apps/app type-check`, 대상 vitest 3파일, 대상 eslint로 수행했습니다.


[DUT-915]: https://gom3.atlassian.net/browse/DUT-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ