### PR TITLE
[-]: CodeRabbit 리뷰 잡음 제거

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,14 +1,28 @@
 language: 'ko-KR'
+tone_instructions: >
+  실제 결함, 회귀 가능성, 보안 문제, 성능 문제, 명확한 유지보수 리스크만 코멘트하세요.
+  스타일 제안, 취향 차이, 이미 린터/포매터가 잡는 내용, 중요하지 않은 리네이밍 제안은 하지 마세요.
 early_access: false
 reviews:
   profile: 'chill'
   request_changes_workflow: true
-  high_level_summary: true
-  poem: true
-  review_status: true
-  collapse_walkthrough: false
+  high_level_summary: false
+  review_status: false
+  review_details: false
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  suggested_reviewers: false
+  in_progress_fortune: false
+  poem: false
+  enable_prompt_for_ai_agents: false
   auto_review:
     enabled: true
     drafts: false
 chat:
-  auto_reply: true
+  auto_reply: false


### PR DESCRIPTION
## 변경 내용
- CodeRabbit이 실제 문제 중심으로만 코멘트하도록  추가
- walkthrough 성격의 요약, 상태, 시, 다이어그램, 추천 항목 비활성화
- PR 대화 자동 응답과 AI agent 프롬프트 출력 비활성화

## 기대 효과
- 불필요한 설명성 코멘트 감소
- 버그, 회귀, 보안, 성능, 유지보수 리스크 중심 리뷰 유도

## 테스트
- 설정 파일 변경만 수행
- 별도 런타임 테스트 없음