### PR TITLE
[DUT-911]: make-shift step 책임 분리

### DIFF
--- a/apps/app/src/pages/make-shift/view/index.tsx
+++ b/apps/app/src/pages/make-shift/view/index.tsx
@@ -6,47 +6,8 @@ import {ManagementActionButton} from '@/widgets/duty-management/ui';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../model/make-shift-store';
 import {useMakeShiftUseCase} from '../model/make-shift-use-case';
 import {MakeShiftHeader} from './make-shift-header';
-import {MakeShiftStepper, STEP_LABELS} from './make-shift-stepper';
-import {AiAutofill} from './steps/ai-auto-fill';
-import {Constraints} from './steps/constraints';
-import {FixedShifts} from './steps/fixed-shifts';
-import {RequestsShifts} from './steps/requests-shifts';
-import {Workers} from './steps/workers';
-
-const STEP_INTRO: Record<
-    1 | 2 | 3 | 4 | 5,
-    {
-        title: string;
-        desc: string[];
-        isWideStep: boolean;
-    }
-> = {
-    1: {
-        title: '근무자를 확정해 주세요',
-        desc: ["'근무투입'이 선택된 근무자만 불러왔어요", '목록 순서대로 근무표에 배치해 드릴게요'],
-        isWideStep: false,
-    },
-    2: {
-        title: '제약 조건을 확정해 주세요',
-        desc: ['모든 제약 조건을 적용하기 어려울 수 있어요', '우선순위를 정해 주시면, 더 정확하게 반영해 드릴게요'],
-        isWideStep: false,
-    },
-    3: {
-        title: '신청 근무를 확정해 주세요',
-        desc: ['제출된 신청 근무를 확인하고 확정해 주세요.'],
-        isWideStep: true,
-    },
-    4: {
-        title: '고정 근무를 확인해 주세요',
-        desc: ['고정 근무를 확인하고 반영해 주세요.'],
-        isWideStep: true,
-    },
-    5: {
-        title: 'AI 자동 채우기를 진행해 주세요',
-        desc: ['설정한 조건을 바탕으로 근무표를 자동으로 채워 드릴게요.'],
-        isWideStep: true,
-    },
-};
+import {MakeShiftStepContent} from './make-shift-step-content';
+import {MakeShiftStepper} from './make-shift-stepper';
 
 export const MakeShiftPageView = () => {
     const navigate = useNavigate();
@@ -157,55 +118,13 @@ export const MakeShiftPageView = () => {
                 ) : (
                     <>
                         <MakeShiftStepper currentStep={currentStep} onClickStep={useCase.goToStep} />
-
-                        {STEP_INTRO[currentStep].isWideStep ? (
-                            <div className="flex flex-1 flex-col px-10 pt-[42px] pb-10">
-                                <p className="sr-only">{STEP_LABELS[currentStep]}</p>
-                                {currentStep === 3 && <RequestsShifts />}
-                                {currentStep === 4 && <FixedShifts />}
-                                {currentStep === 5 && <AiAutofill />}
-                            </div>
-                        ) : (
-                            <div className="flex flex-1 gap-10 pt-[42px] pl-[59px]">
-                                <div className="w-[440px] shrink-0">
-                                    <p className="font-apple text-[32px] font-semibold text-sub-1">{STEP_INTRO[currentStep].title}</p>
-                                    <div className="mt-6 font-apple text-xl leading-[1.72] font-medium text-gray-3">
-                                        {STEP_INTRO[currentStep].desc.map((line) => (
-                                            <p key={line}>{line}</p>
-                                        ))}
-                                    </div>
-
-                                    <div className="mt-[82px] flex items-center gap-8">
-                                        <ManagementActionButton
-                                            variant="neutral"
-                                            size="sm"
-                                            onClick={() => useCase.prev()}
-                                            disabled={!canPrev}
-                                        >
-                                            {t('page.makeShift.navigation.previous')}
-                                        </ManagementActionButton>
-                                        <ManagementActionButton size="sm" onClick={() => useCase.next()} disabled={!canNext}>
-                                            {t('page.makeShift.navigation.next')}
-                                        </ManagementActionButton>
-                                        {currentStep === 5 && (
-                                            <ManagementActionButton
-                                                className="bg-sub-3 hover:bg-sub-2"
-                                                size="sm"
-                                                onClick={() => useCase.complete()}
-                                            >
-                                                {t('page.makeShift.navigation.complete')}
-                                            </ManagementActionButton>
-                                        )}
-                                    </div>
-                                </div>
-
-                                <div className="min-w-0 flex-1">
-                                    <p className="sr-only">{STEP_LABELS[currentStep]}</p>
-                                    {currentStep === 1 && <Workers />}
-                                    {currentStep === 2 && <Constraints />}
-                                </div>
-                            </div>
-                        )}
+                        <MakeShiftStepContent
+                            currentStep={currentStep}
+                            canPrev={canPrev}
+                            canNext={canNext}
+                            onPrev={useCase.prev}
+                            onNext={useCase.next}
+                        />
                     </>
                 )}
             </div>

--- a/apps/app/src/pages/make-shift/view/make-shift-step-config.tsx
+++ b/apps/app/src/pages/make-shift/view/make-shift-step-config.tsx
@@ -1,4 +1,5 @@
 import {type ComponentType} from 'react';
+import {type TI18nKey} from '@/shared/hook/use-typed-translation';
 import {type TMakeShiftStep} from '../model/make-shift-store';
 import {AiAutofill} from './steps/ai-auto-fill';
 import {Constraints} from './steps/constraints';
@@ -7,12 +8,12 @@ import {RequestsShifts} from './steps/requests-shifts';
 import {Workers} from './steps/workers';
 
 type TMakeShiftStepIntro = {
-    title: string;
-    desc: string[];
+    titleKey: TI18nKey;
+    descriptionKey: TI18nKey;
 };
 
-type TMakeShiftStepConfig = {
-    label: string;
+export type TMakeShiftStepConfig = {
+    labelKey: TI18nKey;
     layout: 'narrow' | 'wide';
     Component: ComponentType;
     intro?: TMakeShiftStepIntro;
@@ -20,40 +21,36 @@ type TMakeShiftStepConfig = {
 
 export const MAKE_SHIFT_STEP_CONFIG: Record<TMakeShiftStep, TMakeShiftStepConfig> = {
     1: {
-        label: '근무자 확인',
+        labelKey: 'page.makeShift.steps.workers.label',
         layout: 'narrow',
         Component: Workers,
         intro: {
-            title: '근무자를 확정해 주세요',
-            desc: ["'근무투입'이 선택된 근무자만 불러왔어요", '목록 순서대로 근무표에 배치해 드릴게요'],
+            titleKey: 'page.makeShift.steps.workers.introTitle',
+            descriptionKey: 'page.makeShift.steps.workers.introDescription',
         },
     },
     2: {
-        label: '제약 조건',
+        labelKey: 'page.makeShift.steps.constraints.label',
         layout: 'narrow',
         Component: Constraints,
         intro: {
-            title: '제약 조건을 확정해 주세요',
-            desc: ['모든 제약 조건을 적용하기 어려울 수 있어요', '우선순위를 정해 주시면, 더 정확하게 반영해 드릴게요'],
+            titleKey: 'page.makeShift.steps.constraints.introTitle',
+            descriptionKey: 'page.makeShift.steps.constraints.introDescription',
         },
     },
     3: {
-        label: '신청 근무 확정',
+        labelKey: 'page.makeShift.steps.requests.label',
         layout: 'wide',
         Component: RequestsShifts,
     },
     4: {
-        label: '고정 근무',
+        labelKey: 'page.makeShift.steps.fixedShifts.label',
         layout: 'wide',
         Component: FixedShifts,
     },
     5: {
-        label: 'AI 자동 채우기',
+        labelKey: 'page.makeShift.steps.aiAutofill.label',
         layout: 'wide',
         Component: AiAutofill,
     },
 };
-
-export const STEP_LABELS: Record<TMakeShiftStep, string> = Object.fromEntries(
-    Object.entries(MAKE_SHIFT_STEP_CONFIG).map(([step, config]) => [Number(step), config.label]),
-) as Record<TMakeShiftStep, string>;

--- a/apps/app/src/pages/make-shift/view/make-shift-step-config.tsx
+++ b/apps/app/src/pages/make-shift/view/make-shift-step-config.tsx
@@ -1,0 +1,59 @@
+import {type ComponentType} from 'react';
+import {type TMakeShiftStep} from '../model/make-shift-store';
+import {AiAutofill} from './steps/ai-auto-fill';
+import {Constraints} from './steps/constraints';
+import {FixedShifts} from './steps/fixed-shifts';
+import {RequestsShifts} from './steps/requests-shifts';
+import {Workers} from './steps/workers';
+
+type TMakeShiftStepIntro = {
+    title: string;
+    desc: string[];
+};
+
+type TMakeShiftStepConfig = {
+    label: string;
+    layout: 'narrow' | 'wide';
+    Component: ComponentType;
+    intro?: TMakeShiftStepIntro;
+};
+
+export const MAKE_SHIFT_STEP_CONFIG: Record<TMakeShiftStep, TMakeShiftStepConfig> = {
+    1: {
+        label: '근무자 확인',
+        layout: 'narrow',
+        Component: Workers,
+        intro: {
+            title: '근무자를 확정해 주세요',
+            desc: ["'근무투입'이 선택된 근무자만 불러왔어요", '목록 순서대로 근무표에 배치해 드릴게요'],
+        },
+    },
+    2: {
+        label: '제약 조건',
+        layout: 'narrow',
+        Component: Constraints,
+        intro: {
+            title: '제약 조건을 확정해 주세요',
+            desc: ['모든 제약 조건을 적용하기 어려울 수 있어요', '우선순위를 정해 주시면, 더 정확하게 반영해 드릴게요'],
+        },
+    },
+    3: {
+        label: '신청 근무 확정',
+        layout: 'wide',
+        Component: RequestsShifts,
+    },
+    4: {
+        label: '고정 근무',
+        layout: 'wide',
+        Component: FixedShifts,
+    },
+    5: {
+        label: 'AI 자동 채우기',
+        layout: 'wide',
+        Component: AiAutofill,
+    },
+};
+
+export const STEP_LABELS: Record<TMakeShiftStep, string> = Object.fromEntries(
+    Object.entries(MAKE_SHIFT_STEP_CONFIG).map(([step, config]) => [Number(step), config.label]),
+) as Record<TMakeShiftStep, string>;

--- a/apps/app/src/pages/make-shift/view/make-shift-step-content.tsx
+++ b/apps/app/src/pages/make-shift/view/make-shift-step-content.tsx
@@ -1,0 +1,54 @@
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import {ManagementActionButton} from '@/widgets/duty-management/ui';
+import {type TMakeShiftStep} from '../model/make-shift-store';
+import {MAKE_SHIFT_STEP_CONFIG} from './make-shift-step-config';
+
+type TMakeShiftStepContentProps = {
+    currentStep: TMakeShiftStep;
+    canPrev: boolean;
+    canNext: boolean;
+    onPrev: () => void;
+    onNext: () => void;
+};
+
+export function MakeShiftStepContent({currentStep, canPrev, canNext, onPrev, onNext}: TMakeShiftStepContentProps) {
+    const {t} = useTypedTranslation();
+    const stepConfig = MAKE_SHIFT_STEP_CONFIG[currentStep];
+    const StepComponent = stepConfig.Component;
+
+    if (stepConfig.layout === 'wide') {
+        return (
+            <div className="flex flex-1 flex-col px-10 pt-[42px] pb-10">
+                <p className="sr-only">{stepConfig.label}</p>
+                <StepComponent />
+            </div>
+        );
+    }
+
+    const intro = stepConfig.intro;
+
+    return (
+        <div className="flex flex-1 gap-10 pt-[42px] pl-[59px]">
+            <div className="w-[440px] shrink-0">
+                <p className="font-apple text-[32px] font-semibold text-sub-1">{intro?.title}</p>
+                <div className="mt-6 font-apple text-xl leading-[1.72] font-medium text-gray-3">
+                    {intro?.desc.map((line) => <p key={line}>{line}</p>)}
+                </div>
+
+                <div className="mt-[82px] flex items-center gap-8">
+                    <ManagementActionButton variant="neutral" size="sm" onClick={onPrev} disabled={!canPrev}>
+                        {t('page.makeShift.navigation.previous')}
+                    </ManagementActionButton>
+                    <ManagementActionButton size="sm" onClick={onNext} disabled={!canNext}>
+                        {t('page.makeShift.navigation.next')}
+                    </ManagementActionButton>
+                </div>
+            </div>
+
+            <div className="min-w-0 flex-1">
+                <p className="sr-only">{stepConfig.label}</p>
+                <StepComponent />
+            </div>
+        </div>
+    );
+}

--- a/apps/app/src/pages/make-shift/view/make-shift-step-content.tsx
+++ b/apps/app/src/pages/make-shift/view/make-shift-step-content.tsx
@@ -1,4 +1,5 @@
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import {renderMultilineText} from '@/shared/util/string';
 import {ManagementActionButton} from '@/widgets/duty-management/ui';
 import {type TMakeShiftStep} from '../model/make-shift-store';
 import {MAKE_SHIFT_STEP_CONFIG} from './make-shift-step-config';
@@ -19,7 +20,7 @@ export function MakeShiftStepContent({currentStep, canPrev, canNext, onPrev, onN
     if (stepConfig.layout === 'wide') {
         return (
             <div className="flex flex-1 flex-col px-10 pt-[42px] pb-10">
-                <p className="sr-only">{stepConfig.label}</p>
+                <p className="sr-only">{t(stepConfig.labelKey)}</p>
                 <StepComponent />
             </div>
         );
@@ -30,9 +31,9 @@ export function MakeShiftStepContent({currentStep, canPrev, canNext, onPrev, onN
     return (
         <div className="flex flex-1 gap-10 pt-[42px] pl-[59px]">
             <div className="w-[440px] shrink-0">
-                <p className="font-apple text-[32px] font-semibold text-sub-1">{intro?.title}</p>
+                <p className="font-apple text-[32px] font-semibold text-sub-1">{intro ? t(intro.titleKey) : ''}</p>
                 <div className="mt-6 font-apple text-xl leading-[1.72] font-medium text-gray-3">
-                    {intro?.desc.map((line) => <p key={line}>{line}</p>)}
+                    {intro ? renderMultilineText(t(intro.descriptionKey)) : null}
                 </div>
 
                 <div className="mt-[82px] flex items-center gap-8">
@@ -46,7 +47,7 @@ export function MakeShiftStepContent({currentStep, canPrev, canNext, onPrev, onN
             </div>
 
             <div className="min-w-0 flex-1">
-                <p className="sr-only">{stepConfig.label}</p>
+                <p className="sr-only">{t(stepConfig.labelKey)}</p>
                 <StepComponent />
             </div>
         </div>

--- a/apps/app/src/pages/make-shift/view/make-shift-stepper.tsx
+++ b/apps/app/src/pages/make-shift/view/make-shift-stepper.tsx
@@ -1,12 +1,5 @@
 import {type TMakeShiftStep} from '../model/make-shift-store';
-
-export const STEP_LABELS: Record<TMakeShiftStep, string> = {
-    1: '근무자 확인',
-    2: '제약 조건',
-    3: '신청 근무 확정',
-    4: '고정 근무',
-    5: 'AI 자동 채우기',
-};
+import {STEP_LABELS} from './make-shift-step-config';
 
 function StepCircle({state, step}: {state: 'prev' | 'current' | 'next'; step: number}) {
     const base = 'flex size-8 items-center justify-center rounded-full font-poppins text-xl font-medium';

--- a/apps/app/src/pages/make-shift/view/make-shift-stepper.tsx
+++ b/apps/app/src/pages/make-shift/view/make-shift-stepper.tsx
@@ -1,5 +1,6 @@
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import {type TMakeShiftStep} from '../model/make-shift-store';
-import {STEP_LABELS} from './make-shift-step-config';
+import {MAKE_SHIFT_STEP_CONFIG} from './make-shift-step-config';
 
 function StepCircle({state, step}: {state: 'prev' | 'current' | 'next'; step: number}) {
     const base = 'flex size-8 items-center justify-center rounded-full font-poppins text-xl font-medium';
@@ -12,6 +13,8 @@ function StepCircle({state, step}: {state: 'prev' | 'current' | 'next'; step: nu
 }
 
 export function MakeShiftStepper({currentStep, onClickStep}: {currentStep: TMakeShiftStep; onClickStep: (step: TMakeShiftStep) => void}) {
+    const {t} = useTypedTranslation();
+
     return (
         <div className="border-b-[2px] border-gray-6">
             <div className="flex flex-wrap items-center justify-between gap-6 px-10">
@@ -36,7 +39,7 @@ export function MakeShiftStepper({currentStep, onClickStep}: {currentStep: TMake
                                           : 'font-medium text-gray-4'
                                 }`}
                             >
-                                {STEP_LABELS[step]}
+                                {t(MAKE_SHIFT_STEP_CONFIG[step].labelKey)}
                             </div>
 
                             {state === 'current' && (

--- a/apps/app/src/pages/make-shift/view/steps/ai-auto-fill.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/ai-auto-fill.tsx
@@ -254,8 +254,8 @@ export function AiAutofill() {
                 isLoading={dutyQuery.isLoading}
                 isError={dutyQuery.isError}
                 onRetry={dutyQuery.refetch}
-                loadingTitle="근무표를 불러오는 중이에요"
-                errorTitle="근무표를 불러오지 못했어요"
+                loadingTitle={t('page.makeShift.aiRefill.loading')}
+                errorTitle={t('page.makeShift.aiRefill.error')}
                 editorDoc={hydratedDoc}
                 violationMap={violationMap}
                 editorRef={editorRef}

--- a/apps/app/src/pages/make-shift/view/steps/ai-auto-fill.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/ai-auto-fill.tsx
@@ -1,25 +1,11 @@
 import {cn} from '@dutying/utils/style';
-import {useQuery} from '@tanstack/react-query';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import toast from 'react-hot-toast';
-import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
-import {
-    buildWorkKeyMap,
-    buildViolationMap,
-    docToWardShiftsDTO,
-    type TDutyDoc,
-    shiftToDoc,
-    useShiftEditorCommands,
-    useShiftEditorKeyBindings,
-    useShiftEditorStore,
-} from '@/features/shift-editor';
-import CountDutyByDay from '@/features/shift-editor/ui/complex-view/count-duty-by-day';
-import ShiftCalendar from '@/features/shift-editor/ui/complex-view/shift-calendar';
+import {docToWardShiftsDTO, useShiftEditorCommands, useShiftEditorStore} from '@/features/shift-editor';
 import WardAPI from '@/shared/api/ward';
 import {HistoryBackIcon, HistoryNextIcon, InfoIcon, PlusIcon, SaveCompleteIcon, SavingIcon} from '@/shared/assets/svg';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
-import PageState from '@/shared/ui/PageState';
 import {renderMultilineText} from '@/shared/util/string';
 import {
     canConfirmAiAutofill,
@@ -31,20 +17,8 @@ import {
 import {requestAiSchedule} from '../../model/ai-schedule-provider';
 import {canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
-
-function isSameDocShape(a: TDutyDoc, b: TDutyDoc): boolean {
-    if (a.columns.length !== b.columns.length || a.rows.length !== b.rows.length) return false;
-
-    for (let i = 0; i < a.columns.length; i += 1) {
-        if (a.columns[i] !== b.columns[i]) return false;
-    }
-
-    for (let i = 0; i < a.rows.length; i += 1) {
-        if (a.rows[i]?.workerId !== b.rows[i]?.workerId) return false;
-    }
-
-    return true;
-}
+import {DutyEditorStepCanvas} from './shared/duty-editor-step-canvas';
+import {useDutyEditorStep} from './shared/use-duty-editor-step';
 
 export function AiAutofill() {
     const {t} = useTypedTranslation();
@@ -54,30 +28,34 @@ export function AiAutofill() {
     const year = useMakeShiftStore((s) => s.year);
     const month = useMakeShiftStore((s) => s.month);
     const currentShiftTeamId = useMakeShiftStore((s) => s.currentShiftTeamId);
-    const enabled = wardId !== null && currentShiftTeamId !== null;
-    const dutyQuery = useQuery({
-        ...wardQueryOptions.duty(wardId ?? -1, currentShiftTeamId ?? -1, year, month),
-        enabled,
-    });
-    const editorDoc = useShiftEditorStore((s) => s.doc);
-    const violations = useShiftEditorStore((s) => s.violations);
-    const history = useShiftEditorStore((s) => s.history);
     const commands = useShiftEditorCommands();
+    const editorDoc = useShiftEditorStore((s) => s.doc);
+    const history = useShiftEditorStore((s) => s.history);
     const useCase = useMakeShiftUseCase();
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
-    const workKeyMap = useMemo(() => buildWorkKeyMap(dutyQuery.data), [dutyQuery.data]);
-    const {onKeyDown, onPaste} = useShiftEditorKeyBindings({workKeyMap});
-    const editorRef = useRef<HTMLDivElement>(null);
     const [autoFillEnabled, setAutoFillEnabled] = useState(false);
     const [showFaults, setShowFaults] = useState(true);
-    const violationMap = useMemo(() => buildViolationMap(violations, editorDoc), [violations, editorDoc]);
     const [isWorking, setIsWorking] = useState(false);
     const [isAiGenerating, setIsAiGenerating] = useState(false);
     const [aiStatus, setAiStatus] = useState<TAiAutofillStatus>('idle');
     const [lastErrorMessage, setLastErrorMessage] = useState<string | null>(null);
+    const resetAiStatus = useCallback(() => {
+        setAiStatus('idle');
+        setLastErrorMessage(null);
+    }, []);
+    const {
+        dutyQuery,
+        editorRef,
+        editorDoc: hydratedDoc,
+        onKeyDown,
+        onPaste,
+        violationMap,
+        focusEditor,
+    } = useDutyEditorStep({
+        onContextChanged: resetAiStatus,
+    });
     const aiRequestSeqRef = useRef(0);
     const currentAiContextRef = useRef({wardId, shiftTeamId: currentShiftTeamId, year, month});
-    const hydratedContextKeyRef = useRef<string | null>(null);
 
     currentAiContextRef.current = {wardId, shiftTeamId: currentShiftTeamId, year, month};
 
@@ -95,7 +73,6 @@ export function AiAutofill() {
     const statusDescription = getAiAutofillStatusDescription(aiStatus, hasDraftChanges);
     const aiActionLabel = getAiAutofillActionLabel(aiStatus);
     const statusTitle = t(`page.makeShift.aiRefill.title.${aiStatus}`);
-    const currentContextKey = `${wardId ?? 'none'}:${currentShiftTeamId ?? 'none'}:${year}:${month}`;
     const handleConfirm = async () => {
         if (!wardId || !dutyQuery.data || !canConfirm) return;
 
@@ -142,8 +119,7 @@ export function AiAutofill() {
                 currentContext.year !== requestContext.year ||
                 currentContext.month !== requestContext.month
             ) {
-                setAiStatus('idle');
-                setLastErrorMessage(null);
+                resetAiStatus();
 
                 return;
             }
@@ -163,36 +139,6 @@ export function AiAutofill() {
             }
         }
     };
-
-    useEffect(() => {
-        if (!dutyQuery.data) return;
-
-        const nextDoc = shiftToDoc(dutyQuery.data, year, month);
-        const persisted = commands.getPersisted();
-        const hasContextChanged = hydratedContextKeyRef.current !== currentContextKey;
-
-        if (persisted && isSameDocShape(persisted.doc, nextDoc)) {
-            commands.hydrate(persisted);
-
-            if (hasContextChanged) {
-                setAiStatus('idle');
-                setLastErrorMessage(null);
-            }
-
-            hydratedContextKeyRef.current = currentContextKey;
-
-            return;
-        }
-
-        commands.init(nextDoc);
-
-        if (hasContextChanged) {
-            setAiStatus('idle');
-            setLastErrorMessage(null);
-        }
-
-        hydratedContextKeyRef.current = currentContextKey;
-    }, [commands, currentContextKey, dutyQuery.data, month, year]);
 
     return (
         <div className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-scroll">
@@ -303,48 +249,21 @@ export function AiAutofill() {
                 </div>
             </div>
 
-            <div className="mt-8 flex min-h-0 flex-1 outline-none" onKeyDown={onKeyDown} onPaste={onPaste} ref={editorRef} tabIndex={0}>
-                {dutyQuery.isLoading && (
-                    <PageState tone="loading" title="근무표를 불러오는 중이에요" description={t('page.state.loadingDescription')} />
-                )}
-                {dutyQuery.isError && (
-                    <PageState
-                        tone="error"
-                        title="근무표를 불러오지 못했어요"
-                        description={t('page.state.errorDescription')}
-                        action={{label: t('page.state.retry'), onClick: () => void dutyQuery.refetch()}}
-                    />
-                )}
-                {!dutyQuery.isLoading && !dutyQuery.isError && dutyQuery.data && (
-                    <div
-                        className="flex min-h-0 flex-1"
-                        onClick={() => {
-                            editorRef.current?.focus();
-                        }}
-                    >
-                        <div className="mx-auto flex w-fit min-w-418.5 flex-col">
-                            <ShiftCalendar
-                                shift={dutyQuery.data}
-                                doc={editorDoc}
-                                onCellClick={() => editorRef.current?.focus()}
-                                disableInitialSelection
-                                violations={violationMap}
-                                showLayer={{fault: showFaults, check: false, slash: false}}
-                            />
-                            <div
-                                className="sticky bottom-0 z-20 flex items-stretch gap-5 py-5 pl-55.25"
-                                style={{
-                                    height: dutyQuery.data
-                                        ? `${dutyQuery.data.wardShiftTypes.filter((x) => x.isCounted).length * 2.5 + 2.5}rem`
-                                        : '0',
-                                }}
-                            >
-                                <CountDutyByDay shift={dutyQuery.data} doc={editorDoc} />
-                            </div>
-                        </div>
-                    </div>
-                )}
-            </div>
+            <DutyEditorStepCanvas
+                duty={dutyQuery.data}
+                isLoading={dutyQuery.isLoading}
+                isError={dutyQuery.isError}
+                onRetry={dutyQuery.refetch}
+                loadingTitle="근무표를 불러오는 중이에요"
+                errorTitle="근무표를 불러오지 못했어요"
+                editorDoc={hydratedDoc}
+                violationMap={violationMap}
+                editorRef={editorRef}
+                onKeyDown={onKeyDown}
+                onPaste={onPaste}
+                onFocusEditor={focusEditor}
+                showFaults={showFaults}
+            />
         </div>
     );
 }

--- a/apps/app/src/pages/make-shift/view/steps/constraints-sections.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/constraints-sections.tsx
@@ -1,0 +1,194 @@
+import {cn} from '@dutying/utils/style';
+import {Draggable, Droppable} from '@hello-pangea/dnd';
+import {ChevronDown} from 'lucide-react';
+import {type ReactNode} from 'react';
+import {type TDutyRuleMeta, DUTY_RULE_META} from '@/features/shift-editor/model/duty-constraints';
+import {type TDutyRuleKey} from '@/features/shift-editor/model/types';
+import {InfoIcon, SixDotsIcon} from '@/shared/assets/svg';
+import {type useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import Select from '@/shared/ui/form-controls/Select';
+
+type TBucket = 'error' | 'warning' | 'excluded';
+type TTypedT = ReturnType<typeof useTypedTranslation>['t'];
+
+type TConstraintSectionProps = {
+    title: string;
+    countLabel: string;
+    isOpen?: boolean;
+    onToggle?: () => void;
+    disabled?: boolean;
+    infoLabel?: string;
+    children: ReactNode;
+};
+
+export function ConstraintSection({title, countLabel, isOpen, onToggle, disabled = false, infoLabel, children}: TConstraintSectionProps) {
+    const collapsible = typeof isOpen === 'boolean' && onToggle;
+
+    return (
+        <>
+            <div className="flex items-center justify-between">
+                {collapsible ? (
+                    <button
+                        type="button"
+                        className="flex items-center gap-2 font-apple text-[24px] font-bold text-sub-2 disabled:opacity-50"
+                        onClick={onToggle}
+                        disabled={disabled}
+                    >
+                        {title}
+                        <ChevronDown className={cn('h-6 w-6 transition-transform', isOpen ? 'rotate-180' : 'rotate-0')} />
+                    </button>
+                ) : (
+                    <p className="font-apple text-[24px] font-bold text-gray-4">{title}</p>
+                )}
+                <p className="font-apple text-[20px] font-medium text-gray-4">{countLabel}</p>
+            </div>
+
+            {collapsible && !isOpen ? null : (
+                <div className="mt-4 rounded-[15px] bg-gray-7 p-[30px]">
+                    {infoLabel ? (
+                        <div className="mb-[18px] flex items-center gap-2">
+                            <InfoIcon className="h-6 w-6" />
+                            <p className="font-apple text-base font-semibold text-main-1">{infoLabel}</p>
+                        </div>
+                    ) : null}
+                    {children}
+                </div>
+            )}
+        </>
+    );
+}
+
+export function renderRuleEditor(t: TTypedT, meta: TDutyRuleMeta, value: number | null, onChange: (next: number) => void) {
+    if (!meta.valueField || !meta.valueOptions || meta.kind === 'noValue') return null;
+
+    const options = meta.valueOptions.map((n) => ({value: n, label: n}));
+    const select = (
+        <Select
+            value={value ?? ''}
+            onChange={(e) => onChange(parseInt(e.target.value))}
+            options={options}
+            className="mx-[.3125rem] h-11 w-16.75"
+            selectClassName="rounded-[5px] px-[15px] py-[7px] outline-[0.5px] outline-main-4 text-main-1"
+        />
+    );
+
+    if (meta.kind === 'maxDays') {
+        return (
+            <div className="ml-2 flex items-center text-[1.25rem] text-main-1">
+                {t('page.makeShift.constraints.phrase.max')}
+                {select}
+                {t('page.makeShift.constraints.phrase.day')}
+            </div>
+        );
+    }
+
+    if (meta.kind === 'minDays') {
+        return (
+            <div className="ml-2 flex items-center text-[1.25rem] text-main-1">
+                {t('page.makeShift.constraints.phrase.min')}
+                {select}
+                {t('page.makeShift.constraints.phrase.day')}
+            </div>
+        );
+    }
+
+    if (meta.kind === 'daysOnly') {
+        return (
+            <div className="ml-2 flex items-center text-[1.25rem] text-main-1">
+                {select}
+                {t('page.makeShift.constraints.phrase.day')}
+            </div>
+        );
+    }
+
+    return null;
+}
+
+type TConstraintBucketListProps = {
+    t: TTypedT;
+    bucket: TBucket;
+    ruleKeys: TDutyRuleKey[];
+    ruleViolationCount: Map<string, number>;
+    wardConstraint: Record<string, unknown> | null;
+    onUpdateRuleValue: (meta: TDutyRuleMeta, nextValue: number) => void;
+};
+
+export function ConstraintBucketList({
+    t,
+    bucket,
+    ruleKeys,
+    ruleViolationCount,
+    wardConstraint,
+    onUpdateRuleValue,
+}: TConstraintBucketListProps) {
+    if (ruleKeys.length === 0) {
+        return (
+            <div className="rounded-[10px] bg-white px-6 py-5 text-center font-apple text-sm text-gray-4">
+                {t('page.makeShift.constraints.empty')}
+            </div>
+        );
+    }
+
+    return (
+        <Droppable droppableId={bucket}>
+            {(provided, snapshot) => (
+                <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className={cn(bucket === 'excluded' && 'min-h-[10px]', snapshot.isDraggingOver && 'bg-[#f0ecff]')}
+                >
+                    <div className="flex flex-col gap-3">
+                        {ruleKeys.map((key, index) => {
+                            const meta = DUTY_RULE_META[key];
+                            const label = t(meta.labelKey);
+                            const count = ruleViolationCount.get(`duty.${key}`) ?? 0;
+                            const value = wardConstraint && meta.valueField ? (wardConstraint[meta.valueField] as number) : null;
+
+                            return (
+                                <Draggable draggableId={key} index={index} key={key}>
+                                    {(dragProvided, dragSnapshot) => (
+                                        <div
+                                            ref={dragProvided.innerRef}
+                                            {...dragProvided.draggableProps}
+                                            className={cn('flex items-center gap-5', dragSnapshot.isDragging && 'opacity-95')}
+                                        >
+                                            <div className="w-10 text-center font-apple text-[28px] text-gray-3">{index + 1}</div>
+                                            <div className="flex h-[62px] flex-1 items-center rounded-[10px] bg-white px-5">
+                                                <button
+                                                    type="button"
+                                                    aria-label={t('page.makeShift.constraints.dragHandleAria')}
+                                                    className="mr-4 cursor-grab active:cursor-grabbing"
+                                                    {...dragProvided.dragHandleProps}
+                                                >
+                                                    <SixDotsIcon className="h-6 w-6" />
+                                                </button>
+                                                <div className="min-w-0 flex-1">
+                                                    <div className="flex items-center gap-3">
+                                                        <p className="truncate font-apple text-[20px] font-medium text-sub-1">{label}</p>
+                                                        {count > 0 ? (
+                                                            <span className="rounded-full bg-main-light px-2 py-0.5 font-apple text-xs font-medium text-main-1">
+                                                                {t('page.makeShift.constraints.violationCount', {count})}
+                                                            </span>
+                                                        ) : null}
+                                                    </div>
+                                                </div>
+                                                <div className="shrink-0">
+                                                    {wardConstraint
+                                                        ? renderRuleEditor(t, meta, value, (nextValue) =>
+                                                              onUpdateRuleValue(meta, nextValue),
+                                                          )
+                                                        : null}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    )}
+                                </Draggable>
+                            );
+                        })}
+                        {provided.placeholder}
+                    </div>
+                </div>
+            )}
+        </Droppable>
+    );
+}

--- a/apps/app/src/pages/make-shift/view/steps/constraints-sections.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/constraints-sections.tsx
@@ -65,7 +65,7 @@ export function renderRuleEditor(t: TTypedT, meta: TDutyRuleMeta, value: number 
     const select = (
         <Select
             value={value ?? ''}
-            onChange={(e) => onChange(parseInt(e.target.value))}
+            onChange={(e) => onChange(parseInt(e.target.value, 10))}
             options={options}
             className="mx-[.3125rem] h-11 w-16.75"
             selectClassName="rounded-[5px] px-[15px] py-[7px] outline-[0.5px] outline-main-4 text-main-1"
@@ -121,14 +121,6 @@ export function ConstraintBucketList({
     wardConstraint,
     onUpdateRuleValue,
 }: TConstraintBucketListProps) {
-    if (ruleKeys.length === 0) {
-        return (
-            <div className="rounded-[10px] bg-white px-6 py-5 text-center font-apple text-sm text-gray-4">
-                {t('page.makeShift.constraints.empty')}
-            </div>
-        );
-    }
-
     return (
         <Droppable droppableId={bucket}>
             {(provided, snapshot) => (
@@ -137,56 +129,64 @@ export function ConstraintBucketList({
                     {...provided.droppableProps}
                     className={cn(bucket === 'excluded' && 'min-h-[10px]', snapshot.isDraggingOver && 'bg-[#f0ecff]')}
                 >
-                    <div className="flex flex-col gap-3">
-                        {ruleKeys.map((key, index) => {
-                            const meta = DUTY_RULE_META[key];
-                            const label = t(meta.labelKey);
-                            const count = ruleViolationCount.get(`duty.${key}`) ?? 0;
-                            const value = wardConstraint && meta.valueField ? (wardConstraint[meta.valueField] as number) : null;
+                    {ruleKeys.length === 0 ? (
+                        <div className="rounded-[10px] bg-white px-6 py-5 text-center font-apple text-sm text-gray-4">
+                            {t('page.makeShift.constraints.empty')}
+                        </div>
+                    ) : (
+                        <div className="flex flex-col gap-3">
+                            {ruleKeys.map((key, index) => {
+                                const meta = DUTY_RULE_META[key];
+                                const label = t(meta.labelKey);
+                                const count = ruleViolationCount.get(`duty.${key}`) ?? 0;
+                                const value = wardConstraint && meta.valueField ? (wardConstraint[meta.valueField] as number) : null;
 
-                            return (
-                                <Draggable draggableId={key} index={index} key={key}>
-                                    {(dragProvided, dragSnapshot) => (
-                                        <div
-                                            ref={dragProvided.innerRef}
-                                            {...dragProvided.draggableProps}
-                                            className={cn('flex items-center gap-5', dragSnapshot.isDragging && 'opacity-95')}
-                                        >
-                                            <div className="w-10 text-center font-apple text-[28px] text-gray-3">{index + 1}</div>
-                                            <div className="flex h-[62px] flex-1 items-center rounded-[10px] bg-white px-5">
-                                                <button
-                                                    type="button"
-                                                    aria-label={t('page.makeShift.constraints.dragHandleAria')}
-                                                    className="mr-4 cursor-grab active:cursor-grabbing"
-                                                    {...dragProvided.dragHandleProps}
-                                                >
-                                                    <SixDotsIcon className="h-6 w-6" />
-                                                </button>
-                                                <div className="min-w-0 flex-1">
-                                                    <div className="flex items-center gap-3">
-                                                        <p className="truncate font-apple text-[20px] font-medium text-sub-1">{label}</p>
-                                                        {count > 0 ? (
-                                                            <span className="rounded-full bg-main-light px-2 py-0.5 font-apple text-xs font-medium text-main-1">
-                                                                {t('page.makeShift.constraints.violationCount', {count})}
-                                                            </span>
-                                                        ) : null}
+                                return (
+                                    <Draggable draggableId={key} index={index} key={key}>
+                                        {(dragProvided, dragSnapshot) => (
+                                            <div
+                                                ref={dragProvided.innerRef}
+                                                {...dragProvided.draggableProps}
+                                                className={cn('flex items-center gap-5', dragSnapshot.isDragging && 'opacity-95')}
+                                            >
+                                                <div className="w-10 text-center font-apple text-[28px] text-gray-3">{index + 1}</div>
+                                                <div className="flex h-[62px] flex-1 items-center rounded-[10px] bg-white px-5">
+                                                    <button
+                                                        type="button"
+                                                        aria-label={t('page.makeShift.constraints.dragHandleAria')}
+                                                        className="mr-4 cursor-grab active:cursor-grabbing"
+                                                        {...dragProvided.dragHandleProps}
+                                                    >
+                                                        <SixDotsIcon className="h-6 w-6" />
+                                                    </button>
+                                                    <div className="min-w-0 flex-1">
+                                                        <div className="flex items-center gap-3">
+                                                            <p className="truncate font-apple text-[20px] font-medium text-sub-1">
+                                                                {label}
+                                                            </p>
+                                                            {count > 0 ? (
+                                                                <span className="rounded-full bg-main-light px-2 py-0.5 font-apple text-xs font-medium text-main-1">
+                                                                    {t('page.makeShift.constraints.violationCount', {count})}
+                                                                </span>
+                                                            ) : null}
+                                                        </div>
+                                                    </div>
+                                                    <div className="shrink-0">
+                                                        {wardConstraint
+                                                            ? renderRuleEditor(t, meta, value, (nextValue) =>
+                                                                  onUpdateRuleValue(meta, nextValue),
+                                                              )
+                                                            : null}
                                                     </div>
                                                 </div>
-                                                <div className="shrink-0">
-                                                    {wardConstraint
-                                                        ? renderRuleEditor(t, meta, value, (nextValue) =>
-                                                              onUpdateRuleValue(meta, nextValue),
-                                                          )
-                                                        : null}
-                                                </div>
                                             </div>
-                                        </div>
-                                    )}
-                                </Draggable>
-                            );
-                        })}
-                        {provided.placeholder}
-                    </div>
+                                        )}
+                                    </Draggable>
+                                );
+                            })}
+                            {provided.placeholder}
+                        </div>
+                    )}
                 </div>
             )}
         </Droppable>

--- a/apps/app/src/pages/make-shift/view/steps/constraints.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/constraints.tsx
@@ -1,61 +1,11 @@
-import {cn} from '@dutying/utils/style';
-import {DragDropContext, Draggable, Droppable, type DropResult} from '@hello-pangea/dnd';
-import {ChevronDown} from 'lucide-react';
+import {DragDropContext, type DropResult} from '@hello-pangea/dnd';
 import {useMemo, useState} from 'react';
 import {useShiftEditorCommands, useShiftEditorStore} from '@/features/shift-editor';
-import {DUTY_RULE_META, type TDutyRuleMeta} from '@/features/shift-editor/model/duty-constraints';
-import {InfoIcon, SixDotsIcon} from '@/shared/assets/svg';
+import {type TDutyRuleMeta} from '@/features/shift-editor/model/duty-constraints';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
-import Select from '@/shared/ui/form-controls/Select';
+import {ConstraintBucketList, ConstraintSection} from './constraints-sections';
 
 type TBucket = 'error' | 'warning' | 'excluded';
-type TTypedT = ReturnType<typeof useTypedTranslation>['t'];
-
-function renderRuleEditor(t: TTypedT, meta: TDutyRuleMeta, value: number | null, onChange: (next: number) => void) {
-    if (!meta.valueField || !meta.valueOptions || meta.kind === 'noValue') return null;
-
-    const options = meta.valueOptions.map((n) => ({value: n, label: n}));
-    const select = (
-        <Select
-            value={value ?? ''}
-            onChange={(e) => onChange(parseInt(e.target.value))}
-            options={options}
-            className="mx-[.3125rem] h-11 w-16.75"
-            selectClassName="rounded-[5px] px-[15px] py-[7px] outline-[0.5px] outline-main-4 text-main-1"
-        />
-    );
-
-    if (meta.kind === 'maxDays') {
-        return (
-            <div className="ml-2 flex items-center text-[1.25rem] text-main-1">
-                {t('page.makeShift.constraints.phrase.max')}
-                {select}
-                {t('page.makeShift.constraints.phrase.day')}
-            </div>
-        );
-    }
-
-    if (meta.kind === 'minDays') {
-        return (
-            <div className="ml-2 flex items-center text-[1.25rem] text-main-1">
-                {t('page.makeShift.constraints.phrase.min')}
-                {select}
-                {t('page.makeShift.constraints.phrase.day')}
-            </div>
-        );
-    }
-
-    if (meta.kind === 'daysOnly') {
-        return (
-            <div className="ml-2 flex items-center text-[1.25rem] text-main-1">
-                {select}
-                {t('page.makeShift.constraints.phrase.day')}
-            </div>
-        );
-    }
-
-    return null;
-}
 
 export function Constraints() {
     const {t} = useTypedTranslation();
@@ -107,84 +57,6 @@ export function Constraints() {
 
         editor.setWardConstraint({...wardConstraint, [meta.valueField]: nextValue});
     };
-    const renderBucket = (bucket: TBucket, isCollapsed: boolean) => {
-        if (!board) {
-            return (
-                <div className="rounded-[10px] bg-white px-6 py-5 text-center font-apple text-sm text-gray-4">
-                    {t('page.makeShift.constraints.empty')}
-                </div>
-            );
-        }
-
-        const keys = board[bucket];
-
-        if (isCollapsed) return null;
-
-        return (
-            <Droppable droppableId={bucket} isDropDisabled={false} isCombineEnabled={false}>
-                {(provided, snapshot) => (
-                    <div
-                        ref={provided.innerRef}
-                        {...provided.droppableProps}
-                        className={cn(bucket === 'excluded' && 'min-h-[10px]', snapshot.isDraggingOver && 'bg-[#f0ecff]')}
-                    >
-                        <div className="flex flex-col gap-3">
-                            {keys.map((key, index) => {
-                                const meta = DUTY_RULE_META[key];
-                                const label = t(meta.labelKey);
-                                const count = ruleViolationCount.get(`duty.${key}`) ?? 0;
-                                const value =
-                                    wardConstraint && meta.valueField ? (wardConstraint[meta.valueField] as unknown as number) : null;
-
-                                return (
-                                    <Draggable draggableId={key} index={index} key={key} isDragDisabled={false}>
-                                        {(dragProvided, dragSnapshot) => (
-                                            <div
-                                                ref={dragProvided.innerRef}
-                                                {...dragProvided.draggableProps}
-                                                className={cn('flex items-center gap-5', dragSnapshot.isDragging && 'opacity-95')}
-                                            >
-                                                <div className="w-10 text-center font-apple text-[28px] text-gray-3">{index + 1}</div>
-                                                <div className="flex h-[62px] flex-1 items-center rounded-[10px] bg-white px-5">
-                                                    <button
-                                                        type="button"
-                                                        aria-label={t('page.makeShift.constraints.dragHandleAria')}
-                                                        className="mr-4 cursor-grab active:cursor-grabbing"
-                                                        {...dragProvided.dragHandleProps}
-                                                    >
-                                                        <SixDotsIcon className="h-6 w-6" />
-                                                    </button>
-                                                    <div className="min-w-0 flex-1">
-                                                        <div className="flex items-center gap-3">
-                                                            <p className="truncate font-apple text-[20px] font-medium text-sub-1">
-                                                                {label}
-                                                            </p>
-                                                            {count > 0 && (
-                                                                <span className="rounded-full bg-main-light px-2 py-0.5 font-apple text-xs font-medium text-main-1">
-                                                                    {t('page.makeShift.constraints.violationCount', {count})}
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                    </div>
-                                                    <div className="shrink-0">
-                                                        {wardConstraint &&
-                                                            renderRuleEditor(t, meta, value, (v) => {
-                                                                updateRuleValue(meta, v);
-                                                            })}
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        )}
-                                    </Draggable>
-                                );
-                            })}
-                            {provided.placeholder}
-                        </div>
-                    </div>
-                )}
-            </Droppable>
-        );
-    };
     const strongCount = board?.error.length ?? 0;
     const weakCount = board?.warning.length ?? 0;
     const excludedCount = board?.excluded.length ?? 0;
@@ -193,64 +65,59 @@ export function Constraints() {
     return (
         <DragDropContext onDragEnd={onDragEnd}>
             <div className="w-full">
-                <div className="flex items-center justify-between">
-                    <button
-                        type="button"
-                        className="flex items-center gap-2 font-apple text-[24px] font-bold text-sub-2 disabled:opacity-50"
-                        onClick={() => setOpen((s) => ({...s, error: !s.error}))}
+                <ConstraintSection
+                    title={t('page.makeShift.constraints.section.strong')}
+                    countLabel={t('page.makeShift.constraints.count', {count: strongCount})}
+                    isOpen={open.error}
+                    onToggle={() => setOpen((state) => ({...state, error: !state.error}))}
+                    disabled={disabled}
+                    infoLabel={t('page.makeShift.constraints.info')}
+                >
+                    <ConstraintBucketList
+                        t={t}
+                        bucket="error"
+                        ruleKeys={board?.error ?? []}
+                        ruleViolationCount={ruleViolationCount}
+                        wardConstraint={wardConstraint}
+                        onUpdateRuleValue={updateRuleValue}
+                    />
+                </ConstraintSection>
+
+                <div className="mt-6">
+                    <ConstraintSection
+                        title={t('page.makeShift.constraints.section.weak')}
+                        countLabel={t('page.makeShift.constraints.count', {count: weakCount})}
+                        isOpen={open.warning}
+                        onToggle={() => setOpen((state) => ({...state, warning: !state.warning}))}
                         disabled={disabled}
+                        infoLabel={t('page.makeShift.constraints.info')}
                     >
-                        {t('page.makeShift.constraints.section.strong')}
-                        <ChevronDown className={cn('h-6 w-6 transition-transform', open.error ? 'rotate-180' : 'rotate-0')} />
-                    </button>
-                    <p className="font-apple text-[20px] font-medium text-gray-4">
-                        {t('page.makeShift.constraints.count', {count: strongCount})}
-                    </p>
+                        <ConstraintBucketList
+                            t={t}
+                            bucket="warning"
+                            ruleKeys={board?.warning ?? []}
+                            ruleViolationCount={ruleViolationCount}
+                            wardConstraint={wardConstraint}
+                            onUpdateRuleValue={updateRuleValue}
+                        />
+                    </ConstraintSection>
                 </div>
 
-                {open.error && (
-                    <div className="mt-4 rounded-[15px] bg-gray-7 p-[30px] pt-[20px]">
-                        <div className="mb-[18px] flex items-center gap-2">
-                            <InfoIcon className="h-6 w-6" />
-                            <p className="font-apple text-base font-semibold text-main-1">{t('page.makeShift.constraints.info')}</p>
-                        </div>
-                        {renderBucket('error', !open.error)}
-                    </div>
-                )}
-
-                <div className="mt-6 flex items-center justify-between">
-                    <button
-                        type="button"
-                        className="flex items-center gap-2 font-apple text-[24px] font-bold text-sub-2 disabled:opacity-50"
-                        onClick={() => setOpen((s) => ({...s, warning: !s.warning}))}
-                        disabled={disabled}
+                <div className="mt-8">
+                    <ConstraintSection
+                        title={t('page.makeShift.constraints.section.excluded')}
+                        countLabel={t('page.makeShift.constraints.count', {count: excludedCount})}
                     >
-                        {t('page.makeShift.constraints.section.weak')}
-                        <ChevronDown className={cn('h-6 w-6 transition-transform', open.warning ? 'rotate-180' : 'rotate-0')} />
-                    </button>
-                    <p className="font-apple text-[20px] font-medium text-gray-4">
-                        {t('page.makeShift.constraints.count', {count: weakCount})}
-                    </p>
+                        <ConstraintBucketList
+                            t={t}
+                            bucket="excluded"
+                            ruleKeys={board?.excluded ?? []}
+                            ruleViolationCount={ruleViolationCount}
+                            wardConstraint={wardConstraint}
+                            onUpdateRuleValue={updateRuleValue}
+                        />
+                    </ConstraintSection>
                 </div>
-
-                {open.warning && (
-                    <div className="mt-4 rounded-[15px] bg-gray-7 p-[30px]">
-                        <div className="mb-[18px] flex items-center gap-2">
-                            <InfoIcon className="h-6 w-6" />
-                            <p className="font-apple text-base font-semibold text-main-1">{t('page.makeShift.constraints.info')}</p>
-                        </div>
-                        {renderBucket('warning', !open.warning)}
-                    </div>
-                )}
-
-                <div className="mt-8 flex items-center justify-between">
-                    <p className="font-apple text-[24px] font-bold text-gray-4">{t('page.makeShift.constraints.section.excluded')}</p>
-                    <p className="font-apple text-[20px] font-medium text-gray-4">
-                        {t('page.makeShift.constraints.count', {count: excludedCount})}
-                    </p>
-                </div>
-
-                <div className="mt-4 rounded-[15px] bg-gray-7 p-[30px]">{renderBucket('excluded', false)}</div>
             </div>
         </DragDropContext>
     );

--- a/apps/app/src/pages/make-shift/view/steps/fixed-shifts.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/fixed-shifts.tsx
@@ -1,3 +1,4 @@
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import {ManagementActionButton} from '@/widgets/duty-management/ui';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
@@ -5,6 +6,7 @@ import {DutyEditorStepCanvas} from './shared/duty-editor-step-canvas';
 import {useDutyEditorStep} from './shared/use-duty-editor-step';
 
 export function FixedShifts() {
+    const {t} = useTypedTranslation();
     const useCase = useMakeShiftUseCase();
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
     const canNext = useMakeShiftStore((s) => canGoNext(s));
@@ -31,8 +33,8 @@ export function FixedShifts() {
                 isLoading={dutyQuery.isLoading}
                 isError={dutyQuery.isError}
                 onRetry={dutyQuery.refetch}
-                loadingTitle="근무표를 불러오는 중이에요"
-                errorTitle="고정 근무 데이터를 불러오지 못했어요"
+                loadingTitle={t('page.makeShift.fixedShifts.loading')}
+                errorTitle={t('page.makeShift.fixedShifts.error')}
                 editorDoc={editorDoc}
                 violationMap={violationMap}
                 editorRef={editorRef}

--- a/apps/app/src/pages/make-shift/view/steps/fixed-shifts.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/fixed-shifts.tsx
@@ -1,76 +1,14 @@
-import {useQuery} from '@tanstack/react-query';
-import {useEffect, useMemo, useRef} from 'react';
-import {wardQueryOptions} from '@/entities/ward/model/queries';
-import useAuth from '@/features/auth/useAuth';
-import {
-    buildWorkKeyMap,
-    buildViolationMap,
-    shiftToDoc,
-    type TDutyDoc,
-    useShiftEditorCommands,
-    useShiftEditorKeyBindings,
-    useShiftEditorStore,
-} from '@/features/shift-editor';
-import CountDutyByDay from '@/features/shift-editor/ui/complex-view/count-duty-by-day';
-import ShiftCalendar from '@/features/shift-editor/ui/complex-view/shift-calendar';
-import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
-import PageState from '@/shared/ui/PageState';
 import {ManagementActionButton} from '@/widgets/duty-management/ui';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
-
-function isSameDocShape(a: TDutyDoc, b: TDutyDoc): boolean {
-    if (a.columns.length !== b.columns.length || a.rows.length !== b.rows.length) return false;
-
-    for (let i = 0; i < a.columns.length; i += 1) {
-        if (a.columns[i] !== b.columns[i]) return false;
-    }
-
-    for (let i = 0; i < a.rows.length; i += 1) {
-        if (a.rows[i]?.workerId !== b.rows[i]?.workerId) return false;
-    }
-
-    return true;
-}
+import {DutyEditorStepCanvas} from './shared/duty-editor-step-canvas';
+import {useDutyEditorStep} from './shared/use-duty-editor-step';
 
 export function FixedShifts() {
     const useCase = useMakeShiftUseCase();
-    const {t} = useTypedTranslation();
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
     const canNext = useMakeShiftStore((s) => canGoNext(s));
-    const editorDoc = useShiftEditorStore((s) => s.doc);
-    const commands = useShiftEditorCommands();
-    const editorRef = useRef<HTMLDivElement>(null);
-    const {
-        state: {wardId},
-    } = useAuth();
-    const year = useMakeShiftStore((s) => s.year);
-    const month = useMakeShiftStore((s) => s.month);
-    const currentShiftTeamId = useMakeShiftStore((s) => s.currentShiftTeamId);
-    const enabled = wardId !== null && currentShiftTeamId !== null;
-    const dutyQuery = useQuery({
-        ...wardQueryOptions.duty(wardId ?? -1, currentShiftTeamId ?? -1, year, month),
-        enabled,
-    });
-    const workKeyMap = useMemo(() => buildWorkKeyMap(dutyQuery.data), [dutyQuery.data]);
-    const {onKeyDown, onPaste} = useShiftEditorKeyBindings({workKeyMap});
-    const violations = useShiftEditorStore((s) => s.violations);
-    const violationMap = useMemo(() => buildViolationMap(violations, editorDoc), [violations, editorDoc]);
-
-    useEffect(() => {
-        if (!dutyQuery.data) return;
-
-        const nextDoc = shiftToDoc(dutyQuery.data, year, month);
-        const persisted = commands.getPersisted();
-
-        if (persisted && isSameDocShape(persisted.doc, nextDoc)) {
-            commands.hydrate(persisted);
-
-            return;
-        }
-
-        commands.init(nextDoc);
-    }, [commands, dutyQuery.data, month, year]);
+    const {dutyQuery, editorDoc, violationMap, editorRef, onKeyDown, onPaste, focusEditor} = useDutyEditorStep();
 
     return (
         <div className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-scroll">
@@ -88,49 +26,21 @@ export function FixedShifts() {
                     </ManagementActionButton>
                 </div>
             </div>
-
-            <div className="mt-8 flex min-h-0 flex-1 outline-none" onKeyDown={onKeyDown} onPaste={onPaste} ref={editorRef} tabIndex={0}>
-                {dutyQuery.isLoading && (
-                    <PageState tone="loading" title="근무표를 불러오는 중이에요" description={t('page.state.loadingDescription')} />
-                )}
-                {dutyQuery.isError && (
-                    <PageState
-                        tone="error"
-                        title="고정 근무 데이터를 불러오지 못했어요"
-                        description={t('page.state.errorDescription')}
-                        action={{label: t('page.state.retry'), onClick: () => void dutyQuery.refetch()}}
-                    />
-                )}
-                {!dutyQuery.isLoading && !dutyQuery.isError && dutyQuery.data && (
-                    <div
-                        className="flex min-h-0 flex-1"
-                        onClick={() => {
-                            editorRef.current?.focus();
-                        }}
-                    >
-                        <div className="mx-auto flex w-fit min-w-418.5 flex-col">
-                            <ShiftCalendar
-                                shift={dutyQuery.data}
-                                doc={editorDoc}
-                                onCellClick={() => editorRef.current?.focus()}
-                                disableInitialSelection
-                                violations={violationMap}
-                                showLayer={{fault: true, check: false, slash: false}}
-                            />
-                            <div
-                                className="sticky bottom-0 z-20 flex items-stretch gap-5 py-5 pl-55.25"
-                                style={{
-                                    height: dutyQuery.data
-                                        ? `${dutyQuery.data.wardShiftTypes.filter((x) => x.isCounted).length * 2.5 + 2.5}rem`
-                                        : '0',
-                                }}
-                            >
-                                <CountDutyByDay shift={dutyQuery.data} doc={editorDoc} />
-                            </div>
-                        </div>
-                    </div>
-                )}
-            </div>
+            <DutyEditorStepCanvas
+                duty={dutyQuery.data}
+                isLoading={dutyQuery.isLoading}
+                isError={dutyQuery.isError}
+                onRetry={dutyQuery.refetch}
+                loadingTitle="근무표를 불러오는 중이에요"
+                errorTitle="고정 근무 데이터를 불러오지 못했어요"
+                editorDoc={editorDoc}
+                violationMap={violationMap}
+                editorRef={editorRef}
+                onKeyDown={onKeyDown}
+                onPaste={onPaste}
+                onFocusEditor={focusEditor}
+                showFaults
+            />
         </div>
     );
 }

--- a/apps/app/src/pages/make-shift/view/steps/requests-shifts-sections.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/requests-shifts-sections.tsx
@@ -1,0 +1,359 @@
+import {type ReactNode} from 'react';
+import {type TDutyRequest, type TRequestShift, type TWardShiftType} from '@/entities';
+import ShiftBadge from '@/entities/shift/ui/shift-badge';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import Button from '@/shared/ui/form-controls/Button';
+import PageState from '@/shared/ui/PageState';
+import StatusBadge from '@/shared/ui/StatusBadge';
+
+type TAcceptedRequestSummary = {
+    id: TDutyRequest['wardReqShiftId'];
+    nurseName: TDutyRequest['nurseName'];
+    date: TDutyRequest['date'];
+    wardShiftTypeId: TDutyRequest['wardShiftTypeId'];
+};
+
+type TDecisionAction = (wardReqShiftId: number, isAccepted: boolean | null) => void;
+
+type TRequestsShiftsHeaderProps = {
+    acceptedCount: number;
+    pendingCount: number;
+    rejectedCount: number;
+    canPrev: boolean;
+    canNext: boolean;
+    onPrev: () => void;
+    onNext: () => void;
+};
+
+export function RequestsShiftsHeader({
+    acceptedCount,
+    pendingCount,
+    rejectedCount,
+    canPrev,
+    canNext,
+    onPrev,
+    onNext,
+}: TRequestsShiftsHeaderProps) {
+    const {t} = useTypedTranslation();
+
+    return (
+        <div className="flex flex-wrap items-start justify-between gap-6">
+            <div className="flex items-baseline gap-[20px]">
+                <div>
+                    <p className="font-apple text-[32px] font-semibold text-sub-1">{t('page.makeShift.requests.title')}</p>
+                    <p className="font-apple text-xl font-medium text-gray-3">
+                        {t('page.makeShift.requests.descriptionPrefix')}{' '}
+                        <span className="text-main-1">{t('page.makeShift.requests.descriptionHighlight')}</span>
+                        {t('page.makeShift.requests.descriptionSuffix')}
+                    </p>
+                    <div className="mt-4 flex flex-wrap items-center gap-2">
+                        <StatusBadge label={t('page.makeShift.requests.badge.accepted')} tone="success" count={acceptedCount} />
+                        <StatusBadge label={t('page.makeShift.requests.badge.pending')} tone="brand" count={pendingCount} />
+                        <StatusBadge label={t('page.makeShift.requests.badge.rejected')} tone="neutral" count={rejectedCount} />
+                    </div>
+                </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+                <Button
+                    variant="secondary"
+                    size="md"
+                    className="h-[42px] rounded-[10px] px-5 font-semibold"
+                    onClick={onPrev}
+                    disabled={!canPrev}
+                    type="button"
+                >
+                    {t('page.makeShift.navigation.previous')}
+                </Button>
+                <Button size="md" className="h-[42px] rounded-[10px] px-5 font-semibold" onClick={onNext} disabled={!canNext} type="button">
+                    {t('page.makeShift.navigation.next')}
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+type TRequestsShiftBoardProps = {
+    loading: boolean;
+    error: boolean;
+    requestShift: TRequestShift | null;
+    wardShiftTypeMap: Map<number, TWardShiftType>;
+    separateWeekendColor: boolean;
+    onRetry: () => Promise<unknown>;
+};
+
+export function RequestsShiftBoard({
+    loading,
+    error,
+    requestShift,
+    wardShiftTypeMap,
+    separateWeekendColor,
+    onRetry,
+}: TRequestsShiftBoardProps) {
+    const {t} = useTypedTranslation();
+
+    if (loading) {
+        return <PageState tone="loading" title={t('page.makeShift.requests.loading')} description={t('page.state.loadingDescription')} />;
+    }
+
+    if (error) {
+        return (
+            <PageState
+                tone="error"
+                title={t('page.makeShift.requests.error')}
+                description={t('page.state.errorDescription')}
+                action={{label: t('page.state.retry'), onClick: () => void onRetry()}}
+            />
+        );
+    }
+
+    if (!requestShift) {
+        return <PageState tone="empty" title={t('page.makeShift.requests.empty')} description={t('page.state.emptyDescription')} />;
+    }
+
+    return (
+        <div className="flex h-full min-h-0 flex-col">
+            <div className="scrollbar-default min-h-0 scroll-m-2 overflow-auto rounded-[15px] shadow-banner">
+                <div className="flex items-center px-5">
+                    <div className="w-24 shrink-0 text-center font-apple text-[1rem] font-medium text-sub-3">
+                        {t('page.makeShift.requests.table.name')}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                        <div className="inline-flex rounded-[2.5rem] px-4 py-[.1875rem]">
+                            {requestShift.days.map((item, idx) => {
+                                const isSat = item.dayType === 'saturday';
+                                const isSun = item.dayType === 'sunday' || item.dayType === 'holiday';
+                                const textColor = isSun
+                                    ? 'text-red'
+                                    : isSat
+                                      ? separateWeekendColor
+                                          ? 'text-blue'
+                                          : 'text-red'
+                                      : 'text-sub-2.5';
+
+                                return (
+                                    <p key={idx} className={`w-9 flex-1 rounded-full text-center font-poppins text-[1rem] ${textColor}`}>
+                                        {item.day}
+                                    </p>
+                                );
+                            })}
+                        </div>
+                    </div>
+                </div>
+
+                <div className="flex flex-col">
+                    {requestShift.divisionShiftNurses.map((division, divisionIndex) => {
+                        if (division.length === 0) return null;
+
+                        return (
+                            <div key={divisionIndex} className="rounded-[20px] bg-white">
+                                <div className="min-w-0">
+                                    <div className="flex flex-col">
+                                        {division.map((row) => (
+                                            <div key={row.shiftNurse.shiftNurseId} className="flex h-10 items-center px-5">
+                                                <div className="w-24 shrink-0 truncate text-center font-apple text-[1.25rem] text-sub-1">
+                                                    {row.shiftNurse.name}
+                                                </div>
+                                                <div className="flex h-full min-w-max px-4.25">
+                                                    {row.wardReqShiftList.map((wardShiftTypeId, dateIdx) => {
+                                                        const dayType = requestShift.days[dateIdx]?.dayType;
+                                                        const isSat = dayType === 'saturday';
+                                                        const isSun = dayType === 'sunday' || dayType === 'holiday';
+                                                        const bg = isSun
+                                                            ? 'bg-[#FFE1E680]'
+                                                            : isSat
+                                                              ? separateWeekendColor
+                                                                  ? 'bg-[#E1E5FF80]'
+                                                                  : 'bg-[#FFE1E680]'
+                                                              : '';
+
+                                                        return (
+                                                            <div
+                                                                key={dateIdx}
+                                                                className={`flex h-full w-9 items-center justify-center px-[.25rem] ${bg}`}
+                                                            >
+                                                                <ShiftBadge shiftType={wardShiftTypeMap.get(wardShiftTypeId ?? -1)} />
+                                                            </div>
+                                                        );
+                                                    })}
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+type TRequestsDecisionPanelProps = {
+    acceptedRequestSummaries: TAcceptedRequestSummary[];
+    pendingRequests: TDutyRequest[];
+    rejectedRequests: TDutyRequest[];
+    wardShiftTypeMap: Map<number, TWardShiftType>;
+    updatingRequestId: number | null;
+    onDecideRequest: TDecisionAction;
+};
+
+export function RequestsDecisionPanel({
+    acceptedRequestSummaries,
+    pendingRequests,
+    rejectedRequests,
+    wardShiftTypeMap,
+    updatingRequestId,
+    onDecideRequest,
+}: TRequestsDecisionPanelProps) {
+    const {t} = useTypedTranslation();
+
+    return (
+        <div className="w-[360px] shrink-0 rounded-[20px] bg-white shadow-banner">
+            <div className="border-b border-sub-4.5 px-6 py-4">
+                <p className="font-apple text-[1.25rem] font-semibold text-main-1">{t('page.makeShift.requests.panelTitle')}</p>
+            </div>
+
+            <div className="scrollbar-hide max-h-[calc(100vh-22rem)] overflow-y-auto px-6 py-4">
+                <RequestsDecisionSection
+                    title={t('page.makeShift.requests.section.accepted')}
+                    count={acceptedRequestSummaries.length}
+                    emptyLabel={t('page.makeShift.requests.emptyAccepted')}
+                    items={acceptedRequestSummaries}
+                    renderActions={(item) => (
+                        <Button
+                            variant="secondary"
+                            size="sm"
+                            className="h-8 rounded-[10px] px-3 text-sm font-semibold"
+                            onClick={() => onDecideRequest(item.id, null)}
+                            disabled={updatingRequestId === item.id}
+                            type="button"
+                        >
+                            {t('page.makeShift.requests.action.hold')}
+                        </Button>
+                    )}
+                    renderBadge={(item) => <ShiftBadge shiftType={wardShiftTypeMap.get(item.wardShiftTypeId ?? -1)} />}
+                />
+
+                <RequestsDecisionSection
+                    className="mt-6"
+                    title={t('page.makeShift.requests.section.pending')}
+                    count={pendingRequests.length}
+                    emptyLabel={t('page.makeShift.requests.emptyPending')}
+                    items={pendingRequests}
+                    renderActions={(item) => (
+                        <div className="flex items-center gap-1">
+                            <Button
+                                size="sm"
+                                className="h-8 rounded-[10px] px-3 text-sm font-semibold"
+                                onClick={() => onDecideRequest(item.wardReqShiftId, true)}
+                                disabled={updatingRequestId === item.wardReqShiftId}
+                                type="button"
+                            >
+                                {t('page.makeShift.requests.action.accept')}
+                            </Button>
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                className="h-8 rounded-[10px] px-3 text-sm font-semibold"
+                                onClick={() => onDecideRequest(item.wardReqShiftId, false)}
+                                disabled={updatingRequestId === item.wardReqShiftId}
+                                type="button"
+                            >
+                                {t('page.makeShift.requests.action.reject')}
+                            </Button>
+                        </div>
+                    )}
+                    renderBadge={(item) => <ShiftBadge shiftType={wardShiftTypeMap.get(item.wardShiftTypeId ?? -1)} isOnlyRequest />}
+                />
+
+                <RequestsDecisionSection
+                    className="mt-6"
+                    title={t('page.makeShift.requests.section.rejected')}
+                    count={rejectedRequests.length}
+                    emptyLabel={t('page.makeShift.requests.emptyRejected')}
+                    items={rejectedRequests}
+                    renderActions={(item) => (
+                        <div className="flex items-center gap-1">
+                            <Button
+                                size="sm"
+                                className="h-8 rounded-[10px] px-3 text-sm font-semibold"
+                                onClick={() => onDecideRequest(item.wardReqShiftId, true)}
+                                disabled={updatingRequestId === item.wardReqShiftId}
+                                type="button"
+                            >
+                                {t('page.makeShift.requests.action.accept')}
+                            </Button>
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                className="h-8 rounded-[10px] px-3 text-sm font-semibold"
+                                onClick={() => onDecideRequest(item.wardReqShiftId, null)}
+                                disabled={updatingRequestId === item.wardReqShiftId}
+                                type="button"
+                            >
+                                {t('page.makeShift.requests.action.hold')}
+                            </Button>
+                        </div>
+                    )}
+                    renderBadge={(item) => <ShiftBadge shiftType={wardShiftTypeMap.get(item.wardShiftTypeId ?? -1)} isOnlyRequest />}
+                />
+            </div>
+        </div>
+    );
+}
+
+type TRequestsDecisionSectionItem = TAcceptedRequestSummary | TDutyRequest;
+
+type TRequestsDecisionSectionProps<TItem extends TRequestsDecisionSectionItem> = {
+    className?: string;
+    title: string;
+    count: number;
+    emptyLabel: string;
+    items: TItem[];
+    renderBadge: (item: TItem) => ReactNode;
+    renderActions: (item: TItem) => ReactNode;
+};
+
+function RequestsDecisionSection<TItem extends TRequestsDecisionSectionItem>({
+    className,
+    title,
+    count,
+    emptyLabel,
+    items,
+    renderBadge,
+    renderActions,
+}: TRequestsDecisionSectionProps<TItem>) {
+    const {t} = useTypedTranslation();
+
+    return (
+        <div className={className}>
+            <div className="flex items-center justify-between">
+                <p className="font-apple text-base font-semibold text-sub-1">{title}</p>
+                <p className="font-apple text-sm font-medium text-gray-4">{t('page.makeShift.requests.count', {count})}</p>
+            </div>
+
+            <div className="mt-3 space-y-2">
+                {items.length === 0 ? (
+                    <p className="font-apple text-sm font-medium text-gray-4">{emptyLabel}</p>
+                ) : (
+                    items.map((item) => (
+                        <div
+                            key={'wardReqShiftId' in item ? item.wardReqShiftId : item.id}
+                            className="flex items-center gap-3 rounded-[10px] border border-gray-6 px-3 py-2"
+                        >
+                            <div className="min-w-0 flex-1">
+                                <p className="truncate font-apple text-sm font-medium text-sub-1">
+                                    {item.nurseName} / {item.date}일
+                                </p>
+                            </div>
+                            {renderBadge(item)}
+                            {renderActions(item)}
+                        </div>
+                    ))
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/app/src/pages/make-shift/view/steps/requests-shifts-sections.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/requests-shifts-sections.tsx
@@ -345,7 +345,7 @@ function RequestsDecisionSection<TItem extends TRequestsDecisionSectionItem>({
                         >
                             <div className="min-w-0 flex-1">
                                 <p className="truncate font-apple text-sm font-medium text-sub-1">
-                                    {item.nurseName} / {item.date}일
+                                    {t('page.makeShift.requests.itemLabel', {name: item.nurseName, date: item.date})}
                                 </p>
                             </div>
                             {renderBadge(item)}

--- a/apps/app/src/pages/make-shift/view/steps/requests-shifts.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/requests-shifts.tsx
@@ -1,17 +1,12 @@
 import {useMemo} from 'react';
-import ShiftBadge from '@/entities/shift/ui/shift-badge';
 import {useUIConfigStore} from '@/entities/ui/useUIConfig/store';
-import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
-import Button from '@/shared/ui/form-controls/Button';
-import PageState from '@/shared/ui/PageState';
-import StatusBadge from '@/shared/ui/StatusBadge';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
 import {useRequestsShiftsHook} from '../../model/requestsShiftsHook';
+import {RequestsDecisionPanel, RequestsShiftBoard, RequestsShiftsHeader} from './requests-shifts-sections';
 
 export function RequestsShifts() {
     const useCase = useMakeShiftUseCase();
-    const {t} = useTypedTranslation();
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
     const canNext = useMakeShiftStore((s) => canGoNext(s));
     const {
@@ -33,317 +28,36 @@ export function RequestsShifts() {
 
     return (
         <div className="flex min-h-0 flex-1 flex-col">
-            <div className="flex flex-wrap items-start justify-between gap-6">
-                <div className="flex items-baseline gap-[20px]">
-                    <div>
-                        <p className="font-apple text-[32px] font-semibold text-sub-1">{t('page.makeShift.requests.title')}</p>
-                        <p className="font-apple text-xl font-medium text-gray-3">
-                            {t('page.makeShift.requests.descriptionPrefix')}{' '}
-                            <span className="text-main-1">{t('page.makeShift.requests.descriptionHighlight')}</span>
-                            {t('page.makeShift.requests.descriptionSuffix')}
-                        </p>
-                        <div className="mt-4 flex flex-wrap items-center gap-2">
-                            <StatusBadge
-                                label={t('page.makeShift.requests.badge.accepted')}
-                                tone="success"
-                                count={acceptedRequestSummaries.length}
-                            />
-                            <StatusBadge label={t('page.makeShift.requests.badge.pending')} tone="brand" count={pendingRequests.length} />
-                            <StatusBadge
-                                label={t('page.makeShift.requests.badge.rejected')}
-                                tone="neutral"
-                                count={rejectedRequests.length}
-                            />
-                        </div>
-                    </div>
-                </div>
-
-                <div className="flex items-center gap-3">
-                    <Button
-                        variant="secondary"
-                        size="md"
-                        className="h-[42px] rounded-[10px] px-5 font-semibold"
-                        onClick={() => useCase.prev()}
-                        disabled={!canPrev}
-                        type="button"
-                    >
-                        {t('page.makeShift.navigation.previous')}
-                    </Button>
-                    <Button
-                        size="md"
-                        className="h-[42px] rounded-[10px] px-5 font-semibold"
-                        onClick={() => useCase.next()}
-                        disabled={!canNext}
-                        type="button"
-                    >
-                        {t('page.makeShift.navigation.next')}
-                    </Button>
-                </div>
-            </div>
+            <RequestsShiftsHeader
+                acceptedCount={acceptedRequestSummaries.length}
+                pendingCount={pendingRequests.length}
+                rejectedCount={rejectedRequests.length}
+                canPrev={canPrev}
+                canNext={canNext}
+                onPrev={useCase.prev}
+                onNext={useCase.next}
+            />
 
             <div className="mt-6 flex min-h-0 flex-1 gap-6">
                 <div className="min-w-0 flex-1">
-                    {loading && (
-                        <PageState
-                            tone="loading"
-                            title={t('page.makeShift.requests.loading')}
-                            description={t('page.state.loadingDescription')}
-                        />
-                    )}
-                    {!loading && error && (
-                        <PageState
-                            tone="error"
-                            title={t('page.makeShift.requests.error')}
-                            description={t('page.state.errorDescription')}
-                            action={{label: t('page.state.retry'), onClick: () => void retry()}}
-                        />
-                    )}
-                    {!loading && !error && !requestShift && (
-                        <PageState tone="empty" title={t('page.makeShift.requests.empty')} description={t('page.state.emptyDescription')} />
-                    )}
-
-                    {!loading && !error && requestShift && (
-                        <div className="flex h-full min-h-0 flex-col">
-                            <div className="scrollbar-default min-h-0 scroll-m-2 overflow-auto rounded-[15px] shadow-banner">
-                                <div className="flex items-center px-5">
-                                    <div className="w-24 shrink-0 text-center font-apple text-[1rem] font-medium text-sub-3">
-                                        {t('page.makeShift.requests.table.name')}
-                                    </div>
-                                    <div className="min-w-0 flex-1">
-                                        <div className="inline-flex rounded-[2.5rem] px-4 py-[.1875rem]">
-                                            {requestShift.days.map((item, idx) => {
-                                                const isSat = item.dayType === 'saturday';
-                                                const isSun = item.dayType === 'sunday' || item.dayType === 'holiday';
-                                                const textColor = isSun
-                                                    ? 'text-red'
-                                                    : isSat
-                                                      ? separateWeekendColor
-                                                          ? 'text-blue'
-                                                          : 'text-red'
-                                                      : 'text-sub-2.5';
-
-                                                return (
-                                                    <p
-                                                        key={idx}
-                                                        className={`w-9 flex-1 rounded-full text-center font-poppins text-[1rem] ${textColor}`}
-                                                    >
-                                                        {item.day}
-                                                    </p>
-                                                );
-                                            })}
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div className="flex flex-col">
-                                    {requestShift.divisionShiftNurses.map((division, divisionIndex) => {
-                                        if (division.length === 0) return null;
-
-                                        return (
-                                            <div key={divisionIndex} className="rounded-[20px] bg-white">
-                                                <div className="min-w-0">
-                                                    <div className="flex flex-col">
-                                                        {division.map((row) => (
-                                                            <div key={row.shiftNurse.shiftNurseId} className="flex h-10 items-center px-5">
-                                                                <div className="w-24 shrink-0 truncate text-center font-apple text-[1.25rem] text-sub-1">
-                                                                    {row.shiftNurse.name}
-                                                                </div>
-                                                                <div className="flex h-full min-w-max px-4.25">
-                                                                    {row.wardReqShiftList.map((wardShiftTypeId, dateIdx) => {
-                                                                        const dayType = requestShift.days[dateIdx]?.dayType;
-                                                                        const isSat = dayType === 'saturday';
-                                                                        const isSun = dayType === 'sunday' || dayType === 'holiday';
-                                                                        const bg = isSun
-                                                                            ? 'bg-[#FFE1E680]'
-                                                                            : isSat
-                                                                              ? separateWeekendColor
-                                                                                  ? 'bg-[#E1E5FF80]'
-                                                                                  : 'bg-[#FFE1E680]'
-                                                                              : '';
-
-                                                                        return (
-                                                                            <div
-                                                                                key={dateIdx}
-                                                                                className={`flex h-full w-9 items-center justify-center px-[.25rem] ${bg}`}
-                                                                            >
-                                                                                <ShiftBadge
-                                                                                    shiftType={wardShiftTypeMap.get(wardShiftTypeId ?? -1)}
-                                                                                />
-                                                                            </div>
-                                                                        );
-                                                                    })}
-                                                                </div>
-                                                            </div>
-                                                        ))}
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        );
-                                    })}
-                                </div>
-                            </div>
-                        </div>
-                    )}
+                    <RequestsShiftBoard
+                        loading={loading}
+                        error={error}
+                        requestShift={requestShift}
+                        wardShiftTypeMap={wardShiftTypeMap}
+                        separateWeekendColor={separateWeekendColor}
+                        onRetry={retry}
+                    />
                 </div>
 
-                <div className="w-[360px] shrink-0 rounded-[20px] bg-white shadow-banner">
-                    <div className="border-b border-sub-4.5 px-6 py-4">
-                        <p className="font-apple text-[1.25rem] font-semibold text-main-1">{t('page.makeShift.requests.panelTitle')}</p>
-                    </div>
-
-                    <div className="scrollbar-hide max-h-[calc(100vh-22rem)] overflow-y-auto px-6 py-4">
-                        <div>
-                            <div className="flex items-center justify-between">
-                                <p className="font-apple text-base font-semibold text-sub-1">
-                                    {t('page.makeShift.requests.section.accepted')}
-                                </p>
-                                <p className="font-apple text-sm font-medium text-gray-4">
-                                    {t('page.makeShift.requests.count', {count: acceptedRequestSummaries.length})}
-                                </p>
-                            </div>
-
-                            <div className="mt-3 space-y-2">
-                                {acceptedRequestSummaries.length === 0 ? (
-                                    <p className="font-apple text-sm font-medium text-gray-4">
-                                        {t('page.makeShift.requests.emptyAccepted')}
-                                    </p>
-                                ) : (
-                                    acceptedRequestSummaries.map((item) => (
-                                        <div
-                                            key={item.id}
-                                            className="flex items-center gap-3 rounded-[10px] border border-gray-6 px-3 py-2"
-                                        >
-                                            <div className="min-w-0 flex-1">
-                                                <p className="truncate font-apple text-sm font-medium text-sub-1">
-                                                    {item.nurseName} / {item.date}일
-                                                </p>
-                                            </div>
-                                            <ShiftBadge shiftType={wardShiftTypeMap.get(item.wardShiftTypeId)} />
-                                            <Button
-                                                variant="secondary"
-                                                size="sm"
-                                                className="h-8 rounded-[10px] px-3 text-sm font-semibold"
-                                                onClick={() => decideRequest(item.id, null)}
-                                                disabled={updatingRequestId === item.id}
-                                                type="button"
-                                            >
-                                                {t('page.makeShift.requests.action.hold')}
-                                            </Button>
-                                        </div>
-                                    ))
-                                )}
-                            </div>
-                        </div>
-
-                        <div className="mt-6">
-                            <div className="flex items-center justify-between">
-                                <p className="font-apple text-base font-semibold text-sub-1">
-                                    {t('page.makeShift.requests.section.pending')}
-                                </p>
-                                <p className="font-apple text-sm font-medium text-gray-4">
-                                    {t('page.makeShift.requests.count', {count: pendingRequests.length})}
-                                </p>
-                            </div>
-
-                            <div className="mt-3 space-y-2">
-                                {pendingRequests.length === 0 ? (
-                                    <p className="font-apple text-sm font-medium text-gray-4">
-                                        {t('page.makeShift.requests.emptyPending')}
-                                    </p>
-                                ) : (
-                                    pendingRequests.map((dutyRequest) => (
-                                        <div
-                                            key={dutyRequest.wardReqShiftId}
-                                            className="flex items-center gap-3 rounded-[10px] border border-gray-6 px-3 py-2"
-                                        >
-                                            <div className="min-w-0 flex-1">
-                                                <p className="truncate font-apple text-sm font-medium text-sub-1">
-                                                    {dutyRequest.nurseName} / {dutyRequest.date}일
-                                                </p>
-                                            </div>
-                                            <ShiftBadge shiftType={wardShiftTypeMap.get(dutyRequest.wardShiftTypeId)} isOnlyRequest />
-                                            <div className="flex items-center gap-1">
-                                                <Button
-                                                    size="sm"
-                                                    className="h-8 rounded-[10px] px-3 text-sm font-semibold"
-                                                    onClick={() => decideRequest(dutyRequest.wardReqShiftId, true)}
-                                                    disabled={updatingRequestId === dutyRequest.wardReqShiftId}
-                                                    type="button"
-                                                >
-                                                    {t('page.makeShift.requests.action.accept')}
-                                                </Button>
-                                                <Button
-                                                    variant="secondary"
-                                                    size="sm"
-                                                    className="h-8 rounded-[10px] px-3 text-sm font-semibold"
-                                                    onClick={() => decideRequest(dutyRequest.wardReqShiftId, false)}
-                                                    disabled={updatingRequestId === dutyRequest.wardReqShiftId}
-                                                    type="button"
-                                                >
-                                                    {t('page.makeShift.requests.action.reject')}
-                                                </Button>
-                                            </div>
-                                        </div>
-                                    ))
-                                )}
-                            </div>
-                        </div>
-
-                        <div className="mt-6">
-                            <div className="flex items-center justify-between">
-                                <p className="font-apple text-base font-semibold text-sub-1">
-                                    {t('page.makeShift.requests.section.rejected')}
-                                </p>
-                                <p className="font-apple text-sm font-medium text-gray-4">
-                                    {t('page.makeShift.requests.count', {count: rejectedRequests.length})}
-                                </p>
-                            </div>
-
-                            <div className="mt-3 space-y-2">
-                                {rejectedRequests.length === 0 ? (
-                                    <p className="font-apple text-sm font-medium text-gray-4">
-                                        {t('page.makeShift.requests.emptyRejected')}
-                                    </p>
-                                ) : (
-                                    rejectedRequests.map((dutyRequest) => (
-                                        <div
-                                            key={dutyRequest.wardReqShiftId}
-                                            className="flex items-center gap-3 rounded-[10px] border border-gray-6 px-3 py-2"
-                                        >
-                                            <div className="min-w-0 flex-1">
-                                                <p className="truncate font-apple text-sm font-medium text-sub-1">
-                                                    {dutyRequest.nurseName} / {dutyRequest.date}일
-                                                </p>
-                                            </div>
-                                            <ShiftBadge shiftType={wardShiftTypeMap.get(dutyRequest.wardShiftTypeId)} isOnlyRequest />
-                                            <div className="flex items-center gap-1">
-                                                <Button
-                                                    size="sm"
-                                                    className="h-8 rounded-[10px] px-3 text-sm font-semibold"
-                                                    onClick={() => decideRequest(dutyRequest.wardReqShiftId, true)}
-                                                    disabled={updatingRequestId === dutyRequest.wardReqShiftId}
-                                                    type="button"
-                                                >
-                                                    {t('page.makeShift.requests.action.accept')}
-                                                </Button>
-                                                <Button
-                                                    variant="secondary"
-                                                    size="sm"
-                                                    className="h-8 rounded-[10px] px-3 text-sm font-semibold"
-                                                    onClick={() => decideRequest(dutyRequest.wardReqShiftId, null)}
-                                                    disabled={updatingRequestId === dutyRequest.wardReqShiftId}
-                                                    type="button"
-                                                >
-                                                    {t('page.makeShift.requests.action.hold')}
-                                                </Button>
-                                            </div>
-                                        </div>
-                                    ))
-                                )}
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <RequestsDecisionPanel
+                    acceptedRequestSummaries={acceptedRequestSummaries}
+                    pendingRequests={pendingRequests}
+                    rejectedRequests={rejectedRequests}
+                    wardShiftTypeMap={wardShiftTypeMap}
+                    updatingRequestId={updatingRequestId}
+                    onDecideRequest={decideRequest}
+                />
             </div>
         </div>
     );

--- a/apps/app/src/pages/make-shift/view/steps/shared/duty-editor-step-canvas.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/shared/duty-editor-step-canvas.tsx
@@ -1,0 +1,78 @@
+import {type ClipboardEventHandler, type ComponentProps, type KeyboardEventHandler, type RefObject} from 'react';
+import {type TShift} from '@/entities';
+import CountDutyByDay from '@/features/shift-editor/ui/complex-view/count-duty-by-day';
+import ShiftCalendar from '@/features/shift-editor/ui/complex-view/shift-calendar';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import PageState from '@/shared/ui/PageState';
+
+type TShiftCalendarViolations = ComponentProps<typeof ShiftCalendar>['violations'];
+
+type TDutyEditorStepCanvasProps = {
+    duty: TShift | undefined;
+    isLoading: boolean;
+    isError: boolean;
+    onRetry: () => void;
+    loadingTitle: string;
+    errorTitle: string;
+    editorDoc: ComponentProps<typeof ShiftCalendar>['doc'];
+    violationMap: TShiftCalendarViolations;
+    editorRef: RefObject<HTMLDivElement | null>;
+    onKeyDown: KeyboardEventHandler<HTMLDivElement>;
+    onPaste: ClipboardEventHandler<HTMLDivElement>;
+    onFocusEditor: () => void;
+    showFaults: boolean;
+};
+
+export function DutyEditorStepCanvas({
+    duty,
+    isLoading,
+    isError,
+    onRetry,
+    loadingTitle,
+    errorTitle,
+    editorDoc,
+    violationMap,
+    editorRef,
+    onKeyDown,
+    onPaste,
+    onFocusEditor,
+    showFaults,
+}: TDutyEditorStepCanvasProps) {
+    const {t} = useTypedTranslation();
+
+    return (
+        <div className="mt-8 flex min-h-0 flex-1 outline-none" onKeyDown={onKeyDown} onPaste={onPaste} ref={editorRef} tabIndex={0}>
+            {isLoading && <PageState tone="loading" title={loadingTitle} description={t('page.state.loadingDescription')} />}
+            {isError && (
+                <PageState
+                    tone="error"
+                    title={errorTitle}
+                    description={t('page.state.errorDescription')}
+                    action={{label: t('page.state.retry'), onClick: () => void onRetry()}}
+                />
+            )}
+            {!isLoading && !isError && duty && (
+                <div className="flex min-h-0 flex-1" onClick={onFocusEditor}>
+                    <div className="mx-auto flex w-fit min-w-418.5 flex-col">
+                        <ShiftCalendar
+                            shift={duty}
+                            doc={editorDoc}
+                            onCellClick={onFocusEditor}
+                            disableInitialSelection
+                            violations={violationMap}
+                            showLayer={{fault: showFaults, check: false, slash: false}}
+                        />
+                        <div
+                            className="sticky bottom-0 z-20 flex items-stretch gap-5 py-5 pl-55.25"
+                            style={{
+                                height: `${duty.wardShiftTypes.filter((shiftType) => shiftType.isCounted).length * 2.5 + 2.5}rem`,
+                            }}
+                        >
+                            <CountDutyByDay shift={duty} doc={editorDoc} />
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/app/src/pages/make-shift/view/steps/shared/use-duty-editor-step.ts
+++ b/apps/app/src/pages/make-shift/view/steps/shared/use-duty-editor-step.ts
@@ -31,6 +31,11 @@ type TUseDutyEditorStepOptions = {
     onContextChanged?: () => void;
 };
 
+/**
+ * `onContextChanged` should be passed as a stable reference such as `useCallback`.
+ * This hook includes the callback in the hydration effect dependency list, so changing
+ * the callback identity will re-run the effect that compares `hydratedContextKeyRef.current`.
+ */
 export function useDutyEditorStep({onContextChanged}: TUseDutyEditorStepOptions = {}) {
     const {
         state: {wardId},

--- a/apps/app/src/pages/make-shift/view/steps/shared/use-duty-editor-step.ts
+++ b/apps/app/src/pages/make-shift/view/steps/shared/use-duty-editor-step.ts
@@ -1,0 +1,93 @@
+import {useQuery} from '@tanstack/react-query';
+import {useEffect, useMemo, useRef} from 'react';
+import {wardQueryOptions} from '@/entities/ward/model/queries';
+import useAuth from '@/features/auth/useAuth';
+import {
+    buildWorkKeyMap,
+    buildViolationMap,
+    shiftToDoc,
+    type TDutyDoc,
+    useShiftEditorCommands,
+    useShiftEditorKeyBindings,
+    useShiftEditorStore,
+} from '@/features/shift-editor';
+import {useMakeShiftStore} from '../../../model/make-shift-store';
+
+function isSameDutyDocShape(a: TDutyDoc, b: TDutyDoc): boolean {
+    if (a.columns.length !== b.columns.length || a.rows.length !== b.rows.length) return false;
+
+    for (let i = 0; i < a.columns.length; i += 1) {
+        if (a.columns[i] !== b.columns[i]) return false;
+    }
+
+    for (let i = 0; i < a.rows.length; i += 1) {
+        if (a.rows[i]?.workerId !== b.rows[i]?.workerId) return false;
+    }
+
+    return true;
+}
+
+type TUseDutyEditorStepOptions = {
+    onContextChanged?: () => void;
+};
+
+export function useDutyEditorStep({onContextChanged}: TUseDutyEditorStepOptions = {}) {
+    const {
+        state: {wardId},
+    } = useAuth();
+    const year = useMakeShiftStore((s) => s.year);
+    const month = useMakeShiftStore((s) => s.month);
+    const currentShiftTeamId = useMakeShiftStore((s) => s.currentShiftTeamId);
+    const enabled = wardId !== null && currentShiftTeamId !== null;
+    const dutyQuery = useQuery({
+        ...wardQueryOptions.duty(wardId ?? -1, currentShiftTeamId ?? -1, year, month),
+        enabled,
+    });
+    const editorDoc = useShiftEditorStore((s) => s.doc);
+    const violations = useShiftEditorStore((s) => s.violations);
+    const commands = useShiftEditorCommands();
+    const editorRef = useRef<HTMLDivElement>(null);
+    const workKeyMap = useMemo(() => buildWorkKeyMap(dutyQuery.data), [dutyQuery.data]);
+    const {onKeyDown, onPaste} = useShiftEditorKeyBindings({workKeyMap});
+    const violationMap = useMemo(() => buildViolationMap(violations, editorDoc), [violations, editorDoc]);
+    const hydratedContextKeyRef = useRef<string | null>(null);
+    const currentContextKey = `${wardId ?? 'none'}:${currentShiftTeamId ?? 'none'}:${year}:${month}`;
+
+    useEffect(() => {
+        if (!dutyQuery.data) return;
+
+        const nextDoc = shiftToDoc(dutyQuery.data, year, month);
+        const persisted = commands.getPersisted();
+        const hasContextChanged = hydratedContextKeyRef.current !== currentContextKey;
+
+        if (persisted && isSameDutyDocShape(persisted.doc, nextDoc)) {
+            commands.hydrate(persisted);
+
+            if (hasContextChanged) onContextChanged?.();
+
+            hydratedContextKeyRef.current = currentContextKey;
+
+            return;
+        }
+
+        commands.init(nextDoc);
+
+        if (hasContextChanged) onContextChanged?.();
+
+        hydratedContextKeyRef.current = currentContextKey;
+    }, [commands, currentContextKey, dutyQuery.data, month, onContextChanged, year]);
+
+    const focusEditor = () => {
+        editorRef.current?.focus();
+    };
+
+    return {
+        dutyQuery,
+        editorDoc,
+        editorRef,
+        onKeyDown,
+        onPaste,
+        violationMap,
+        focusEditor,
+    };
+}

--- a/apps/app/src/pages/make-shift/view/steps/workers-sections.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/workers-sections.tsx
@@ -1,0 +1,154 @@
+import {Draggable, Droppable} from '@hello-pangea/dnd';
+import {ChevronDown} from 'lucide-react';
+import {type ComponentProps} from 'react';
+import {type TNurse} from '@/entities';
+import SkillBadge from '@/features/ward/SkillBadge';
+import {SixDotsIcon} from '@/shared/assets/svg';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import {DutyManagementStatusCard} from '@/widgets/duty-management/ui';
+
+const SHIFT_TYPE_STYLE: Record<string, {bg: string; text: string}> = {
+    D: {bg: '#4dc2ad', text: '#ffffff'},
+    E: {bg: '#ff8ba5', text: '#ffffff'},
+    N: {bg: '#3580ff', text: '#ffffff'},
+    O: {bg: '#465b7a', text: '#ffffff'},
+};
+
+type TSkillConfig = ComponentProps<typeof SkillBadge>['config'];
+
+function ShiftTypeBadge({code}: {code: string}) {
+    const style = SHIFT_TYPE_STYLE[code] ?? {bg: '#939ba9', text: '#ffffff'};
+
+    return (
+        <div
+            className="flex h-[23px] w-[21px] items-center justify-center rounded-[4.5px] font-apple text-[15px] font-medium"
+            style={{backgroundColor: style.bg, color: style.text}}
+        >
+            {code}
+        </div>
+    );
+}
+
+export function buildShiftCodes(nurse: TNurse) {
+    return nurse.nurseShiftTypes
+        .filter((shift) => shift.isPossible)
+        .map((shift) => shift.shortName || shift.name)
+        .map((name) => name.trim().toUpperCase())
+        .filter((code) => code.length > 0);
+}
+
+export function WorkersHeader({totalCount, onSortByLevel}: {totalCount: number; onSortByLevel: () => void}) {
+    const {t} = useTypedTranslation();
+
+    return (
+        <div className="flex items-center justify-between">
+            <p className="text-gray-2 font-apple text-[20px] font-semibold">
+                {t('page.makeShift.workers.totalCount', {count: totalCount})}
+            </p>
+            <button
+                type="button"
+                className="flex items-center gap-1 rounded-[5px] px-2 py-1 font-apple text-base font-medium text-gray-3 hover:bg-white"
+                onClick={onSortByLevel}
+            >
+                {t('page.makeShift.workers.sortByLevel')}
+                <ChevronDown className="h-5 w-5" />
+            </button>
+        </div>
+    );
+}
+
+export function WorkersTableHeader() {
+    const {t} = useTypedTranslation();
+
+    return (
+        <div className="mt-3 grid grid-cols-[24px_140px_80px_200px_1fr] items-center gap-6 px-3 text-[16px] text-gray-3">
+            <div />
+            <p className="font-apple">{t('page.makeShift.workers.column.name')}</p>
+            <p className="text-center font-apple">{t('page.makeShift.workers.column.level')}</p>
+            <p className="text-center font-apple">{t('page.makeShift.workers.column.shiftTypes')}</p>
+            <p className="text-center font-apple">{t('page.makeShift.workers.column.memo')}</p>
+        </div>
+    );
+}
+
+type TWorkersListProps = {
+    workers: TNurse[];
+    levelsByNurseId: Record<number, number>;
+    skillConfig: TSkillConfig;
+};
+
+export function WorkersList({workers, levelsByNurseId, skillConfig}: TWorkersListProps) {
+    return (
+        <Droppable droppableId="workers">
+            {(provided) => (
+                <div ref={provided.innerRef} {...provided.droppableProps} className="mt-4 flex flex-col gap-3">
+                    {workers.length === 0 ? (
+                        <DutyManagementStatusCard
+                            title="근무자로 확정된 인력이 없어요."
+                            description="근무 투입이 설정된 인원을 먼저 확인해 주세요."
+                            className="min-h-[220px] border-solid"
+                        />
+                    ) : null}
+                    {workers.map((nurse, index) => (
+                        <WorkerRow
+                            key={nurse.nurseId}
+                            nurse={nurse}
+                            index={index}
+                            level={levelsByNurseId[nurse.nurseId]}
+                            skillConfig={skillConfig}
+                        />
+                    ))}
+                    {provided.placeholder}
+                </div>
+            )}
+        </Droppable>
+    );
+}
+
+type TWorkerRowProps = {
+    nurse: TNurse;
+    index: number;
+    level: number | undefined;
+    skillConfig: TSkillConfig;
+};
+
+function WorkerRow({nurse, index, level, skillConfig}: TWorkerRowProps) {
+    const {t} = useTypedTranslation();
+    const shiftCodes = buildShiftCodes(nurse);
+    const memo = nurse.memo?.trim();
+
+    return (
+        <Draggable draggableId={`nurse-${nurse.nurseId}`} index={index}>
+            {(dragProvided, dragSnapshot) => (
+                <div
+                    ref={dragProvided.innerRef}
+                    {...dragProvided.draggableProps}
+                    className={`grid h-[52px] grid-cols-[24px_140px_80px_200px_1fr] items-center gap-6 rounded-[10px] border border-gray-6 bg-white px-3 ${
+                        dragSnapshot.isDragging ? 'opacity-95' : ''
+                    }`}
+                >
+                    <button
+                        type="button"
+                        aria-label={t('page.makeShift.workers.dragHandleAria')}
+                        className="cursor-grab active:cursor-grabbing"
+                        {...dragProvided.dragHandleProps}
+                    >
+                        <SixDotsIcon className="h-6 w-6" />
+                    </button>
+                    <p className="font-apple text-[20px] font-medium text-sub-1">{nurse.name}</p>
+                    <div className="flex justify-center">
+                        <SkillBadge level={level} config={skillConfig} />
+                    </div>
+                    <div className="flex items-center justify-center gap-1">
+                        {shiftCodes.length > 0 ? (
+                            shiftCodes.map((code) => <ShiftTypeBadge key={`${nurse.nurseId}-${code}`} code={code} />)
+                        ) : (
+                            <span className="font-apple text-sm text-gray-4">-</span>
+                        )}
+                    </div>
+                    <p className="text-center font-apple text-[20px] font-medium text-sub-1">{memo || '-'}</p>
+                </div>
+            )}
+        </Draggable>
+    );
+}

--- a/apps/app/src/pages/make-shift/view/steps/workers-sections.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/workers-sections.tsx
@@ -78,14 +78,16 @@ type TWorkersListProps = {
 };
 
 export function WorkersList({workers, levelsByNurseId, skillConfig}: TWorkersListProps) {
+    const {t} = useTypedTranslation();
+
     return (
         <Droppable droppableId="workers">
             {(provided) => (
                 <div ref={provided.innerRef} {...provided.droppableProps} className="mt-4 flex flex-col gap-3">
                     {workers.length === 0 ? (
                         <DutyManagementStatusCard
-                            title="근무자로 확정된 인력이 없어요."
-                            description="근무 투입이 설정된 인원을 먼저 확인해 주세요."
+                            title={t('page.makeShift.workers.emptyTitle')}
+                            description={t('page.makeShift.workers.emptyDescription')}
                             className="min-h-[220px] border-solid"
                         />
                     ) : null}

--- a/apps/app/src/pages/make-shift/view/steps/workers.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/workers.tsx
@@ -1,49 +1,14 @@
-import {DragDropContext, Draggable, Droppable, type DropResult} from '@hello-pangea/dnd';
+import {DragDropContext, type DropResult} from '@hello-pangea/dnd';
 import {useQuery} from '@tanstack/react-query';
-import {ChevronDown} from 'lucide-react';
 import {useEffect, useMemo, useState} from 'react';
 import {type TNurse} from '@/entities';
 import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth/useAuth';
 import {getWardSkillSettings, resolveWardSkillLevels} from '@/features/ward/skill-level';
-import SkillBadge from '@/features/ward/SkillBadge';
-import {SixDotsIcon} from '@/shared/assets/svg';
-import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
-import {DutyManagementStatusCard} from '@/widgets/duty-management/ui';
 import {useMakeShiftStore} from '../../model/make-shift-store';
-
-const SHIFT_TYPE_STYLE: Record<string, {bg: string; text: string}> = {
-    D: {bg: '#4dc2ad', text: '#ffffff'},
-    E: {bg: '#ff8ba5', text: '#ffffff'},
-    N: {bg: '#3580ff', text: '#ffffff'},
-    O: {bg: '#465b7a', text: '#ffffff'},
-};
-
-function ShiftTypeBadge({code}: {code: string}) {
-    const style = SHIFT_TYPE_STYLE[code] ?? {bg: '#939ba9', text: '#ffffff'};
-
-    return (
-        <div
-            className="flex h-[23px] w-[21px] items-center justify-center rounded-[4.5px] font-apple text-[15px] font-medium"
-            style={{backgroundColor: style.bg, color: style.text}}
-        >
-            {code}
-        </div>
-    );
-}
-
-function buildShiftCodes(nurse: TNurse) {
-    const possible = nurse.nurseShiftTypes.filter((shift) => shift.isPossible);
-    const ordered = possible
-        .map((shift) => shift.shortName || shift.name)
-        .map((name) => name.trim().toUpperCase())
-        .filter((code) => code.length > 0);
-
-    return ordered;
-}
+import {WorkersHeader, WorkersList, WorkersTableHeader} from './workers-sections';
 
 export function Workers() {
-    const {t} = useTypedTranslation();
     const {
         state: {wardId},
     } = useAuth();
@@ -96,82 +61,11 @@ export function Workers() {
 
     return (
         <div className="rounded-[15px] bg-gray-7 p-[30px]">
-            <div className="flex items-center justify-between">
-                <p className="text-gray-2 font-apple text-[20px] font-semibold">
-                    {t('page.makeShift.workers.totalCount', {count: totalCount})}
-                </p>
-                <button
-                    type="button"
-                    className="flex items-center gap-1 rounded-[5px] px-2 py-1 font-apple text-base font-medium text-gray-3 hover:bg-white"
-                    onClick={sortByLevel}
-                >
-                    {t('page.makeShift.workers.sortByLevel')}
-                    <ChevronDown className="h-5 w-5" />
-                </button>
-            </div>
-
-            <div className="mt-3 grid grid-cols-[24px_140px_80px_200px_1fr] items-center gap-6 px-3 text-[16px] text-gray-3">
-                <div />
-                <p className="font-apple">{t('page.makeShift.workers.column.name')}</p>
-                <p className="text-center font-apple">{t('page.makeShift.workers.column.level')}</p>
-                <p className="text-center font-apple">{t('page.makeShift.workers.column.shiftTypes')}</p>
-                <p className="text-center font-apple">{t('page.makeShift.workers.column.memo')}</p>
-            </div>
+            <WorkersHeader totalCount={totalCount} onSortByLevel={sortByLevel} />
+            <WorkersTableHeader />
 
             <DragDropContext onDragEnd={onDragEnd}>
-                <Droppable droppableId="workers">
-                    {(provided) => (
-                        <div ref={provided.innerRef} {...provided.droppableProps} className="mt-4 flex flex-col gap-3">
-                            {orderedWorkers.length === 0 && (
-                                <DutyManagementStatusCard
-                                    title="근무자로 확정된 인력이 없어요."
-                                    description="근무 투입이 설정된 인원을 먼저 확인해 주세요."
-                                    className="min-h-[220px] border-solid"
-                                />
-                            )}
-                            {orderedWorkers.map((nurse, index) => {
-                                const shiftCodes = buildShiftCodes(nurse);
-                                const memo = nurse.memo?.trim();
-
-                                return (
-                                    <Draggable key={nurse.nurseId} draggableId={`nurse-${nurse.nurseId}`} index={index}>
-                                        {(dragProvided, dragSnapshot) => (
-                                            <div
-                                                ref={dragProvided.innerRef}
-                                                {...dragProvided.draggableProps}
-                                                className={`grid h-[52px] grid-cols-[24px_140px_80px_200px_1fr] items-center gap-6 rounded-[10px] border border-gray-6 bg-white px-3 ${dragSnapshot.isDragging ? 'opacity-95' : ''}`}
-                                            >
-                                                <button
-                                                    type="button"
-                                                    aria-label={t('page.makeShift.workers.dragHandleAria')}
-                                                    className="cursor-grab active:cursor-grabbing"
-                                                    {...dragProvided.dragHandleProps}
-                                                >
-                                                    <SixDotsIcon className="h-6 w-6" />
-                                                </button>
-                                                <p className="font-apple text-[20px] font-medium text-sub-1">{nurse.name}</p>
-                                                <div className="flex justify-center">
-                                                    <SkillBadge level={levelsByNurseId[nurse.nurseId]} config={skillConfig} />
-                                                </div>
-                                                <div className="flex items-center justify-center gap-1">
-                                                    {shiftCodes.length > 0 ? (
-                                                        shiftCodes.map((code) => (
-                                                            <ShiftTypeBadge key={`${nurse.nurseId}-${code}`} code={code} />
-                                                        ))
-                                                    ) : (
-                                                        <span className="font-apple text-sm text-gray-4">-</span>
-                                                    )}
-                                                </div>
-                                                <p className="text-center font-apple text-[20px] font-medium text-sub-1">{memo || '-'}</p>
-                                            </div>
-                                        )}
-                                    </Draggable>
-                                );
-                            })}
-                            {provided.placeholder}
-                        </div>
-                    )}
-                </Droppable>
+                <WorkersList workers={orderedWorkers} levelsByNurseId={levelsByNurseId} skillConfig={skillConfig} />
             </DragDropContext>
         </div>
     );

--- a/apps/app/src/shared/locales/en.ts
+++ b/apps/app/src/shared/locales/en.ts
@@ -13,6 +13,28 @@ export const en: TLocale = {
             title: 'Duty Schedule\nNow Easier!',
         },
         makeShift: {
+            steps: {
+                workers: {
+                    label: 'Workers',
+                    introTitle: 'Please confirm the workers',
+                    introDescription:
+                        "We only loaded workers marked as 'included in duty'.\nWe will place them into the schedule in this order.",
+                },
+                constraints: {
+                    label: 'Constraints',
+                    introTitle: 'Please confirm the constraints',
+                    introDescription: 'It may be difficult to satisfy every constraint.\nSet the priority order to improve the result.',
+                },
+                requests: {
+                    label: 'Requested shifts',
+                },
+                fixedShifts: {
+                    label: 'Fixed shifts',
+                },
+                aiAutofill: {
+                    label: 'AI autofill',
+                },
+            },
             navigation: {
                 previous: 'Previous',
                 next: 'Next',
@@ -56,6 +78,7 @@ export const en: TLocale = {
                 emptyAccepted: 'No accepted requests.',
                 emptyPending: 'No pending requests.',
                 emptyRejected: 'No rejected requests.',
+                itemLabel: '{{name}} / {{date}}',
                 action: {
                     accept: 'Accept',
                     reject: 'Reject',
@@ -99,13 +122,21 @@ export const en: TLocale = {
                     shiftTypes: 'Available shifts',
                     memo: 'Memo',
                 },
+                emptyTitle: 'No confirmed workers yet.',
+                emptyDescription: 'Check the staff marked for duty first.',
                 dragHandleAria: 'Drag to reorder',
+            },
+            fixedShifts: {
+                loading: 'Loading the duty schedule',
+                error: 'Failed to load fixed shift data',
             },
             aiRefill: {
                 action: 'Refill with AI',
                 retry: 'Retry AI fill',
                 generating: 'Filling with AI...',
                 intro: 'Your current edits stay in place even if AI fails.\nYou can go back to the previous step to revisit conditions, or retry and confirm here.',
+                loading: 'Loading the duty schedule',
+                error: 'Failed to load the duty schedule',
                 saveFailed: 'Failed to save. Please try again shortly.',
                 title: {
                     idle: 'Ready to start AI autofill',

--- a/apps/app/src/shared/locales/ko.ts
+++ b/apps/app/src/shared/locales/ko.ts
@@ -11,6 +11,27 @@ export const ko = {
             title: '근무표\n이제 더 간편하게!',
         },
         makeShift: {
+            steps: {
+                workers: {
+                    label: '근무자 확인',
+                    introTitle: '근무자를 확정해 주세요',
+                    introDescription: "'근무투입'이 선택된 근무자만 불러왔어요\n목록 순서대로 근무표에 배치해 드릴게요",
+                },
+                constraints: {
+                    label: '제약 조건',
+                    introTitle: '제약 조건을 확정해 주세요',
+                    introDescription: '모든 제약 조건을 적용하기 어려울 수 있어요\n우선순위를 정해 주시면, 더 정확하게 반영해 드릴게요',
+                },
+                requests: {
+                    label: '신청 근무 확정',
+                },
+                fixedShifts: {
+                    label: '고정 근무',
+                },
+                aiAutofill: {
+                    label: 'AI 자동 채우기',
+                },
+            },
             navigation: {
                 previous: '이전',
                 next: '다음',
@@ -54,6 +75,7 @@ export const ko = {
                 emptyAccepted: '반영된 신청이 없어요.',
                 emptyPending: '반영 대기 신청이 없어요.',
                 emptyRejected: '거절된 신청이 없어요.',
+                itemLabel: '{{name}} / {{date}}일',
                 action: {
                     accept: '반영',
                     reject: '거절',
@@ -97,13 +119,21 @@ export const ko = {
                     shiftTypes: '가능 근무',
                     memo: '비고',
                 },
+                emptyTitle: '근무자로 확정된 인력이 없어요.',
+                emptyDescription: '근무 투입이 설정된 인원을 먼저 확인해 주세요.',
                 dragHandleAria: '드래그하여 순서 변경',
+            },
+            fixedShifts: {
+                loading: '근무표를 불러오는 중이에요',
+                error: '고정 근무 데이터를 불러오지 못했어요',
             },
             aiRefill: {
                 action: 'AI 다시 채우기',
                 retry: 'AI 다시 시도',
                 generating: 'AI 채우는 중...',
                 intro: '실패해도 현재 편집본은 유지돼요.\n이전 단계로 돌아가 조건을 다시 보고 오거나, 여기서 바로 재시도하고 확정할 수 있어요.',
+                loading: '근무표를 불러오는 중이에요',
+                error: '근무표를 불러오지 못했어요',
                 saveFailed: '저장에 실패했습니다. 잠시 후 다시 시도해 주세요.',
                 title: {
                     idle: 'AI 자동 채우기를 시작할 준비가 됐어요',


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-911](https://gom3.atlassian.net/browse/DUT-911)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `make-shift` step 메타와 레이아웃 분기를 `MakeShiftStepContent` / `make-shift-step-config`로 분리해 page 레벨 책임을 줄였습니다.
- `requests-shifts`를 헤더, 메인 보드, 우측 결정 패널 섹션으로 나눠 신청 근무 화면의 상태 연결과 화면 구성을 분리했습니다.
- `fixed-shifts`, `ai-auto-fill`에 공통 `useDutyEditorStep` / `DutyEditorStepCanvas`를 도입해 shift-editor 캔버스 책임을 재사용 가능하게 정리했습니다.
- `constraints`, `workers`를 섹션/리스트 단위 컴포넌트로 분리해 이후 step별 수정 범위를 줄였습니다.

<br>

## To Reviewers

- 동작 변경 없이 구조 정리를 목표로 했습니다. `make-shift` 플로우에서 step 전환, 신청 근무 결정, 고정 근무/AI 자동 채우기 화면 진입이 기존과 동일한지 중심으로 확인 부탁드립니다.
- 검증은 `pnpm type-check:app`, 변경 파일 대상 `eslint`까지 수행했습니다. 별도 UI/E2E 테스트는 추가하지 않았습니다.


[DUT-911]: https://gom3.atlassian.net/browse/DUT-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 단계별 콘텐츠 렌더링 로직을 통합된 구성 요소로 재구성하여 코드 유지보수성 개선
  * 제약 조건, 요청 근무, 근로자 UI를 재사용 가능한 하위 구성 요소로 분리
  * 편집기 상태 관리 및 키 바인딩 로직 통합

<!-- end of auto-generated comment: release notes by coderabbit.ai -->