### PR TITLE
[DUT-919]: createAccount 상태 처리 정리

### DIFF
--- a/apps/app/src/features/account/__tests__/useCreateAccount.test.tsx
+++ b/apps/app/src/features/account/__tests__/useCreateAccount.test.tsx
@@ -25,7 +25,6 @@ describe('useCreateAccount', () => {
         );
         const {result} = renderHook(() =>
             useCreateAccount({
-                isValid: true,
                 submit,
             }),
         );
@@ -48,16 +47,17 @@ describe('useCreateAccount', () => {
         expect(result.current.createAccountFeedback.message).toBe('계정 정보를 저장했어요.');
     });
 
-    it('marks validation failure before submit when the form is invalid', async () => {
+    it('marks validation failure without submitting when validation callback runs', () => {
         const submit = vi.fn();
         const {result} = renderHook(() =>
             useCreateAccount({
-                isValid: false,
                 submit,
             }),
         );
 
-        await act(async () => result.current.handleCreateAccount(createNurseDTO));
+        act(() => {
+            result.current.handleCreateAccountValidationFailure();
+        });
 
         expect(submit).not.toHaveBeenCalled();
         expect(result.current.createAccountStatus).toBe('failure');
@@ -68,7 +68,6 @@ describe('useCreateAccount', () => {
         const submit = vi.fn().mockRejectedValue({code: 400});
         const {result} = renderHook(() =>
             useCreateAccount({
-                isValid: true,
                 submit,
             }),
         );
@@ -93,7 +92,6 @@ describe('useCreateAccount', () => {
         const submit = vi.fn().mockRejectedValue(error);
         const {result} = renderHook(() =>
             useCreateAccount({
-                isValid: true,
                 submit,
             }),
         );
@@ -125,7 +123,6 @@ describe('useCreateAccount', () => {
         );
         const {result} = renderHook(() =>
             useCreateAccount({
-                isValid: true,
                 submit,
             }),
         );

--- a/apps/app/src/features/account/__tests__/useCreateAccount.test.tsx
+++ b/apps/app/src/features/account/__tests__/useCreateAccount.test.tsx
@@ -1,0 +1,116 @@
+import {act, renderHook} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import useCreateAccount from '../useCreateAccount';
+
+const createNurseDTO = {
+    name: '홍길동',
+    gender: '여' as const,
+    phoneNum: '01012341234',
+    employmentDate: '2024-01-01',
+    isWorker: true,
+    profileImg: {
+        defaultProfileImgId: 1,
+    },
+};
+
+describe('useCreateAccount', () => {
+    it('tracks loading to success when account creation succeeds', async () => {
+        let resolveSubmit: (() => void) | undefined;
+
+        const submit = vi.fn(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveSubmit = resolve;
+                }),
+        );
+        const {result} = renderHook(() =>
+            useCreateAccount({
+                isValid: true,
+                submit,
+            }),
+        );
+
+        let request: Promise<unknown>;
+
+        act(() => {
+            request = result.current.handleCreateAccount(createNurseDTO);
+        });
+
+        expect(result.current.createAccountStatus).toBe('loading');
+        expect(result.current.createAccountFeedback.message).toBe('계정 정보를 저장하고 있어요.');
+
+        await act(async () => {
+            resolveSubmit?.();
+            await request!;
+        });
+
+        expect(result.current.createAccountStatus).toBe('success');
+        expect(result.current.createAccountFeedback.message).toBe('계정 정보를 저장했어요.');
+    });
+
+    it('marks validation failure before submit when the form is invalid', async () => {
+        const submit = vi.fn();
+        const {result} = renderHook(() =>
+            useCreateAccount({
+                isValid: false,
+                submit,
+            }),
+        );
+
+        await act(async () => result.current.handleCreateAccount(createNurseDTO));
+
+        expect(submit).not.toHaveBeenCalled();
+        expect(result.current.createAccountStatus).toBe('failure');
+        expect(result.current.createAccountFeedback.message).toBe('입력한 계정 정보를 다시 확인해 주세요.');
+    });
+
+    it('classifies handled api errors as failure', async () => {
+        const submit = vi.fn().mockRejectedValue({code: 400});
+        const {result} = renderHook(() =>
+            useCreateAccount({
+                isValid: true,
+                submit,
+            }),
+        );
+
+        let request: Promise<unknown>;
+
+        act(() => {
+            request = result.current.handleCreateAccount(createNurseDTO);
+        });
+
+        await act(async () => {
+            await request!.catch(() => undefined);
+        });
+
+        await expect(request!).rejects.toEqual({code: 400});
+
+        expect(result.current.createAccountStatus).toBe('failure');
+    });
+
+    it('classifies unexpected errors as exception', async () => {
+        const error = new Error('network');
+        const submit = vi.fn().mockRejectedValue(error);
+        const {result} = renderHook(() =>
+            useCreateAccount({
+                isValid: true,
+                submit,
+            }),
+        );
+
+        let request: Promise<unknown>;
+
+        act(() => {
+            request = result.current.handleCreateAccount(createNurseDTO);
+        });
+
+        await act(async () => {
+            await request!.catch(() => undefined);
+        });
+
+        await expect(request!).rejects.toThrow('network');
+
+        expect(result.current.createAccountStatus).toBe('exception');
+        expect(result.current.createAccountFeedback.message).toBe('계정 생성 중 문제가 발생했어요. 잠시 후 다시 시도해 주세요.');
+    });
+});

--- a/apps/app/src/features/account/__tests__/useCreateAccount.test.tsx
+++ b/apps/app/src/features/account/__tests__/useCreateAccount.test.tsx
@@ -113,4 +113,36 @@ describe('useCreateAccount', () => {
         expect(result.current.createAccountStatus).toBe('exception');
         expect(result.current.createAccountFeedback.message).toBe('계정 생성 중 문제가 발생했어요. 잠시 후 다시 시도해 주세요.');
     });
+
+    it('does not reset back to idle while submit is still loading', async () => {
+        let resolveSubmit: (() => void) | undefined;
+
+        const submit = vi.fn(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveSubmit = resolve;
+                }),
+        );
+        const {result} = renderHook(() =>
+            useCreateAccount({
+                isValid: true,
+                submit,
+            }),
+        );
+
+        act(() => {
+            void result.current.handleCreateAccount(createNurseDTO);
+        });
+
+        act(() => {
+            result.current.resetCreateAccountStatus();
+        });
+
+        expect(result.current.createAccountStatus).toBe('loading');
+
+        await act(async () => {
+            resolveSubmit?.();
+            await Promise.resolve();
+        });
+    });
 });

--- a/apps/app/src/features/account/useCreateAccount.tsx
+++ b/apps/app/src/features/account/useCreateAccount.tsx
@@ -1,102 +1,86 @@
-import {type JSX, useCallback, useEffect, useState} from 'react';
-import {type TNurse} from '@/entities/nurse';
+import {useCallback, useMemo, useState} from 'react';
+import {type TCreateNurseDTO} from '@/shared/api/nurse/type';
 
-export type TStep = {
-    name: string;
-    contents: JSX.Element;
-    description: JSX.Element | null;
+export type TCreateAccountStatus = 'idle' | 'loading' | 'success' | 'failure' | 'exception';
+
+type TCreateAccountFeedback = {
+    tone: 'neutral' | 'error';
+    message: string | null;
 };
 
-type TCreateAccountRequestDTO = Pick<TNurse, 'name' | 'gender' | 'phoneNum' | 'employmentDate' | 'isWorker'>;
+type TUseCreateAccountParams = {
+    isValid: boolean;
+    submit: (createNurseDTO: TCreateNurseDTO & {profileImg: {profileImgUrl?: string; defaultProfileImgId?: number}}) => Promise<unknown>;
+};
 
-const useCreateAccount = () => {
-    // 추후 server state로 변경
-    const [account, setAccount] = useState<TCreateAccountRequestDTO>({
-        name: '',
-        gender: '여',
-        phoneNum: '',
-        employmentDate: '',
-        isWorker: true,
-    });
-    const [isFilled, setIsFilled] = useState<boolean>(false);
-    const [error, setError] = useState<{
-        key: keyof TCreateAccountRequestDTO;
-        message: string;
-    } | null>(null);
-    /** 인풋값이 상태에 반영될 수 있는지 체크하며 업데이트 합니다. */
-    const handleChangeAccount = (key: keyof TCreateAccountRequestDTO, value: string | boolean) => {
-        if (key === 'gender' && value !== '여' && value !== '남') return;
+const DEFAULT_FEEDBACK: TCreateAccountFeedback = {
+    tone: 'neutral',
+    message: null,
+};
+const FEEDBACK_BY_STATUS: Record<Exclude<TCreateAccountStatus, 'idle'>, TCreateAccountFeedback> = {
+    loading: {
+        tone: 'neutral',
+        message: '계정 정보를 저장하고 있어요.',
+    },
+    success: {
+        tone: 'neutral',
+        message: '계정 정보를 저장했어요.',
+    },
+    failure: {
+        tone: 'error',
+        message: '입력한 계정 정보를 다시 확인해 주세요.',
+    },
+    exception: {
+        tone: 'error',
+        message: '계정 생성 중 문제가 발생했어요. 잠시 후 다시 시도해 주세요.',
+    },
+};
 
-        if (key === 'name') {
-            if (/![a-z|A-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣|s]/.test(value as string)) return;
+function isHandledFailure(error: unknown) {
+    const code = typeof error === 'object' && error !== null && 'code' in error ? (error as {code?: number}).code : undefined;
 
-            if (typeof value === 'string' && value.length > 10) return;
+    return code === 400 || code === 401 || code === 404;
+}
+
+const useCreateAccount = ({isValid, submit}: TUseCreateAccountParams) => {
+    const [createAccountStatus, setCreateAccountStatus] = useState<TCreateAccountStatus>('idle');
+    const createAccountFeedback = useMemo(() => {
+        if (createAccountStatus === 'idle') {
+            return DEFAULT_FEEDBACK;
         }
 
-        if (key === 'phoneNum') {
-            if (/![d|-]/.test(value as string)) return;
+        return FEEDBACK_BY_STATUS[createAccountStatus];
+    }, [createAccountStatus]);
+    const resetCreateAccountStatus = useCallback(() => {
+        setCreateAccountStatus((currentStatus) => (currentStatus === 'idle' ? currentStatus : 'idle'));
+    }, []);
+    const handleCreateAccount = useCallback(
+        async (createNurseDTO: TCreateNurseDTO & {profileImg: {profileImgUrl?: string; defaultProfileImgId?: number}}) => {
+            if (!isValid) {
+                setCreateAccountStatus('failure');
 
-            if (typeof value === 'string') {
-                if (value.length > 13) return;
+                return;
             }
-        }
 
-        if (key === 'employmentDate') {
-            if (/![d|.]/.test(value as string)) return;
+            setCreateAccountStatus('loading');
 
-            if (typeof value === 'string') {
-                if (value.length > 10) return;
+            try {
+                await submit(createNurseDTO);
+                setCreateAccountStatus('success');
+            } catch (error) {
+                setCreateAccountStatus(isHandledFailure(error) ? 'failure' : 'exception');
+                throw error;
             }
-        }
-
-        setAccount({...account, [key]: value});
-    };
-    /** 서버에 제출하기 전 검토를 합니다. */
-    const validate = useCallback(() => {
-        if (!/^[가-힣|A-Z|a-z]{2,10}$/.test(account.name)) {
-            setIsFilled(false);
-            setError({
-                key: 'name',
-                message: '이름은 2~10자 한/영문에 숫자나 특수문자를 사용할 수 없습니다.',
-            });
-
-            return false;
-        }
-
-        if (!/(\d{3})-(\d{4})-(\d{4})/.test(account.phoneNum)) {
-            setIsFilled(false);
-            setError({key: 'name', message: '전화번호 형식을 지켜주세요.'});
-
-            return false;
-        }
-
-        if (account.gender !== '여' && account.gender !== '남') {
-            setIsFilled(false);
-            setError({key: 'name', message: '여, 남만 선택 가능합니다.'});
-
-            return false;
-        }
-
-        setIsFilled(true);
-        setError(null);
-
-        return true;
-    }, [account]);
-
-    useEffect(() => {
-        validate();
-    }, [account, validate]);
-
-    const handleCreateAccount = async () => {
-        //@TODO 상태 변경
-    };
+        },
+        [isValid, submit],
+    );
 
     return {
-        account,
-        isFilled,
-        error,
-        handleChangeAccount,
+        createAccountStatus,
+        createAccountFeedback,
+        isSubmitting: createAccountStatus === 'loading',
         handleCreateAccount,
+        resetCreateAccountStatus,
     };
 };
 

--- a/apps/app/src/features/account/useCreateAccount.tsx
+++ b/apps/app/src/features/account/useCreateAccount.tsx
@@ -52,7 +52,7 @@ const useCreateAccount = ({isValid, submit}: TUseCreateAccountParams) => {
         return FEEDBACK_BY_STATUS[createAccountStatus];
     }, [createAccountStatus]);
     const resetCreateAccountStatus = useCallback(() => {
-        setCreateAccountStatus((currentStatus) => (currentStatus === 'idle' ? currentStatus : 'idle'));
+        setCreateAccountStatus((currentStatus) => (currentStatus === 'idle' || currentStatus === 'loading' ? currentStatus : 'idle'));
     }, []);
     const handleCreateAccount = useCallback(
         async (createNurseDTO: TCreateNurseDTO & {profileImg: {profileImgUrl?: string; defaultProfileImgId?: number}}) => {

--- a/apps/app/src/features/account/useCreateAccount.tsx
+++ b/apps/app/src/features/account/useCreateAccount.tsx
@@ -9,7 +9,6 @@ type TCreateAccountFeedback = {
 };
 
 type TUseCreateAccountParams = {
-    isValid: boolean;
     submit: (createNurseDTO: TCreateNurseDTO & {profileImg: {profileImgUrl?: string; defaultProfileImgId?: number}}) => Promise<unknown>;
 };
 
@@ -42,7 +41,7 @@ function isHandledFailure(error: unknown) {
     return code === 400 || code === 401 || code === 404;
 }
 
-const useCreateAccount = ({isValid, submit}: TUseCreateAccountParams) => {
+const useCreateAccount = ({submit}: TUseCreateAccountParams) => {
     const [createAccountStatus, setCreateAccountStatus] = useState<TCreateAccountStatus>('idle');
     const createAccountFeedback = useMemo(() => {
         if (createAccountStatus === 'idle') {
@@ -54,14 +53,11 @@ const useCreateAccount = ({isValid, submit}: TUseCreateAccountParams) => {
     const resetCreateAccountStatus = useCallback(() => {
         setCreateAccountStatus((currentStatus) => (currentStatus === 'idle' || currentStatus === 'loading' ? currentStatus : 'idle'));
     }, []);
+    const handleCreateAccountValidationFailure = useCallback(() => {
+        setCreateAccountStatus('failure');
+    }, []);
     const handleCreateAccount = useCallback(
         async (createNurseDTO: TCreateNurseDTO & {profileImg: {profileImgUrl?: string; defaultProfileImgId?: number}}) => {
-            if (!isValid) {
-                setCreateAccountStatus('failure');
-
-                return;
-            }
-
             setCreateAccountStatus('loading');
 
             try {
@@ -72,7 +68,7 @@ const useCreateAccount = ({isValid, submit}: TUseCreateAccountParams) => {
                 throw error;
             }
         },
-        [isValid, submit],
+        [submit],
     );
 
     return {
@@ -80,6 +76,7 @@ const useCreateAccount = ({isValid, submit}: TUseCreateAccountParams) => {
         createAccountFeedback,
         isSubmitting: createAccountStatus === 'loading',
         handleCreateAccount,
+        handleCreateAccountValidationFailure,
         resetCreateAccountStatus,
     };
 };

--- a/apps/app/src/features/auth/useRegister/index.ts
+++ b/apps/app/src/features/auth/useRegister/index.ts
@@ -124,6 +124,9 @@ const useRegister = () => {
 
             await NurseAPI.createAccountNurse(accountId, createNurseDTO);
             await changeAccountStatus({accountId, status: 'WARD_SELECT_PENDING'});
+        } catch (error) {
+            showActionErrorFeedback(error, '계정 생성에 실패했습니다.');
+            throw error;
         } finally {
             setLoading(false);
         }

--- a/apps/app/src/features/auth/useRegister/index.ts
+++ b/apps/app/src/features/auth/useRegister/index.ts
@@ -124,9 +124,6 @@ const useRegister = () => {
 
             await NurseAPI.createAccountNurse(accountId, createNurseDTO);
             await changeAccountStatus({accountId, status: 'WARD_SELECT_PENDING'});
-        } catch (error) {
-            showActionErrorFeedback(error, '계정 생성에 실패했습니다.');
-            throw error;
         } finally {
             setLoading(false);
         }

--- a/apps/app/src/pages/RegisterPage/ui/RegisterNurse.tsx
+++ b/apps/app/src/pages/RegisterPage/ui/RegisterNurse.tsx
@@ -11,6 +11,7 @@ import useRegister from '@/features/auth/useRegister';
 import useProfileImage from '@/features/file/useProfileImage';
 import {type TCreateNurseDTO} from '@/shared/api/nurse/type';
 import {CameraIcon, CheckedIcon, RandomIcon, UncheckedIcon} from '@/shared/assets/svg';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import Button from '@/shared/ui/form-controls/Button';
 import Select from '@/shared/ui/form-controls/Select';
 import TextField from '@/shared/ui/form-controls/TextField';
@@ -43,6 +44,7 @@ const schema = yup
     .required();
 
 function RegisterNurse() {
+    const {t} = useTypedTranslation();
     const {
         formState: {errors, isValid},
         watch,
@@ -220,7 +222,7 @@ function RegisterNurse() {
             </p>
 
             <Button disabled={!isValid || isSubmitting} className="mt-4 h-15 w-30 self-end text-center text-[2rem] font-semibold">
-                {isSubmitting ? '처리 중...' : '다음'}
+                {isSubmitting ? t('page.register.nurse.submitting') : t('page.makeShift.navigation.next')}
             </Button>
         </form>
     );

--- a/apps/app/src/pages/RegisterPage/ui/RegisterNurse.tsx
+++ b/apps/app/src/pages/RegisterPage/ui/RegisterNurse.tsx
@@ -64,10 +64,10 @@ function RegisterNurse() {
     } = useRegister();
     const watchIsWorker = watch('isWorker');
     const {profileImg, setRandomImage, setPhotoImage} = useProfileImage({defaultProfileImgId: 1});
-    const {createAccountFeedback, isSubmitting, handleCreateAccount, resetCreateAccountStatus} = useCreateAccount({
-        isValid,
-        submit: registerAccountAndNurse,
-    });
+    const {createAccountFeedback, isSubmitting, handleCreateAccount, handleCreateAccountValidationFailure, resetCreateAccountStatus} =
+        useCreateAccount({
+            submit: registerAccountAndNurse,
+        });
     const imageInputRef = useRef<HTMLInputElement>(null);
     const handleUploadImage = () => {
         imageInputRef.current?.click();
@@ -98,14 +98,19 @@ function RegisterNurse() {
 
     useEffect(() => {
         const subscription = watch(() => {
-            resetCreateAccountStatus();
+            if (!isSubmitting) {
+                resetCreateAccountStatus();
+            }
         });
 
         return () => subscription.unsubscribe();
-    }, [resetCreateAccountStatus, watch]);
+    }, [isSubmitting, resetCreateAccountStatus, watch]);
 
     return (
-        <form onSubmit={handleSubmit(handleCreateAccount)} className="my-auto flex w-full flex-col items-center justify-center">
+        <form
+            onSubmit={handleSubmit(handleCreateAccount, handleCreateAccountValidationFailure)}
+            className="my-auto flex w-full flex-col items-center justify-center"
+        >
             <h1 className="absolute top-0 left-0 font-apple text-[2rem] font-semibold text-text-1">회원 정보</h1>
             <div className="mt-15 flex w-full min-w-[500px] shrink-0 rounded-[1.25rem] bg-white px-11.25 pt-7.5 pb-10.5 shadow-banner">
                 <div className="flex flex-col items-center gap-7.5">

--- a/apps/app/src/pages/RegisterPage/ui/RegisterNurse.tsx
+++ b/apps/app/src/pages/RegisterPage/ui/RegisterNurse.tsx
@@ -6,6 +6,7 @@ import toast from 'react-hot-toast';
 import {match} from 'ts-pattern';
 import * as yup from 'yup';
 import {ProfileImage} from '@/entities/account/ui/profile-image';
+import useCreateAccount from '@/features/account/useCreateAccount';
 import useRegister from '@/features/auth/useRegister';
 import useProfileImage from '@/features/file/useProfileImage';
 import {type TCreateNurseDTO} from '@/shared/api/nurse/type';
@@ -61,6 +62,10 @@ function RegisterNurse() {
     } = useRegister();
     const watchIsWorker = watch('isWorker');
     const {profileImg, setRandomImage, setPhotoImage} = useProfileImage({defaultProfileImgId: 1});
+    const {createAccountFeedback, isSubmitting, handleCreateAccount, resetCreateAccountStatus} = useCreateAccount({
+        isValid,
+        submit: registerAccountAndNurse,
+    });
     const imageInputRef = useRef<HTMLInputElement>(null);
     const handleUploadImage = () => {
         imageInputRef.current?.click();
@@ -89,8 +94,16 @@ function RegisterNurse() {
         }
     }, [profileImg, setValue]);
 
+    useEffect(() => {
+        const subscription = watch(() => {
+            resetCreateAccountStatus();
+        });
+
+        return () => subscription.unsubscribe();
+    }, [resetCreateAccountStatus, watch]);
+
     return (
-        <form onSubmit={handleSubmit(registerAccountAndNurse)} className="my-auto flex w-full flex-col items-center justify-center">
+        <form onSubmit={handleSubmit(handleCreateAccount)} className="my-auto flex w-full flex-col items-center justify-center">
             <h1 className="absolute top-0 left-0 font-apple text-[2rem] font-semibold text-text-1">회원 정보</h1>
             <div className="mt-15 flex w-full min-w-[500px] shrink-0 rounded-[1.25rem] bg-white px-11.25 pt-7.5 pb-10.5 shadow-banner">
                 <div className="flex flex-col items-center gap-7.5">
@@ -198,8 +211,16 @@ function RegisterNurse() {
                 </div>
             </div>
 
-            <Button disabled={!isValid} className="mt-10 h-15 w-30 self-end text-center text-[2rem] font-semibold">
-                다음
+            <p
+                className={`mt-6 min-h-6 self-end text-right font-apple text-[1rem] ${
+                    createAccountFeedback.tone === 'error' ? 'text-red' : 'text-sub-2'
+                }`}
+            >
+                {createAccountFeedback.message}
+            </p>
+
+            <Button disabled={!isValid || isSubmitting} className="mt-4 h-15 w-30 self-end text-center text-[2rem] font-semibold">
+                {isSubmitting ? '처리 중...' : '다음'}
             </Button>
         </form>
     );

--- a/apps/app/src/shared/locales/en.ts
+++ b/apps/app/src/shared/locales/en.ts
@@ -12,6 +12,11 @@ export const en: TLocale = {
         landing: {
             title: 'Duty Schedule\nNow Easier!',
         },
+        register: {
+            nurse: {
+                submitting: 'Processing...',
+            },
+        },
         makeShift: {
             steps: {
                 workers: {

--- a/apps/app/src/shared/locales/ko.ts
+++ b/apps/app/src/shared/locales/ko.ts
@@ -10,6 +10,11 @@ export const ko = {
         landing: {
             title: '근무표\n이제 더 간편하게!',
         },
+        register: {
+            nurse: {
+                submitting: '처리 중...',
+            },
+        },
         makeShift: {
             steps: {
                 workers: {


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-919](https://gom3.atlassian.net/browse/DUT-919)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `useCreateAccount`를 제출 상태 컨트롤러로 정리해 `idle/loading/success/failure/exception` 흐름과 피드백 문구를 한 곳에서 관리하도록 변경했습니다.
- 회원가입 화면이 `createAccount` 제출 상태를 직접 읽어 버튼 비활성화, 진행 중 문구, 실패 메시지를 일관되게 보여주도록 연결했습니다.
- 계정 생성 API 실패 시 `useRegister`에서 액션 에러 피드백을 보장하고, 훅 테스트를 추가해 성공/검증 실패/처리된 실패/예외 상태 전이를 고정했습니다.

<br>

## To Reviewers

- 회원가입 완료 후 다음 단계로 이동하는 기존 흐름은 유지했습니다.
- `success` 상태는 다음 화면으로 전이되기 전의 짧은 과도 상태라, 현재는 내부 상태 정리와 테스트 안정성 확보에 중점을 뒀습니다.


[DUT-919]: https://gom3.atlassian.net/browse/DUT-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ