### PR TITLE
[DUT-912]: shift-editor complex-view 분해

### DIFF
--- a/apps/app/src/features/shift-editor/ui/complex-view/nurse-edit-modal.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/nurse-edit-modal.tsx
@@ -1,12 +1,8 @@
-import {produce} from 'immer';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
-import {events, sendEvent} from '@/analytics';
 import {type TNurse} from '@/entities/nurse';
 import useEditShiftTeam from '@/features/ward/useEditShiftTeam';
-import {CancelIcon, CheckedIcon, UncheckedIcon2} from '@/shared/assets/svg';
-import Button from '@/shared/ui/form-controls/Button';
-import TextField from '@/shared/ui/form-controls/TextField';
+import {NurseEditForm} from './nurse-edit-modal/nurse-edit-form';
 
 function NurseEditModal() {
     const {
@@ -15,17 +11,13 @@ function NurseEditModal() {
     } = useEditShiftTeam();
     const [writeNurse, setWriteNurse] = useState<TNurse | null>(null);
     const nameRef = useRef<HTMLInputElement>(null);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handleChange = (key: keyof TNurse, value: any) => {
-        if (!writeNurse) return;
-
-        setWriteNurse({...writeNurse, [key]: value});
-    };
+    const handleChange = useCallback(<K extends keyof TNurse>(key: K, value: TNurse[K]) => {
+        setWriteNurse((prev) => (prev ? {...prev, [key]: value} : prev));
+    }, []);
 
     useEffect(() => {
         if (selectedNurse) {
             nameRef.current?.focus();
-
             setWriteNurse(selectedNurse);
         }
     }, [selectedNurse]);
@@ -51,176 +43,14 @@ function NurseEditModal() {
                 selectedNurse ? 'right-12.5' : '-right-100'
             }`}
         >
-            <div className="flex h-fit w-full flex-col">
-                <div className="flex h-11 items-center bg-sub-5 px-10">
-                    <p className="font-apple text-base text-sub-3">간호사별 관리</p>
-                    <div className="ml-auto flex cursor-pointer items-center" onClick={() => selectNurse(null)}>
-                        <p className="font-apple text-base text-sub-3">닫기</p>
-                        <CancelIcon className="h-6 w-6" />
-                    </div>
-                </div>
-                <div className="my-5 flex h-10.5 w-full items-center px-10">
-                    <div className="h-10.5 w-10.5 rounded-full bg-gray-400" />
-                    <TextField
-                        ref={nameRef}
-                        autoFocus
-                        className="ml-5 h-10.5 w-40.5 px-3 text-[1.875rem] font-semibold text-text-1"
-                        onChange={(e) => {
-                            handleChange('name', e.target.value);
-                            sendEvent(events.makePage.editNurseModal.changeNurseName);
-                        }}
-                        value={writeNurse?.name ?? ''}
-                    />
-                    <div
-                        className="ml-auto flex h-5 w-7 cursor-pointer items-center justify-center rounded-[.3125rem] bg-sub-5 font-apple text-[.875rem] text-[#A2A6F5]"
-                        onClick={() => {
-                            handleChange('gender', writeNurse?.gender === '남' ? '여' : '남');
-                            sendEvent(events.makePage.editNurseModal.changeNurseGender);
-                        }}
-                    >
-                        {writeNurse?.gender}
-                    </div>
-                </div>
-                <div className="h-[.3125rem] w-full bg-sub-5" />
-                <div className="flex h-29 w-full flex-col items-stretch justify-between border-b-[.0313rem] border-sub-4 px-10 pt-[.625rem] pb-7.5">
-                    <div className="flex items-center justify-between">
-                        <p className="shrink-0 font-apple text-base font-medium text-sub-2">입사 년도</p>
-                        <p className="ml-8 truncate font-apple text-[.625rem] font-light text-sub-3">
-                            * 해당 병원에 입사한 년도를 작성해주세요.
-                        </p>
-                    </div>
-                    <TextField
-                        type="date"
-                        className="h-10 font-poppins text-[1.25rem] text-sub-3"
-                        placeholder="YYYY-MM-DD"
-                        onChange={(e) => {
-                            handleChange('employmentDate', e.target.value);
-                            sendEvent(events.makePage.editNurseModal.changeNurseEmploymentDate);
-                        }}
-                        value={writeNurse?.employmentDate ?? ''}
-                    />
-                </div>
-                <div className="flex h-29 w-full flex-col items-stretch justify-between border-b-[.0313rem] border-sub-4 px-10 pt-[.625rem] pb-7.5">
-                    <div className="flex items-center justify-between">
-                        <p className="shrink-0 font-apple text-base font-medium text-sub-2">전화 번호</p>
-                        <p className="ml-8 truncate font-apple text-[.625rem] font-light text-sub-3">* 비상 연락 망</p>
-                    </div>
-                    <TextField
-                        type="tel"
-                        className="h-10 font-poppins text-[1.25rem] text-sub-3"
-                        onChange={(e) => {
-                            handleChange('phoneNum', e.target.value);
-                            sendEvent(events.makePage.editNurseModal.changeNursePhone);
-                        }}
-                        value={writeNurse?.phoneNum ?? ''}
-                    />
-                </div>
-                <div className="flex h-29 w-full flex-col items-stretch justify-between border-b-[.0313rem] border-sub-4 px-10 pt-[.625rem] pb-7.5">
-                    <div className="flex items-center justify-between">
-                        <p className="shrink-0 font-apple text-base font-medium text-sub-2">가능 근무</p>
-                        <p className="ml-8 truncate font-apple text-[.625rem] font-light text-sub-3">* 가능 근무를 모두 선택해주세요.</p>
-                    </div>
-                    <div className="flex gap-5.5">
-                        {writeNurse?.nurseShiftTypes.slice(0, 3).map(({nurseShiftTypeId, isPossible, name}) => (
-                            <div
-                                key={nurseShiftTypeId}
-                                className={`flex h-10 flex-1 cursor-pointer items-center justify-center rounded-[.3125rem] border-[.0625rem] font-apple text-[1.25rem] ${isPossible ? 'border-main-1 text-main-1' : 'border-sub-4 text-sub-3'} `}
-                                onClick={() => {
-                                    handleChange(
-                                        'nurseShiftTypes',
-                                        produce(writeNurse.nurseShiftTypes, (draft: TNurse['nurseShiftTypes']) => {
-                                            draft.find((x) => x.nurseShiftTypeId === nurseShiftTypeId)!.isPossible = !isPossible;
-                                        }),
-                                    );
-                                    sendEvent(events.makePage.editNurseModal.changeNurseShiftTypes);
-                                }}
-                            >
-                                {name}
-                            </div>
-                        ))}
-                    </div>
-                </div>
-                <div className="flex h-10 w-full items-center border-b-[.0313rem] border-sub-4 bg-main-bg px-10 py-[.625rem]">
-                    <p className="font-apple text-base font-medium text-sub-2">근무자</p>
-                    {writeNurse?.isWorker ? (
-                        <div className="ml-auto flex items-center gap-[.625rem]">
-                            <p className="font-apple text-[.75rem] text-sub-3">해당 됨</p>
-                            <CheckedIcon
-                                className="h-5 w-5 cursor-pointer"
-                                fill="#B08BFF"
-                                onClick={() => {
-                                    handleChange('isWorker', false);
-                                    sendEvent(events.makePage.editNurseModal.changeNurseIsWorker);
-                                }}
-                            />
-                        </div>
-                    ) : (
-                        <div className="ml-auto flex items-center gap-[.625rem]">
-                            <p className="font-apple text-[.75rem] text-sub-3">해당 안됨</p>
-                            <UncheckedIcon2
-                                className="h-5 w-5 cursor-pointer"
-                                onClick={() => {
-                                    handleChange('isWorker', true);
-                                    sendEvent(events.makePage.editNurseModal.changeNurseIsWorker);
-                                }}
-                            />
-                        </div>
-                    )}
-                </div>
-                <div className="mt-[.3125rem] flex h-10 w-full items-center border-y-[.0313rem] border-sub-4 bg-main-bg px-10 py-[.625rem]">
-                    <p className="font-apple text-base font-medium text-sub-2">근무표 작성 가능자</p>
-                    {writeNurse?.isDutyManager ? (
-                        <div className="ml-auto flex items-center gap-[.625rem]">
-                            <p className="font-apple text-[.75rem] text-sub-3">해당 됨</p>
-                            <CheckedIcon
-                                className="h-5 w-5 cursor-pointer"
-                                fill="#B08BFF"
-                                onClick={() => {
-                                    handleChange('isDutyManager', false);
-                                    sendEvent(events.makePage.editNurseModal.changeNurseIsManager);
-                                }}
-                            />
-                        </div>
-                    ) : (
-                        <div className="ml-auto flex items-center gap-[.625rem]">
-                            <p className="font-apple text-[.75rem] text-sub-3">해당 안됨</p>
-                            <UncheckedIcon2
-                                className="h-5 w-5 cursor-pointer"
-                                onClick={() => {
-                                    handleChange('isDutyManager', true);
-                                    sendEvent(events.makePage.editNurseModal.changeNurseIsManager);
-                                }}
-                            />
-                        </div>
-                    )}
-                </div>
-
-                <p className="mt-7.5 ml-10 font-apple text-base font-medium text-sub-2.5">메모</p>
-                <textarea
-                    value={writeNurse?.memo ?? ''}
-                    className="mx-10 mt-[.9375rem] h-43.25 resize-none rounded-[.3125rem] border-[.0313rem] border-sub-4.5 bg-main-bg p-2 font-apple text-sm text-sub-1"
-                    onChange={(e) => {
-                        handleChange('memo', e.target.value);
-                        sendEvent(events.makePage.editNurseModal.changeNurseMemo);
-                    }}
-                />
-                <Button
-                    id="nurse_edit_drawer"
-                    className="mt-6.25 mr-10 mb-6.5 ml-auto flex h-9 items-center justify-center rounded-[3.125rem] bg-main-1 px-5 py-[.5rem] font-apple text-base font-medium text-white"
-                    disabled={
-                        selectedNurse?.name === writeNurse?.name &&
-                        selectedNurse?.employmentDate === writeNurse?.employmentDate &&
-                        selectedNurse?.phoneNum === writeNurse?.phoneNum &&
-                        selectedNurse?.isWorker === writeNurse?.isWorker &&
-                        selectedNurse?.isDutyManager === writeNurse?.isDutyManager &&
-                        selectedNurse?.memo === writeNurse?.memo &&
-                        selectedNurse?.nurseShiftTypes.length === writeNurse?.nurseShiftTypes.length
-                    }
-                    onClick={() => writeNurse && updateNurse(writeNurse.nurseId, writeNurse)}
-                >
-                    저장
-                </Button>
-            </div>
+            <NurseEditForm
+                selectedNurse={selectedNurse ?? null}
+                writeNurse={writeNurse}
+                nameRef={nameRef}
+                onClose={() => selectNurse(null)}
+                onChange={handleChange}
+                onSubmit={() => writeNurse && updateNurse(writeNurse.nurseId, writeNurse)}
+            />
         </div>,
         document.getElementById('nurse-modal-root')!,
     );

--- a/apps/app/src/features/shift-editor/ui/complex-view/nurse-edit-modal/is-nurse-edit-save-disabled.ts
+++ b/apps/app/src/features/shift-editor/ui/complex-view/nurse-edit-modal/is-nurse-edit-save-disabled.ts
@@ -1,0 +1,13 @@
+import {type TNurse} from '@/entities/nurse';
+
+export function isNurseEditSaveDisabled(selectedNurse: TNurse | null, writeNurse: TNurse | null) {
+    return (
+        selectedNurse?.name === writeNurse?.name &&
+        selectedNurse?.employmentDate === writeNurse?.employmentDate &&
+        selectedNurse?.phoneNum === writeNurse?.phoneNum &&
+        selectedNurse?.isWorker === writeNurse?.isWorker &&
+        selectedNurse?.isDutyManager === writeNurse?.isDutyManager &&
+        selectedNurse?.memo === writeNurse?.memo &&
+        selectedNurse?.nurseShiftTypes.length === writeNurse?.nurseShiftTypes.length
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/nurse-edit-modal/nurse-edit-form.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/nurse-edit-modal/nurse-edit-form.tsx
@@ -1,0 +1,178 @@
+import {produce} from 'immer';
+import {type ReactNode, type RefObject} from 'react';
+import {events, sendEvent} from '@/analytics';
+import {type TNurse} from '@/entities/nurse';
+import {CancelIcon, CheckedIcon, UncheckedIcon2} from '@/shared/assets/svg';
+import Button from '@/shared/ui/form-controls/Button';
+import TextField from '@/shared/ui/form-controls/TextField';
+import {isNurseEditSaveDisabled} from './is-nurse-edit-save-disabled';
+
+type TNurseEditFormProps = {
+    selectedNurse: TNurse | null;
+    writeNurse: TNurse | null;
+    nameRef: RefObject<HTMLInputElement | null>;
+    onClose: () => void;
+    onChange: <K extends keyof TNurse>(key: K, value: TNurse[K]) => void;
+    onSubmit: () => void;
+};
+
+type TNurseEditFieldSectionProps = {
+    title: string;
+    description: string;
+    children: ReactNode;
+};
+
+function NurseEditFieldSection({title, description, children}: TNurseEditFieldSectionProps) {
+    return (
+        <div className="flex h-29 w-full flex-col items-stretch justify-between border-b-[.0313rem] border-sub-4 px-10 pt-[.625rem] pb-7.5">
+            <div className="flex items-center justify-between">
+                <p className="shrink-0 font-apple text-base font-medium text-sub-2">{title}</p>
+                <p className="ml-8 truncate font-apple text-[.625rem] font-light text-sub-3">{description}</p>
+            </div>
+            {children}
+        </div>
+    );
+}
+
+type TNurseEditToggleRowProps = {
+    title: string;
+    checked: boolean | undefined;
+    onToggle: () => void;
+    borderClassName: string;
+};
+
+function NurseEditToggleRow({title, checked, onToggle, borderClassName}: TNurseEditToggleRowProps) {
+    return (
+        <div className={`flex h-10 w-full items-center ${borderClassName} bg-main-bg px-10 py-[.625rem]`}>
+            <p className="font-apple text-base font-medium text-sub-2">{title}</p>
+            {checked ? (
+                <div className="ml-auto flex items-center gap-[.625rem]">
+                    <p className="font-apple text-[.75rem] text-sub-3">해당 됨</p>
+                    <CheckedIcon className="h-5 w-5 cursor-pointer" fill="#B08BFF" onClick={onToggle} />
+                </div>
+            ) : (
+                <div className="ml-auto flex items-center gap-[.625rem]">
+                    <p className="font-apple text-[.75rem] text-sub-3">해당 안됨</p>
+                    <UncheckedIcon2 className="h-5 w-5 cursor-pointer" onClick={onToggle} />
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function NurseEditForm({selectedNurse, writeNurse, nameRef, onClose, onChange, onSubmit}: TNurseEditFormProps) {
+    return (
+        <div className="flex h-fit w-full flex-col">
+            <div className="flex h-11 items-center bg-sub-5 px-10">
+                <p className="font-apple text-base text-sub-3">간호사별 관리</p>
+                <div className="ml-auto flex cursor-pointer items-center" onClick={onClose}>
+                    <p className="font-apple text-base text-sub-3">닫기</p>
+                    <CancelIcon className="h-6 w-6" />
+                </div>
+            </div>
+            <div className="my-5 flex h-10.5 w-full items-center px-10">
+                <div className="h-10.5 w-10.5 rounded-full bg-gray-400" />
+                <TextField
+                    ref={nameRef}
+                    autoFocus
+                    className="ml-5 h-10.5 w-40.5 px-3 text-[1.875rem] font-semibold text-text-1"
+                    onChange={(e) => {
+                        onChange('name', e.target.value);
+                        sendEvent(events.makePage.editNurseModal.changeNurseName);
+                    }}
+                    value={writeNurse?.name ?? ''}
+                />
+                <div
+                    className="ml-auto flex h-5 w-7 cursor-pointer items-center justify-center rounded-[.3125rem] bg-sub-5 font-apple text-[.875rem] text-[#A2A6F5]"
+                    onClick={() => {
+                        onChange('gender', writeNurse?.gender === '남' ? '여' : '남');
+                        sendEvent(events.makePage.editNurseModal.changeNurseGender);
+                    }}
+                >
+                    {writeNurse?.gender}
+                </div>
+            </div>
+            <div className="h-[.3125rem] w-full bg-sub-5" />
+            <NurseEditFieldSection title="입사 년도" description="* 해당 병원에 입사한 년도를 작성해주세요.">
+                <TextField
+                    type="date"
+                    className="h-10 font-poppins text-[1.25rem] text-sub-3"
+                    placeholder="YYYY-MM-DD"
+                    onChange={(e) => {
+                        onChange('employmentDate', e.target.value);
+                        sendEvent(events.makePage.editNurseModal.changeNurseEmploymentDate);
+                    }}
+                    value={writeNurse?.employmentDate ?? ''}
+                />
+            </NurseEditFieldSection>
+            <NurseEditFieldSection title="전화 번호" description="* 비상 연락 망">
+                <TextField
+                    type="tel"
+                    className="h-10 font-poppins text-[1.25rem] text-sub-3"
+                    onChange={(e) => {
+                        onChange('phoneNum', e.target.value);
+                        sendEvent(events.makePage.editNurseModal.changeNursePhone);
+                    }}
+                    value={writeNurse?.phoneNum ?? ''}
+                />
+            </NurseEditFieldSection>
+            <NurseEditFieldSection title="가능 근무" description="* 가능 근무를 모두 선택해주세요.">
+                <div className="flex gap-5.5">
+                    {writeNurse?.nurseShiftTypes.slice(0, 3).map(({nurseShiftTypeId, isPossible, name}) => (
+                        <div
+                            key={nurseShiftTypeId}
+                            className={`flex h-10 flex-1 cursor-pointer items-center justify-center rounded-[.3125rem] border-[.0625rem] font-apple text-[1.25rem] ${isPossible ? 'border-main-1 text-main-1' : 'border-sub-4 text-sub-3'} `}
+                            onClick={() => {
+                                onChange(
+                                    'nurseShiftTypes',
+                                    produce(writeNurse.nurseShiftTypes, (draft: TNurse['nurseShiftTypes']) => {
+                                        draft.find((x) => x.nurseShiftTypeId === nurseShiftTypeId)!.isPossible = !isPossible;
+                                    }),
+                                );
+                                sendEvent(events.makePage.editNurseModal.changeNurseShiftTypes);
+                            }}
+                        >
+                            {name}
+                        </div>
+                    ))}
+                </div>
+            </NurseEditFieldSection>
+            <NurseEditToggleRow
+                title="근무자"
+                checked={writeNurse?.isWorker}
+                borderClassName="border-b-[.0313rem] border-sub-4"
+                onToggle={() => {
+                    onChange('isWorker', !writeNurse?.isWorker);
+                    sendEvent(events.makePage.editNurseModal.changeNurseIsWorker);
+                }}
+            />
+            <NurseEditToggleRow
+                title="근무표 작성 가능자"
+                checked={writeNurse?.isDutyManager}
+                borderClassName="mt-[.3125rem] border-y-[.0313rem] border-sub-4"
+                onToggle={() => {
+                    onChange('isDutyManager', !writeNurse?.isDutyManager);
+                    sendEvent(events.makePage.editNurseModal.changeNurseIsManager);
+                }}
+            />
+
+            <p className="mt-7.5 ml-10 font-apple text-base font-medium text-sub-2.5">메모</p>
+            <textarea
+                value={writeNurse?.memo ?? ''}
+                className="mx-10 mt-[.9375rem] h-43.25 resize-none rounded-[.3125rem] border-[.0313rem] border-sub-4.5 bg-main-bg p-2 font-apple text-sm text-sub-1"
+                onChange={(e) => {
+                    onChange('memo', e.target.value);
+                    sendEvent(events.makePage.editNurseModal.changeNurseMemo);
+                }}
+            />
+            <Button
+                id="nurse_edit_drawer"
+                className="mt-6.25 mr-10 mb-6.5 ml-auto flex h-9 items-center justify-center rounded-[3.125rem] bg-main-1 px-5 py-[.5rem] font-apple text-base font-medium text-white"
+                disabled={isNurseEditSaveDisabled(selectedNurse, writeNurse)}
+                onClick={onSubmit}
+            >
+                저장
+            </Button>
+        </div>
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar.tsx
@@ -1,26 +1,16 @@
-import {DragDropContext, type DropResult, Droppable, Draggable} from '@hello-pangea/dnd';
-import {type ComponentProps, type RefObject, useEffect, useMemo, useRef} from 'react';
+import {DragDropContext, type DropResult} from '@hello-pangea/dnd';
+import {type ComponentProps, useEffect, useMemo, useRef} from 'react';
 import useOnclickOutside from 'react-cool-onclickoutside';
 import {type TWardShiftType, type TShift} from '@/entities';
-import ShiftBadge from '@/entities/shift/ui/shift-badge';
 import {useUIConfigStore} from '@/entities/ui/useUIConfig/store';
 import {type TDutyDoc, useShiftEditorCommands, useShiftEditorStore} from '@/features/shift-editor/model';
 import {normalizeSelection} from '@/features/shift-editor/model/selection';
-import {DragIcon, FoldDutyIcon, MinusIcon, PlusIcon2} from '@/shared/assets/svg';
-import RequestLayer from './request-layer';
-import ViolationLayer from './violation-layer';
+import {ShiftCalendarDivision} from './shift-calendar/shift-calendar-division';
+import {ShiftCalendarHeader} from './shift-calendar/shift-calendar-header';
+import {type TLayerFlags, type TShiftCalendarFocus} from './types';
+import type ViolationLayer from './violation-layer';
 
-type TFocus = {shiftNurseId: number; day: number};
-type TLayerFlags = {fault: boolean; check: boolean; slash: boolean};
 type TViolationItem = ComponentProps<typeof ViolationLayer>['violation'];
-
-function getWeekendCellBg(dayType: TShift['days'][number]['dayType'], separateWeekendColor: boolean): string {
-    if (dayType === 'sunday' || dayType === 'holiday') return 'bg-[#FFE1E680]';
-
-    if (dayType === 'saturday') return separateWeekendColor ? 'bg-[#E1E5FF80]' : 'bg-[#FFE1E680]';
-
-    return '';
-}
 
 interface IShiftCalendarProps {
     shift: TShift;
@@ -28,7 +18,7 @@ interface IShiftCalendarProps {
     readonly?: boolean;
     onCellClick?: (rowIndex: number, colIndex: number) => void;
     disableInitialSelection?: boolean;
-    focus?: TFocus | null;
+    focus?: TShiftCalendarFocus | null;
     showLayer?: TLayerFlags;
     violations?: Map<string, TViolationItem>;
     foldedLevels?: boolean[];
@@ -64,7 +54,7 @@ function ShiftCalendar({
     const {separateWeekendColor, shiftTypeColorStyle} = useUIConfigStore();
     const commands = useShiftEditorCommands();
     const selection = useShiftEditorStore((s) => s.selection);
-    const focusedCellRef = useRef<HTMLElement>(null);
+    const focusedCellRef = useRef<HTMLParagraphElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const didClearInitialSelection = useRef(false);
     const clickAwayRef = useOnclickOutside(() => {
@@ -126,19 +116,21 @@ function ShiftCalendar({
 
         if (!focusRect || !container) return;
 
-        if (focusRect.x + focusRect.width > window.innerWidth)
-            window.scroll({
-                left: focusRect.left + container.scrollLeft,
-            });
+        if (focusRect.x + focusRect.width > window.innerWidth) {
+            window.scroll({left: focusRect.left + container.scrollLeft});
+        }
 
-        if (focusRect.x - container.offsetLeft < 0) window.scroll({left: 0});
+        if (focusRect.x - container.offsetLeft < 0) {
+            window.scroll({left: 0});
+        }
 
-        if (focusRect.y + focusRect.height - container.offsetTop > container.clientHeight)
-            window.scroll({
-                top: focusRect.top + container.scrollTop,
-            });
+        if (focusRect.y + focusRect.height - container.offsetTop > container.clientHeight) {
+            window.scroll({top: focusRect.top + container.scrollTop});
+        }
 
-        if (focusRect.y - container.offsetTop < 0) window.scroll({top: focusRect.top + window.scrollY - 132});
+        if (focusRect.y - container.offsetTop < 0) {
+            window.scroll({top: focusRect.top + window.scrollY - 132});
+        }
     }, [effectiveFocus]);
 
     useEffect(() => {
@@ -171,337 +163,44 @@ function ShiftCalendar({
 
     return (
         <div id="calendar" ref={clickAwayRef} className="flex w-full flex-col overflow-hidden">
-            <div className="z-20 flex items-center gap-5 py-[.75rem] pr-4">
-                <div className="flex h-7.5 gap-5">
-                    <div className="w-13.5 text-center font-apple text-[1rem] font-medium text-sub-3">{/* 구분 */}</div>
-                    <div className="w-17.5 text-center font-apple text-[1rem] font-medium text-sub-3">이름</div>
-                    <div className="w-7.5 text-center font-apple text-[1rem] font-medium text-sub-3">이월</div>
-                    <div className="w-22.5 text-center font-apple text-[1rem] font-medium text-sub-3">전달 근무</div>
-                    <div className="flex rounded-[2.5rem] border-[.0625rem] border-sub-4 px-4 py-[.1875rem]">
-                        {shift.days.map((item, j) => (
-                            <p
-                                key={j}
-                                className={`w-9 flex-1 rounded-full text-center font-poppins text-[1rem] ${
-                                    item.dayType === 'saturday'
-                                        ? j === effectiveFocus?.day
-                                            ? separateWeekendColor
-                                                ? 'bg-blue text-white'
-                                                : 'bg-red text-white'
-                                            : separateWeekendColor
-                                              ? 'text-blue'
-                                              : 'text-red'
-                                        : item.dayType === 'sunday' || item.dayType === 'holiday'
-                                          ? j === effectiveFocus?.day
-                                              ? 'bg-red text-white'
-                                              : 'text-red'
-                                          : item.dayType === 'workday'
-                                            ? j === effectiveFocus?.day
-                                                ? 'bg-main-1 text-white'
-                                                : 'text-sub-2.5'
-                                            : ''
-                                } `}
-                            >
-                                {item.day}
-                            </p>
-                        ))}
-                    </div>
-                </div>
-                <div className="flex shrink-0 items-center gap-2 px-6.25 text-center">
-                    {shift.wardShiftTypes
-                        .filter((x) => x.isCounted)
-                        .map((shiftType, index) => (
-                            <div
-                                key={index}
-                                className="flex h-6 w-6 items-center justify-center rounded-[.375rem] p-2 font-poppins text-[1.25rem]"
-                                style={
-                                    shiftTypeColorStyle === 'background'
-                                        ? {backgroundColor: shiftType.color, color: 'white'}
-                                        : {color: shiftType.color, backgroundColor: 'white'}
-                                }
-                            >
-                                {shiftType.shortName}
-                            </div>
-                        ))}
-                    <div
-                        className="flex h-6 w-6 items-center justify-center rounded-[.375rem] bg-red p-2 font-poppins text-[0.8rem] text-white"
-                        style={
-                            shiftTypeColorStyle === 'background'
-                                ? {
-                                      backgroundColor: shift.wardShiftTypes.find((x) => x.name === '오프')?.color,
-                                      color: 'white',
-                                  }
-                                : {
-                                      color: shift.wardShiftTypes.find((x) => x.name === '오프')?.color,
-                                      backgroundColor: 'white',
-                                  }
-                        }
-                    >
-                        WO
-                    </div>
-                </div>
-            </div>
+            <ShiftCalendarHeader
+                shift={shift}
+                effectiveFocusDay={effectiveFocus?.day}
+                separateWeekendColor={separateWeekendColor}
+                shiftTypeColorStyle={shiftTypeColorStyle}
+            />
             <DragDropContext onDragEnd={handleDragEnd}>
                 <div
                     className="-mt-5 scrollbar-hide flex flex-col gap-[.3125rem] overflow-x-hidden overflow-y-scroll pt-5 pr-4 pb-8"
                     ref={containerRef}
                 >
-                    {divisions.map((division, level) => {
-                        const rows = division.rows;
-
-                        if (!rows.length) return null;
-
-                        if (foldedLevels?.[level]) {
-                            return (
-                                <div
-                                    key={level}
-                                    className="ml-5 flex h-7.5 w-[calc(100%-1.25rem)] cursor-pointer items-center gap-[.125rem] rounded-[.625rem] bg-sub-4.5 px-[.625rem]"
-                                    onClick={() => onToggleFoldLevel?.(level)}
-                                >
-                                    <FoldDutyIcon className="h-5.5 w-5.5 rotate-180" />
-                                </div>
-                            );
-                        }
-
-                        return (
-                            <Droppable droppableId={level.toString()} key={level.toString()}>
-                                {(provided) => (
-                                    <div ref={provided.innerRef} key={level} className="flex gap-5" {...provided.droppableProps}>
-                                        <div className="relative ml-5 rounded-[1.25rem] shadow-banner">
-                                            {!readonly && foldedLevels && onToggleFoldLevel && (
-                                                <div className="absolute left-[-.9375rem] flex h-full w-7.5 items-center justify-center font-poppins font-light text-sub-2.5">
-                                                    <FoldDutyIcon
-                                                        className="absolute top-[50%] left-0 z-10 h-5.5 w-5.5 translate-x-[50%] translate-y-[-50%] cursor-pointer"
-                                                        onClick={() => onToggleFoldLevel(level)}
-                                                    />
-                                                </div>
-                                            )}
-                                            {rows.map((row, rowIndex) => {
-                                                const workerId = String(row.shiftNurse.shiftNurseId);
-                                                const docEntry = workerRowMap.get(workerId);
-                                                const docRowIndex = docEntry?.index ?? -1;
-                                                const docRow = docEntry?.row;
-                                                const isRowFocused = effectiveFocus?.shiftNurseId === row.shiftNurse.shiftNurseId;
-                                                const getCountByNurse = (wardShiftTypeId: number) =>
-                                                    docRow?.cells.filter((_current, index) => {
-                                                        const shiftType = getCellShiftType(docRowIndex, index);
-
-                                                        return shiftType?.wardShiftTypeId === wardShiftTypeId;
-                                                    }).length ?? 0;
-                                                const getOffCount = () =>
-                                                    docRow?.cells.filter((_current, i) => {
-                                                        const shiftType = getCellShiftType(docRowIndex, i);
-                                                        const day = shift.days[i];
-
-                                                        return Boolean(shiftType?.isOff) && day?.dayType !== 'workday';
-                                                    }).length ?? 0;
-
-                                                return (
-                                                    <Draggable
-                                                        draggableId={row.shiftNurse.shiftNurseId.toString()}
-                                                        index={rowIndex}
-                                                        key={row.shiftNurse.shiftNurseId}
-                                                        isDragDisabled={readonly || !enableDragAndDrop}
-                                                    >
-                                                        {(provided) => (
-                                                            <div
-                                                                className={`relative flex h-10 items-center gap-5 ${
-                                                                    rowIndex === 0
-                                                                        ? rowIndex === rows.length - 1
-                                                                            ? 'rounded-[1.25rem]'
-                                                                            : 'rounded-t-[1.25rem]'
-                                                                        : rowIndex === rows.length - 1
-                                                                          ? 'rounded-b-[1.25rem]'
-                                                                          : ''
-                                                                } ${isRowFocused ? 'bg-main-4' : 'bg-white'}`}
-                                                                ref={provided.innerRef}
-                                                                {...provided.draggableProps}
-                                                                {...provided.dragHandleProps}
-                                                            >
-                                                                {!readonly && enableDragAndDrop ? (
-                                                                    <div className="relative w-8.5 shrink-0">
-                                                                        <DragIcon className="absolute top-[50%] -right-2.5 h-6 w-6 translate-y-[-50%]" />
-                                                                    </div>
-                                                                ) : (
-                                                                    <div />
-                                                                )}
-                                                                <div
-                                                                    className="w-17.5 shrink-0 truncate text-center font-apple text-[1.25rem] text-sub-1"
-                                                                    onClick={() => {
-                                                                        onSelectNurse?.(row.shiftNurse.nurseId);
-                                                                    }}
-                                                                >
-                                                                    {row.shiftNurse.name}
-                                                                </div>
-                                                                <div className="w-7.5 shrink-0 text-center font-apple text-[1.25rem] text-sub-1">
-                                                                    {readonly || !onUpdateCarry ? (
-                                                                        <div className="h-7.5 w-7.5 cursor-default rounded-[.3125rem] border-[.0313rem] bg-main-bg font-poppins text-[1.25rem] text-sub-2 outline-none focus:bg-main-4">
-                                                                            {row.shiftNurse.carried}
-                                                                        </div>
-                                                                    ) : (
-                                                                        <button
-                                                                            className="h-7.5 w-7.5 rounded-[.3125rem] border-[.0313rem] bg-main-bg font-poppins text-[1.25rem] text-sub-2 outline-none focus:bg-main-4"
-                                                                            onKeyDown={(e) => {
-                                                                                e.preventDefault();
-
-                                                                                if (e.key === 'ArrowUp')
-                                                                                    onUpdateCarry(
-                                                                                        row.shiftNurse.shiftNurseId,
-                                                                                        row.shiftNurse.carried + 1,
-                                                                                    );
-
-                                                                                if (e.key === 'ArrowDown')
-                                                                                    onUpdateCarry(
-                                                                                        row.shiftNurse.shiftNurseId,
-                                                                                        row.shiftNurse.carried - 1,
-                                                                                    );
-                                                                            }}
-                                                                        >
-                                                                            {row.shiftNurse.carried}
-                                                                        </button>
-                                                                    )}
-                                                                </div>
-                                                                <div className="flex w-22.5 gap-[.125rem]">
-                                                                    {row.lastWardShiftList.map((current, j) => (
-                                                                        <ShiftBadge
-                                                                            key={j}
-                                                                            shiftType={current != null ? idToType.get(current) : null}
-                                                                            className="h-5.25 w-5.25 text-[.9375rem]"
-                                                                        />
-                                                                    ))}
-                                                                </div>
-                                                                <div className="flex h-full px-4.25">
-                                                                    {row.wardShiftList.map((_current, j) => {
-                                                                        const request = row.wardReqShiftList[j];
-                                                                        const dayType = shift.days[j]?.dayType ?? 'workday';
-                                                                        const weekendBg = getWeekendCellBg(dayType, separateWeekendColor);
-                                                                        const shiftType = getCellShiftType(docRowIndex, j);
-                                                                        const isSelected =
-                                                                            selection?.type === 'single' &&
-                                                                            selection.anchor.row === docRowIndex &&
-                                                                            selection.anchor.col === j;
-                                                                        const isInRange =
-                                                                            selectionRect !== null &&
-                                                                            docRowIndex >= selectionRect.top &&
-                                                                            docRowIndex <= selectionRect.bottom &&
-                                                                            j >= selectionRect.left &&
-                                                                            j <= selectionRect.right;
-                                                                        const isFocused = isRowFocused && effectiveFocus?.day === j;
-                                                                        const selectionClass =
-                                                                            !readonly && (isSelected || isInRange)
-                                                                                ? 'outline-[.125rem] outline-main-1'
-                                                                                : undefined;
-                                                                        const violation = violations?.get(
-                                                                            `${row.shiftNurse.shiftNurseId},${j}`,
-                                                                        );
-
-                                                                        return (
-                                                                            <div
-                                                                                key={j}
-                                                                                className={`group relative flex h-full w-9 flex-1 items-center justify-center px-[.25rem] ${
-                                                                                    weekendBg
-                                                                                } ${effectiveFocus?.day === j ? 'bg-main-4' : ''}`}
-                                                                                onClick={() => handleCellClick(docRowIndex, j)}
-                                                                            >
-                                                                                {!readonly && layerFlags.fault && violation && (
-                                                                                    <ViolationLayer violation={violation} />
-                                                                                )}
-                                                                                {!readonly && request !== null && shiftType && (
-                                                                                    <RequestLayer
-                                                                                        isAccept={request === shiftType.wardShiftTypeId}
-                                                                                        request={idToType.get(request)!}
-                                                                                        showCheck={layerFlags.check}
-                                                                                        showSlash={layerFlags.slash}
-                                                                                    />
-                                                                                )}
-                                                                                <ShiftBadge
-                                                                                    id={
-                                                                                        rowIndex === 0 && j === 0
-                                                                                            ? 'cell_sample'
-                                                                                            : undefined
-                                                                                    }
-                                                                                    shiftType={shiftType}
-                                                                                    isOnlyRequest={shiftType === null && request !== null}
-                                                                                    className={`z-10 ${readonly ? 'cursor-default' : 'cursor-pointer'} ${
-                                                                                        isFocused ? 'outline-[.125rem] outline-main-1' : ''
-                                                                                    } ${selectionClass ?? ''}`}
-                                                                                    forwardRef={
-                                                                                        isFocused
-                                                                                            ? (focusedCellRef as unknown as RefObject<HTMLParagraphElement>)
-                                                                                            : null
-                                                                                    }
-                                                                                />
-                                                                            </div>
-                                                                        );
-                                                                    })}
-                                                                </div>
-                                                                <div
-                                                                    id="count_by_nurse"
-                                                                    className="relative flex shrink-0 items-center gap-2 px-6.25 text-center"
-                                                                >
-                                                                    {shift.wardShiftTypes
-                                                                        .filter((x) => x.isCounted)
-                                                                        .map((wardShiftType) => (
-                                                                            <div
-                                                                                key={wardShiftType.wardShiftTypeId}
-                                                                                className="w-6 text-center font-poppins text-[1.25rem] text-sub-2"
-                                                                            >
-                                                                                {getCountByNurse(wardShiftType.wardShiftTypeId)}
-                                                                            </div>
-                                                                        ))}
-                                                                    <div className="w-6 text-center font-poppins text-[1.25rem] text-sub-2">
-                                                                        {getOffCount()}
-                                                                    </div>
-                                                                </div>
-                                                                {enableDivisionManagement && onEditDivision && !readonly && (
-                                                                    <>
-                                                                        {rowIndex !== rows.length - 1 ? (
-                                                                            <>
-                                                                                <div
-                                                                                    className="justify-cente group peer absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-80%] translate-y-[50%] items-center"
-                                                                                    onClick={(e) => {
-                                                                                        e.stopPropagation();
-                                                                                        onEditDivision({
-                                                                                            shiftNurseId: row.shiftNurse.shiftNurseId,
-                                                                                            level,
-                                                                                            direction: 1,
-                                                                                        });
-                                                                                    }}
-                                                                                >
-                                                                                    <PlusIcon2 className="invisible h-5 w-5 group-hover:visible" />
-                                                                                </div>
-                                                                                <div className="invisible absolute bottom-0 h-[.0938rem] w-full bg-sub-2.5 peer-hover:visible" />
-                                                                            </>
-                                                                        ) : (
-                                                                            level !== shift.divisionShiftNurses.length - 1 && (
-                                                                                <div
-                                                                                    className="absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-65%] translate-y-[calc(50%+.1563rem)] items-center"
-                                                                                    onClick={(e) => {
-                                                                                        e.stopPropagation();
-                                                                                        onEditDivision({
-                                                                                            shiftNurseId: row.shiftNurse.shiftNurseId,
-                                                                                            level,
-                                                                                            direction: -1,
-                                                                                        });
-                                                                                    }}
-                                                                                >
-                                                                                    <MinusIcon className="h-5 w-5 opacity-0 hover:opacity-100" />
-                                                                                </div>
-                                                                            )
-                                                                        )}
-                                                                    </>
-                                                                )}
-                                                            </div>
-                                                        )}
-                                                    </Draggable>
-                                                );
-                                            })}
-                                            {provided.placeholder}
-                                        </div>
-                                    </div>
-                                )}
-                            </Droppable>
-                        );
-                    })}
+                    {divisions.map((division, level) => (
+                        <ShiftCalendarDivision
+                            key={level}
+                            level={level}
+                            rows={division.rows}
+                            shift={shift}
+                            readonly={readonly}
+                            folded={Boolean(foldedLevels?.[level])}
+                            enableDragAndDrop={enableDragAndDrop}
+                            enableDivisionManagement={enableDivisionManagement}
+                            onToggleFoldLevel={onToggleFoldLevel}
+                            onEditDivision={onEditDivision}
+                            onSelectNurse={onSelectNurse}
+                            onUpdateCarry={onUpdateCarry}
+                            workerRowMap={workerRowMap}
+                            getCellShiftType={getCellShiftType}
+                            idToType={idToType}
+                            selection={selection}
+                            selectionRect={selectionRect}
+                            effectiveFocus={effectiveFocus}
+                            layerFlags={layerFlags}
+                            violations={violations}
+                            separateWeekendColor={separateWeekendColor}
+                            focusedCellRef={focusedCellRef}
+                            onCellClick={handleCellClick}
+                        />
+                    ))}
                 </div>
             </DragDropContext>
         </div>

--- a/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar/shift-calendar-division.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar/shift-calendar-division.tsx
@@ -1,0 +1,129 @@
+import {Droppable} from '@hello-pangea/dnd';
+import {type ComponentProps, type RefObject} from 'react';
+import {type TWardShiftType, type TShift} from '@/entities';
+import {type TDutyDoc} from '@/features/shift-editor/model';
+import {FoldDutyIcon} from '@/shared/assets/svg';
+import {type TLayerFlags, type TShiftCalendarFocus} from '../types';
+import {ShiftCalendarRow} from './shift-calendar-row';
+
+type TSelection = ComponentProps<typeof ShiftCalendarRow>['selection'];
+type TSelectionRect = ComponentProps<typeof ShiftCalendarRow>['selectionRect'];
+type TViolationMap = ComponentProps<typeof ShiftCalendarRow>['violations'];
+
+type TShiftCalendarDivisionProps = {
+    level: number;
+    rows: TShift['divisionShiftNurses'][number];
+    shift: TShift;
+    readonly: boolean;
+    folded: boolean;
+    enableDragAndDrop: boolean;
+    enableDivisionManagement: boolean;
+    onToggleFoldLevel?: (level: number) => void;
+    onEditDivision?: (opts: {shiftNurseId: number; level: number; direction: 1 | -1}) => void;
+    onSelectNurse?: (nurseId: number | null) => void;
+    onUpdateCarry?: (shiftNurseId: number, nextCarry: number) => void;
+    workerRowMap: Map<string, {row: TDutyDoc['rows'][number]; index: number}>;
+    getCellShiftType: (rowIndex: number, colIndex: number) => TWardShiftType | null;
+    idToType: Map<number, TWardShiftType>;
+    selection: TSelection;
+    selectionRect: TSelectionRect;
+    effectiveFocus: TShiftCalendarFocus | null;
+    layerFlags: TLayerFlags;
+    violations?: TViolationMap;
+    separateWeekendColor: boolean;
+    focusedCellRef: RefObject<HTMLParagraphElement | null>;
+    onCellClick: (rowIndex: number, colIndex: number) => void;
+};
+
+export function ShiftCalendarDivision({
+    level,
+    rows,
+    shift,
+    readonly,
+    folded,
+    enableDragAndDrop,
+    enableDivisionManagement,
+    onToggleFoldLevel,
+    onEditDivision,
+    onSelectNurse,
+    onUpdateCarry,
+    workerRowMap,
+    getCellShiftType,
+    idToType,
+    selection,
+    selectionRect,
+    effectiveFocus,
+    layerFlags,
+    violations,
+    separateWeekendColor,
+    focusedCellRef,
+    onCellClick,
+}: TShiftCalendarDivisionProps) {
+    if (!rows.length) return null;
+
+    if (folded) {
+        return (
+            <div
+                className="ml-5 flex h-7.5 w-[calc(100%-1.25rem)] cursor-pointer items-center gap-[.125rem] rounded-[.625rem] bg-sub-4.5 px-[.625rem]"
+                onClick={() => onToggleFoldLevel?.(level)}
+            >
+                <FoldDutyIcon className="h-5.5 w-5.5 rotate-180" />
+                <p className="font-poppins text-base font-light text-sub-3">Duty {level + 1}</p>
+                <p className="ml-4 font-poppins text-base font-light text-sub-3">{rows.length}명</p>
+            </div>
+        );
+    }
+
+    return (
+        <Droppable droppableId={level.toString()} key={level.toString()}>
+            {(provided) => (
+                <div ref={provided.innerRef} className="flex gap-5" {...provided.droppableProps}>
+                    <div className="relative ml-5 rounded-[1.25rem] shadow-banner">
+                        {!readonly && onToggleFoldLevel && (
+                            <div className="absolute left-[-.9375rem] flex h-full w-7.5 items-center justify-center font-poppins font-light text-sub-2.5">
+                                <FoldDutyIcon
+                                    className="absolute top-[50%] left-0 z-10 h-5.5 w-5.5 translate-x-[50%] translate-y-[-50%] cursor-pointer"
+                                    onClick={() => onToggleFoldLevel(level)}
+                                />
+                            </div>
+                        )}
+                        {rows.map((row, rowIndex) => {
+                            const workerId = String(row.shiftNurse.shiftNurseId);
+                            const docEntry = workerRowMap.get(workerId);
+
+                            return (
+                                <ShiftCalendarRow
+                                    key={row.shiftNurse.shiftNurseId}
+                                    row={row}
+                                    rowIndex={rowIndex}
+                                    rowsLength={rows.length}
+                                    level={level}
+                                    shift={shift}
+                                    readonly={readonly}
+                                    enableDragAndDrop={enableDragAndDrop}
+                                    enableDivisionManagement={enableDivisionManagement}
+                                    onEditDivision={onEditDivision}
+                                    onSelectNurse={onSelectNurse}
+                                    onUpdateCarry={onUpdateCarry}
+                                    docRowIndex={docEntry?.index ?? -1}
+                                    docRow={docEntry?.row}
+                                    getCellShiftType={getCellShiftType}
+                                    idToType={idToType}
+                                    selection={selection}
+                                    selectionRect={selectionRect}
+                                    effectiveFocus={effectiveFocus}
+                                    layerFlags={layerFlags}
+                                    violations={violations}
+                                    separateWeekendColor={separateWeekendColor}
+                                    focusedCellRef={focusedCellRef}
+                                    onCellClick={onCellClick}
+                                />
+                            );
+                        })}
+                        {provided.placeholder}
+                    </div>
+                </div>
+            )}
+        </Droppable>
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar/shift-calendar-header.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar/shift-calendar-header.tsx
@@ -1,0 +1,78 @@
+import {type TWardShiftType, type TShift} from '@/entities';
+
+type TShiftCalendarHeaderProps = {
+    shift: TShift;
+    effectiveFocusDay?: number;
+    separateWeekendColor: boolean;
+    shiftTypeColorStyle: string;
+};
+
+export function ShiftCalendarHeader({shift, effectiveFocusDay, separateWeekendColor, shiftTypeColorStyle}: TShiftCalendarHeaderProps) {
+    const offShiftType = shift.wardShiftTypes.find((x) => x.name === '오프');
+
+    return (
+        <div className="z-20 flex items-center gap-5 py-[.75rem] pr-4">
+            <div className="flex h-7.5 gap-5">
+                <div className="w-13.5 text-center font-apple text-[1rem] font-medium text-sub-3">{/* 구분 */}</div>
+                <div className="w-17.5 text-center font-apple text-[1rem] font-medium text-sub-3">이름</div>
+                <div className="w-7.5 text-center font-apple text-[1rem] font-medium text-sub-3">이월</div>
+                <div className="w-22.5 text-center font-apple text-[1rem] font-medium text-sub-3">전달 근무</div>
+                <div className="flex rounded-[2.5rem] border-[.0625rem] border-sub-4 px-4 py-[.1875rem]">
+                    {shift.days.map((item, j) => (
+                        <p
+                            key={j}
+                            className={`w-9 flex-1 rounded-full text-center font-poppins text-[1rem] ${
+                                item.dayType === 'saturday'
+                                    ? j === effectiveFocusDay
+                                        ? separateWeekendColor
+                                            ? 'bg-blue text-white'
+                                            : 'bg-red text-white'
+                                        : separateWeekendColor
+                                          ? 'text-blue'
+                                          : 'text-red'
+                                    : item.dayType === 'sunday' || item.dayType === 'holiday'
+                                      ? j === effectiveFocusDay
+                                          ? 'bg-red text-white'
+                                          : 'text-red'
+                                      : item.dayType === 'workday'
+                                        ? j === effectiveFocusDay
+                                            ? 'bg-main-1 text-white'
+                                            : 'text-sub-2.5'
+                                        : ''
+                            } `}
+                        >
+                            {item.day}
+                        </p>
+                    ))}
+                </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2 px-6.25 text-center">
+                {shift.wardShiftTypes
+                    .filter((x) => x.isCounted)
+                    .map((shiftType: TWardShiftType) => (
+                        <div
+                            key={shiftType.wardShiftTypeId}
+                            className="flex h-6 w-6 items-center justify-center rounded-[.375rem] p-2 font-poppins text-[1.25rem]"
+                            style={
+                                shiftTypeColorStyle === 'background'
+                                    ? {backgroundColor: shiftType.color, color: 'white'}
+                                    : {color: shiftType.color, backgroundColor: 'white'}
+                            }
+                        >
+                            {shiftType.shortName}
+                        </div>
+                    ))}
+                <div
+                    className="flex h-6 w-6 items-center justify-center rounded-[.375rem] bg-red p-2 font-poppins text-[0.8rem] text-white"
+                    style={
+                        shiftTypeColorStyle === 'background'
+                            ? {backgroundColor: offShiftType?.color, color: 'white'}
+                            : {color: offShiftType?.color, backgroundColor: 'white'}
+                    }
+                >
+                    WO
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar/shift-calendar-row.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar/shift-calendar-row.tsx
@@ -1,0 +1,246 @@
+import {Draggable} from '@hello-pangea/dnd';
+import {type ComponentProps, type RefObject} from 'react';
+import {type TWardShiftType, type TShift} from '@/entities';
+import ShiftBadge from '@/entities/shift/ui/shift-badge';
+import {type TDutyDoc, type TSelection} from '@/features/shift-editor/model';
+import {DragIcon, MinusIcon, PlusIcon2} from '@/shared/assets/svg';
+import RequestLayer from '../request-layer';
+import {type TLayerFlags, type TShiftCalendarFocus} from '../types';
+import ViolationLayer from '../violation-layer';
+import {getWeekendCellBg} from './shift-calendar-utils';
+
+type TViolationItem = ComponentProps<typeof ViolationLayer>['violation'];
+
+type TShiftCalendarRowProps = {
+    row: TShift['divisionShiftNurses'][number][number];
+    rowIndex: number;
+    rowsLength: number;
+    level: number;
+    shift: TShift;
+    readonly: boolean;
+    enableDragAndDrop: boolean;
+    enableDivisionManagement: boolean;
+    onEditDivision?: (opts: {shiftNurseId: number; level: number; direction: 1 | -1}) => void;
+    onSelectNurse?: (nurseId: number | null) => void;
+    onUpdateCarry?: (shiftNurseId: number, nextCarry: number) => void;
+    docRowIndex: number;
+    docRow?: TDutyDoc['rows'][number];
+    getCellShiftType: (rowIndex: number, colIndex: number) => TWardShiftType | null;
+    idToType: Map<number, TWardShiftType>;
+    selection: TSelection | null;
+    selectionRect: {top: number; left: number; bottom: number; right: number} | null;
+    effectiveFocus: TShiftCalendarFocus | null;
+    layerFlags: TLayerFlags;
+    violations?: Map<string, TViolationItem>;
+    separateWeekendColor: boolean;
+    focusedCellRef: RefObject<HTMLParagraphElement | null>;
+    onCellClick: (rowIndex: number, colIndex: number) => void;
+};
+
+export function ShiftCalendarRow({
+    row,
+    rowIndex,
+    rowsLength,
+    level,
+    shift,
+    readonly,
+    enableDragAndDrop,
+    enableDivisionManagement,
+    onEditDivision,
+    onSelectNurse,
+    onUpdateCarry,
+    docRowIndex,
+    docRow,
+    getCellShiftType,
+    idToType,
+    selection,
+    selectionRect,
+    effectiveFocus,
+    layerFlags,
+    violations,
+    separateWeekendColor,
+    focusedCellRef,
+    onCellClick,
+}: TShiftCalendarRowProps) {
+    const isRowFocused = effectiveFocus?.shiftNurseId === row.shiftNurse.shiftNurseId;
+    const getCountByNurse = (wardShiftTypeId: number) =>
+        docRow?.cells.filter((_current, index) => {
+            const shiftType = getCellShiftType(docRowIndex, index);
+
+            return shiftType?.wardShiftTypeId === wardShiftTypeId;
+        }).length ?? 0;
+    const getOffCount = () =>
+        docRow?.cells.filter((_current, i) => {
+            const shiftType = getCellShiftType(docRowIndex, i);
+            const day = shift.days[i];
+
+            return Boolean(shiftType?.isOff) && day?.dayType !== 'workday';
+        }).length ?? 0;
+
+    return (
+        <Draggable
+            draggableId={row.shiftNurse.shiftNurseId.toString()}
+            index={rowIndex}
+            key={row.shiftNurse.shiftNurseId}
+            isDragDisabled={readonly || !enableDragAndDrop}
+        >
+            {(provided) => (
+                <div
+                    className={`relative flex h-10 items-center gap-5 ${
+                        rowIndex === 0
+                            ? rowIndex === rowsLength - 1
+                                ? 'rounded-[1.25rem]'
+                                : 'rounded-t-[1.25rem]'
+                            : rowIndex === rowsLength - 1
+                              ? 'rounded-b-[1.25rem]'
+                              : ''
+                    } ${isRowFocused ? 'bg-main-4' : 'bg-white'}`}
+                    ref={provided.innerRef}
+                    {...provided.draggableProps}
+                    {...provided.dragHandleProps}
+                >
+                    {!readonly && enableDragAndDrop ? (
+                        <div className="relative w-8.5 shrink-0">
+                            <DragIcon className="absolute top-[50%] -right-2.5 h-6 w-6 translate-y-[-50%]" />
+                        </div>
+                    ) : (
+                        <div />
+                    )}
+                    <div
+                        className="w-17.5 shrink-0 truncate text-center font-apple text-[1.25rem] text-sub-1"
+                        onClick={() => {
+                            onSelectNurse?.(row.shiftNurse.nurseId);
+                        }}
+                    >
+                        {row.shiftNurse.name}
+                    </div>
+                    <div className="w-7.5 shrink-0 text-center font-apple text-[1.25rem] text-sub-1">
+                        {readonly || !onUpdateCarry ? (
+                            <div className="h-7.5 w-7.5 cursor-default rounded-[.3125rem] border-[.0313rem] bg-main-bg font-poppins text-[1.25rem] text-sub-2 outline-none focus:bg-main-4">
+                                {row.shiftNurse.carried}
+                            </div>
+                        ) : (
+                            <button
+                                className="h-7.5 w-7.5 rounded-[.3125rem] border-[.0313rem] bg-main-bg font-poppins text-[1.25rem] text-sub-2 outline-none focus:bg-main-4"
+                                onKeyDown={(e) => {
+                                    e.preventDefault();
+
+                                    if (e.key === 'ArrowUp') onUpdateCarry(row.shiftNurse.shiftNurseId, row.shiftNurse.carried + 1);
+
+                                    if (e.key === 'ArrowDown') onUpdateCarry(row.shiftNurse.shiftNurseId, row.shiftNurse.carried - 1);
+                                }}
+                            >
+                                {row.shiftNurse.carried}
+                            </button>
+                        )}
+                    </div>
+                    <div className="flex w-22.5 gap-[.125rem]">
+                        {row.lastWardShiftList.map((current, j) => (
+                            <ShiftBadge
+                                key={j}
+                                shiftType={current != null ? idToType.get(current) : null}
+                                className="h-5.25 w-5.25 text-[.9375rem]"
+                            />
+                        ))}
+                    </div>
+                    <div className="flex h-full px-4.25">
+                        {row.wardShiftList.map((_current, j) => {
+                            const request = row.wardReqShiftList[j];
+                            const dayType = shift.days[j]?.dayType ?? 'workday';
+                            const weekendBg = getWeekendCellBg(dayType, separateWeekendColor);
+                            const shiftType = getCellShiftType(docRowIndex, j);
+                            const isSelected =
+                                selection?.type === 'single' && selection.anchor.row === docRowIndex && selection.anchor.col === j;
+                            const isInRange =
+                                selectionRect !== null &&
+                                docRowIndex >= selectionRect.top &&
+                                docRowIndex <= selectionRect.bottom &&
+                                j >= selectionRect.left &&
+                                j <= selectionRect.right;
+                            const isFocused = isRowFocused && effectiveFocus?.day === j;
+                            const selectionClass = !readonly && (isSelected || isInRange) ? 'outline-[.125rem] outline-main-1' : undefined;
+                            const violation = violations?.get(`${row.shiftNurse.shiftNurseId},${j}`);
+
+                            return (
+                                <div
+                                    key={j}
+                                    className={`group relative flex h-full w-9 flex-1 items-center justify-center px-[.25rem] ${weekendBg} ${
+                                        effectiveFocus?.day === j ? 'bg-main-4' : ''
+                                    }`}
+                                    onClick={() => onCellClick(docRowIndex, j)}
+                                >
+                                    {!readonly && layerFlags.fault && violation && <ViolationLayer violation={violation} />}
+                                    {!readonly && request !== null && shiftType && (
+                                        <RequestLayer
+                                            isAccept={request === shiftType.wardShiftTypeId}
+                                            request={idToType.get(request)!}
+                                            showCheck={layerFlags.check}
+                                            showSlash={layerFlags.slash}
+                                        />
+                                    )}
+                                    <ShiftBadge
+                                        id={rowIndex === 0 && j === 0 ? 'cell_sample' : undefined}
+                                        shiftType={shiftType}
+                                        isOnlyRequest={shiftType === null && request !== null}
+                                        className={`z-10 ${readonly ? 'cursor-default' : 'cursor-pointer'} ${
+                                            isFocused ? 'outline-[.125rem] outline-main-1' : ''
+                                        } ${selectionClass ?? ''}`}
+                                        forwardRef={isFocused ? focusedCellRef : null}
+                                    />
+                                </div>
+                            );
+                        })}
+                    </div>
+                    <div id="count_by_nurse" className="relative flex shrink-0 items-center gap-2 px-6.25 text-center">
+                        {shift.wardShiftTypes
+                            .filter((x) => x.isCounted)
+                            .map((wardShiftType) => (
+                                <div key={wardShiftType.wardShiftTypeId} className="w-6 text-center font-poppins text-[1.25rem] text-sub-2">
+                                    {getCountByNurse(wardShiftType.wardShiftTypeId)}
+                                </div>
+                            ))}
+                        <div className="w-6 text-center font-poppins text-[1.25rem] text-sub-2">{getOffCount()}</div>
+                    </div>
+                    {enableDivisionManagement && onEditDivision && !readonly && (
+                        <>
+                            {rowIndex !== rowsLength - 1 ? (
+                                <>
+                                    <div
+                                        className="justify-cente group peer absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-80%] translate-y-[50%] items-center"
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onEditDivision({
+                                                shiftNurseId: row.shiftNurse.shiftNurseId,
+                                                level,
+                                                direction: 1,
+                                            });
+                                        }}
+                                    >
+                                        <PlusIcon2 className="invisible h-5 w-5 group-hover:visible" />
+                                    </div>
+                                    <div className="invisible absolute bottom-0 h-[.0938rem] w-full bg-sub-2.5 peer-hover:visible" />
+                                </>
+                            ) : (
+                                level !== shift.divisionShiftNurses.length - 1 && (
+                                    <div
+                                        className="absolute bottom-0 z-10 flex h-6 w-6 translate-x-[-65%] translate-y-[calc(50%+.1563rem)] items-center"
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onEditDivision({
+                                                shiftNurseId: row.shiftNurse.shiftNurseId,
+                                                level,
+                                                direction: -1,
+                                            });
+                                        }}
+                                    >
+                                        <MinusIcon className="h-5 w-5 opacity-0 hover:opacity-100" />
+                                    </div>
+                                )
+                            )}
+                        </>
+                    )}
+                </div>
+            )}
+        </Draggable>
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar/shift-calendar-utils.ts
+++ b/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar/shift-calendar-utils.ts
@@ -1,0 +1,9 @@
+import {type TShift} from '@/entities';
+
+export function getWeekendCellBg(dayType: TShift['days'][number]['dayType'], separateWeekendColor: boolean): string {
+    if (dayType === 'sunday' || dayType === 'holiday') return 'bg-[#FFE1E680]';
+
+    if (dayType === 'saturday') return separateWeekendColor ? 'bg-[#E1E5FF80]' : 'bg-[#FFE1E680]';
+
+    return '';
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar.tsx
@@ -1,34 +1,13 @@
 import {useState} from 'react';
-import {createPortal} from 'react-dom';
-import Draggable from 'react-draggable';
 import {events, sendEvent} from '@/analytics';
 import {type TShift, type TWardConstraint, type TShiftTeam} from '@/entities';
-import ShiftBadge from '@/entities/shift/ui/shift-badge';
-import {shiftToExcel} from '@/features/shift-editor/model/shift-to-excel';
-import {
-    CancelIcon,
-    DutyIconSelected,
-    FaultDotIcon,
-    HistoryBackIcon,
-    HistoryNextIcon,
-    InfoIcon,
-    NextIcon,
-    PenIcon,
-    PrevIcon,
-    RequestCheckIcon,
-    RequestSlashIcon,
-    SaveCompleteIcon,
-    SavingIcon,
-    ShareIcon,
-} from '@/shared/assets/svg';
+import {InfoIcon, NextIcon, PenIcon, PrevIcon} from '@/shared/assets/svg';
 import Button from '@/shared/ui/form-controls/Button';
-import Select from '@/shared/ui/form-controls/Select';
-import {showValidationFeedback} from '@/shared/util/feedback';
-import SetConstraint from './editWard/set-constraint';
-import SetDesignTheme from './editWard/set-design-theme';
-import SetShiftType from './editWard/set-shift-type';
-
-type TLayerFlags = {fault: boolean; check: boolean; slash: boolean};
+import {ToolbarActionGroup} from './toolbar/toolbar-action-group';
+import {ToolbarLayerToggles} from './toolbar/toolbar-layer-toggles';
+import {ToolbarSettingsPanel} from './toolbar/toolbar-settings-panel';
+import {ToolbarShiftInfoPanel} from './toolbar/toolbar-shift-info-panel';
+import {type TLayerFlags, type TToolbarSetupTab} from './types';
 
 interface IToolbarProps {
     year: number;
@@ -72,7 +51,7 @@ function Toolbar({
     onUpdateConstraint,
 }: IToolbarProps) {
     const [openInfo, setOpenInfo] = useState(false);
-    const [currentSetup, setCurrentSetup] = useState<'constraint' | 'shiftType' | 'designTheme' | null>(null);
+    const [currentSetup, setCurrentSetup] = useState<TToolbarSetupTab | null>(null);
 
     return (
         <div id="toolbar" className="sticky top-0 z-30 flex h-24.5 w-full items-center bg-[#FDFCFE] pt-7.5 pr-4 pb-[.75rem] pl-5">
@@ -109,12 +88,7 @@ function Toolbar({
                     variant="outline"
                     className="mr-5 flex h-10 w-31.75 items-center justify-center rounded-[3.125rem] border-[.0313rem] border-main-2 bg-main-4 text-base font-normal"
                     onClick={() => {
-                        if (currentSetup) {
-                            setCurrentSetup(null);
-                        } else {
-                            setCurrentSetup('constraint');
-                        }
-
+                        setCurrentSetup((prev) => (prev ? null : 'constraint'));
                         sendEvent(events.makePage.toolbar.openEditWardModal);
                     }}
                 >
@@ -123,248 +97,40 @@ function Toolbar({
                 </Button>
             )}
 
-            {currentSetup !== null &&
-                createPortal(
-                    <Draggable>
-                        <div className="absolute top-22 left-70.5 z-1001 flex flex-col rounded-[1.25rem] bg-white shadow-shadow-3">
-                            <div className="flex h-11 cursor-move items-center rounded-t-[1.25rem] bg-sub-5">
-                                <div
-                                    className={`flex h-full w-37.5 cursor-pointer items-center justify-center rounded-t-[1.25rem] font-apple text-base ${currentSetup === 'constraint' ? 'bg-white text-main-1' : 'text-sub-3'} `}
-                                    onClick={() => setCurrentSetup('constraint')}
-                                >
-                                    제약 조건
-                                </div>
-                                <div
-                                    className={`flex h-full w-37.5 cursor-pointer items-center justify-center rounded-t-[1.25rem] font-apple text-base ${currentSetup === 'shiftType' ? 'bg-white text-main-1' : 'text-sub-3'} `}
-                                    onClick={() => setCurrentSetup('shiftType')}
-                                >
-                                    근무 유형
-                                </div>
-                                <div
-                                    className={`flex h-full w-37.5 cursor-pointer items-center justify-center rounded-t-[1.25rem] font-apple text-base ${currentSetup === 'designTheme' ? 'bg-white text-main-1' : 'text-sub-3'} `}
-                                    onClick={() => setCurrentSetup('designTheme')}
-                                >
-                                    디자인 테마
-                                </div>
-                                <CancelIcon
-                                    className="absolute right-[.5rem] h-6 w-6 cursor-pointer"
-                                    onClick={() => setCurrentSetup(null)}
-                                />
-                            </div>
-                            {currentSetup === 'constraint' && wardConstraint && (
-                                <SetConstraint wardConstraint={wardConstraint} onUpdateConstraint={onUpdateConstraint} />
-                            )}
-                            {currentSetup === 'shiftType' && <SetShiftType />}
-                            {currentSetup === 'designTheme' && <SetDesignTheme />}
-                        </div>
-                    </Draggable>,
-
-                    document.getElementById('edit-modal-root')!,
-                )}
+            <ToolbarSettingsPanel
+                currentSetup={currentSetup}
+                wardConstraint={wardConstraint}
+                onSelectSetup={setCurrentSetup}
+                onClose={() => setCurrentSetup(null)}
+                onUpdateConstraint={onUpdateConstraint}
+            />
 
             <InfoIcon
                 className="h-6.5 w-6.5 cursor-pointer"
                 onClick={() => {
-                    setOpenInfo(!openInfo);
+                    setOpenInfo((prev) => !prev);
                     sendEvent(events.makePage.toolbar.openShiftInfoModal);
                 }}
             />
-            {openInfo &&
-                createPortal(
-                    <Draggable>
-                        <div className="absolute top-22 left-70.5 z-1001 flex w-116.5 flex-col rounded-[.625rem] bg-white shadow-shadow-3">
-                            <div className="flex h-6.5 cursor-move items-center rounded-t-[.625rem] bg-sub-5 pl-10">
-                                <p className="bottom-0 font-apple text-[.875rem] text-sub-2.5">근무 유형 보기</p>
-                                <CancelIcon
-                                    className="absolute right-[.5rem] h-4.5 w-4.5 cursor-pointer"
-                                    onClick={() => setOpenInfo(false)}
-                                />
-                            </div>
-                            <div className="flex flex-wrap items-center justify-start gap-5 py-[.875rem] pl-10">
-                                {shift?.wardShiftTypes.map((shiftType, index) => (
-                                    <div key={index} className="flex shrink-0 items-center gap-[.3125rem]">
-                                        <ShiftBadge key={index} shiftType={shiftType} />
-                                        <p className="font-apple text-[.875rem] text-sub-2">
-                                            {shiftType.name}({shiftType.shortName})
-                                        </p>
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                    </Draggable>,
+            <ToolbarShiftInfoPanel shift={shift} open={openInfo} onClose={() => setOpenInfo(false)} />
 
-                    document.getElementById('info-modal-root')!,
-                )}
+            {!readonly && <ToolbarLayerToggles showLayer={showLayer} onToggleLayer={onToggleLayer} />}
 
-            {!readonly && (
-                <>
-                    <div className="ml-12.5 flex gap-[.25rem]">
-                        <div
-                            className={`flex h-9 cursor-pointer items-center gap-[.5rem] rounded-[.3125rem] border-[.0313rem] border-sub-4 px-[.625rem] ${
-                                showLayer.fault ? 'white' : 'bg-sub-5'
-                            }`}
-                            onClick={() => {
-                                onToggleLayer('fault');
-                                sendEvent(showLayer.fault ? events.makePage.toolbar.offLayer : events.makePage.toolbar.onLayer, 'fault');
-                            }}
-                        >
-                            <div
-                                className={`relative h-[.875rem] w-[.875rem] rounded-[.1875rem] border-[.0806rem] border-[#FF0000] bg-[#ff000033]`}
-                            >
-                                <FaultDotIcon className="absolute -top-2 -right-0.75 h-[.4rem] w-[.4rem]" />
-                            </div>
-                            <p className={`font-apple text-[.75rem] select-none ${showLayer.fault ? 'text-sub-2' : 'text-sub-3'}`}>
-                                잘못된 근무
-                            </p>
-                        </div>
-                        <div
-                            className={`flex h-9 cursor-pointer items-center gap-[.5rem] rounded-[.3125rem] border-[.0313rem] border-sub-4 px-[.625rem] ${
-                                showLayer.check ? 'white' : 'bg-sub-5'
-                            }`}
-                            onClick={() => {
-                                onToggleLayer('check');
-                                sendEvent(showLayer.check ? events.makePage.toolbar.offLayer : events.makePage.toolbar.onLayer, 'check');
-                            }}
-                        >
-                            <div
-                                className={`relative h-[.875rem] w-[.875rem] rounded-[.1875rem] border-[.0806rem] border-[#06E738] bg-[#06e73833]`}
-                            >
-                                <RequestCheckIcon className="absolute -top-2 -right-0.75 h-[.4rem] w-[.4rem]" />
-                            </div>
-                            <p className={`font-apple text-[.75rem] select-none ${showLayer.check ? 'text-sub-2' : 'text-sub-3'}`}>
-                                신청 근무 반영
-                            </p>
-                        </div>
-                        <div
-                            className={`flex h-9 cursor-pointer items-center gap-[.5rem] rounded-[.3125rem] border-[.0313rem] border-sub-4 px-[.625rem] ${
-                                showLayer.slash ? 'white' : 'bg-sub-5'
-                            }`}
-                            onClick={() => {
-                                onToggleLayer('slash');
-                                sendEvent(showLayer.slash ? events.makePage.toolbar.offLayer : events.makePage.toolbar.onLayer, 'slash');
-                            }}
-                        >
-                            <div
-                                className={`relative h-[.875rem] w-[.875rem] rounded-[.1875rem] border-[.0806rem] border-[#0027F4] bg-[#0027f433]`}
-                            >
-                                <RequestSlashIcon className="absolute -top-2 -right-0.75 h-[.4rem] w-[.4rem]" />
-                            </div>
-                            <p className={`font-apple text-[.75rem] select-none ${showLayer.slash ? 'text-sub-2' : 'text-sub-3'}`}>
-                                신청 근무 미반영
-                            </p>
-                        </div>
-                    </div>
-
-                    <div className="ml-auto flex gap-[.3125rem] font-apple text-[.875rem] text-sub-2.5">
-                        {saveStatus === 'pending' ? <SavingIcon className="h-5 w-5" /> : <SaveCompleteIcon className="h-5 w-5" />}
-                        {saveStatus === 'pending' ? '저장중' : '저장 완료'}
-                    </div>
-
-                    <div className="ml-7.5 flex gap-[.625rem]">
-                        <HistoryBackIcon
-                            className="h-6.5 w-6.5 cursor-pointer"
-                            onClick={() => {
-                                onUndo();
-                                sendEvent(events.makePage.toolbar.undoBytoolbar);
-                            }}
-                        />
-                        <HistoryNextIcon
-                            className="h-6.5 w-6.5 cursor-pointer"
-                            onClick={() => {
-                                onRedo();
-                                sendEvent(events.makePage.toolbar.redoByToolbar);
-                            }}
-                        />
-                    </div>
-                </>
-            )}
-
-            <div>
-                {currentShiftTeam && (
-                    <Select
-                        value={currentShiftTeam?.shiftTeamId}
-                        options={shiftTeams?.map((shiftTeam) => ({
-                            label: shiftTeam.name,
-                            value: shiftTeam.shiftTeamId,
-                        }))}
-                        className="ml-7.5 h-11.5 w-42 font-apple text-[1.25rem] font-semibold text-main-1"
-                        selectClassName="outline-[.0938rem] outline-main-1"
-                        onChange={(e) => onChangeShiftTeam(parseInt(e.target.value))}
-                    />
-                )}
-            </div>
-
-            {readonly ? (
-                <div className="ml-auto flex gap-[10px]">
-                    <Button
-                        variant="default"
-                        className="flex h-10 items-center justify-center rounded-[.625rem] bg-main-2 px-[.75rem] text-[1.25rem] font-semibold"
-                        onClick={() => {
-                            onPostShift();
-                            sendEvent(events.makePage.toolbar.postShift);
-                        }}
-                        disabled={new Date(year, month + 1, 1) <= new Date()}
-                    >
-                        게시하기
-                    </Button>
-                    <Button
-                        id="editButton"
-                        variant="default"
-                        className="flex h-10 items-center justify-center gap-[.5rem] rounded-[.625rem] bg-main-2 pr-[.5rem] pl-[.75rem] text-[1.25rem] font-semibold"
-                        onClick={() => {
-                            onToggleEditMode();
-                            sendEvent(events.makePage.toolbar.changeEditMode);
-                        }}
-                        disabled={new Date(year, month + 1, 1) <= new Date()}
-                    >
-                        수정하기
-                        <PenIcon className="h-6 w-6 stroke-white" />
-                    </Button>
-                    {/* @TODO 이미지 저장 구현 */}
-                    <Button
-                        id="El2"
-                        variant="default"
-                        className="flex h-10 items-center justify-center gap-[.5rem] rounded-[.625rem] bg-main-2 pr-[.5rem] pl-[.75rem] text-[1.25rem] font-semibold"
-                        onClick={() => {
-                            if (shift) {
-                                shiftToExcel(month, shift);
-                            }
-
-                            sendEvent(events.makePage.toolbar.downloadExcel);
-                        }}
-                    >
-                        다운로드
-                        <ShareIcon className="h-6 w-6" />
-                    </Button>
-                    <Button
-                        variant="outline"
-                        className="flex h-10 w-59 items-center justify-center gap-[.5rem] rounded-[.625rem] text-[1.25rem] font-semibold"
-                        onClick={() => {
-                            onCreateNextMonth();
-                            sendEvent(events.makePage.toolbar.editNextMonth);
-                        }}
-                    >
-                        다음달 근무표 만들기
-                        <DutyIconSelected className="h-6 w-6" />
-                    </Button>
-                </div>
-            ) : (
-                <div className="ml-5 flex gap-[.875rem]">
-                    <Button
-                        variant="default"
-                        className="h-10 w-33 rounded-[3.125rem] border-none bg-[rgba(171,171,180,0.80)] text-[1.25rem] font-semibold text-white"
-                        onClick={() => showValidationFeedback('아직 준비 중인 기능입니다.')}
-                    >
-                        자동 채우기
-                    </Button>
-                    <Button
-                        className="h-10 rounded-[3.125rem] border-main-1 bg-white px-5 text-[1.25rem] font-semibold text-main-1 transition-all hover:bg-main-1 hover:text-white"
-                        onClick={() => onToggleEditMode()}
-                    >
-                        저장
-                    </Button>
-                </div>
-            )}
+            <ToolbarActionGroup
+                year={year}
+                month={month}
+                shift={shift}
+                readonly={readonly}
+                saveStatus={saveStatus}
+                currentShiftTeam={currentShiftTeam}
+                shiftTeams={shiftTeams}
+                onUndo={onUndo}
+                onRedo={onRedo}
+                onPostShift={onPostShift}
+                onToggleEditMode={onToggleEditMode}
+                onCreateNextMonth={onCreateNextMonth}
+                onChangeShiftTeam={onChangeShiftTeam}
+            />
         </div>
     );
 }

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-action-group.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-action-group.tsx
@@ -1,0 +1,152 @@
+import {events, sendEvent} from '@/analytics';
+import {type TShift, type TShiftTeam} from '@/entities';
+import {shiftToExcel} from '@/features/shift-editor/model/shift-to-excel';
+import {DutyIconSelected, HistoryBackIcon, HistoryNextIcon, PenIcon, SaveCompleteIcon, SavingIcon, ShareIcon} from '@/shared/assets/svg';
+import Button from '@/shared/ui/form-controls/Button';
+import Select from '@/shared/ui/form-controls/Select';
+import {showValidationFeedback} from '@/shared/util/feedback';
+
+type TToolbarActionGroupProps = {
+    year: number;
+    month: number;
+    shift: TShift | null;
+    readonly: boolean;
+    saveStatus: 'pending' | 'saved';
+    currentShiftTeam: TShiftTeam | null;
+    shiftTeams: TShiftTeam[] | null;
+    onUndo: () => void;
+    onRedo: () => void;
+    onPostShift: () => void;
+    onToggleEditMode: () => void;
+    onCreateNextMonth: () => void;
+    onChangeShiftTeam: (shiftTeamId: number) => void;
+};
+
+export function ToolbarActionGroup({
+    year,
+    month,
+    shift,
+    readonly,
+    saveStatus,
+    currentShiftTeam,
+    shiftTeams,
+    onUndo,
+    onRedo,
+    onPostShift,
+    onToggleEditMode,
+    onCreateNextMonth,
+    onChangeShiftTeam,
+}: TToolbarActionGroupProps) {
+    return (
+        <>
+            {!readonly && (
+                <div className="ml-auto flex gap-[.3125rem] font-apple text-[.875rem] text-sub-2.5">
+                    {saveStatus === 'pending' ? <SavingIcon className="h-5 w-5" /> : <SaveCompleteIcon className="h-5 w-5" />}
+                    {saveStatus === 'pending' ? '저장중' : '저장 완료'}
+                    <div className="ml-7.5 flex gap-[.625rem]">
+                        <HistoryBackIcon
+                            className="h-6.5 w-6.5 cursor-pointer"
+                            onClick={() => {
+                                onUndo();
+                                sendEvent(events.makePage.toolbar.undoBytoolbar);
+                            }}
+                        />
+                        <HistoryNextIcon
+                            className="h-6.5 w-6.5 cursor-pointer"
+                            onClick={() => {
+                                onRedo();
+                                sendEvent(events.makePage.toolbar.redoByToolbar);
+                            }}
+                        />
+                    </div>
+                </div>
+            )}
+
+            <div>
+                {currentShiftTeam && (
+                    <Select
+                        value={currentShiftTeam.shiftTeamId}
+                        options={shiftTeams?.map((shiftTeam) => ({
+                            label: shiftTeam.name,
+                            value: shiftTeam.shiftTeamId,
+                        }))}
+                        className="ml-7.5 h-11.5 w-42 font-apple text-[1.25rem] font-semibold text-main-1"
+                        selectClassName="outline-[.0938rem] outline-main-1"
+                        onChange={(e) => onChangeShiftTeam(parseInt(e.target.value))}
+                    />
+                )}
+            </div>
+
+            {readonly ? (
+                <div className="ml-auto flex gap-[10px]">
+                    <Button
+                        variant="default"
+                        className="flex h-10 items-center justify-center rounded-[.625rem] bg-main-2 px-[.75rem] text-[1.25rem] font-semibold"
+                        onClick={() => {
+                            onPostShift();
+                            sendEvent(events.makePage.toolbar.postShift);
+                        }}
+                        disabled={new Date(year, month + 1, 1) <= new Date()}
+                    >
+                        게시하기
+                    </Button>
+                    <Button
+                        id="editButton"
+                        variant="default"
+                        className="flex h-10 items-center justify-center gap-[.5rem] rounded-[.625rem] bg-main-2 pr-[.5rem] pl-[.75rem] text-[1.25rem] font-semibold"
+                        onClick={() => {
+                            onToggleEditMode();
+                            sendEvent(events.makePage.toolbar.changeEditMode);
+                        }}
+                        disabled={new Date(year, month + 1, 1) <= new Date()}
+                    >
+                        수정하기
+                        <PenIcon className="h-6 w-6 stroke-white" />
+                    </Button>
+                    <Button
+                        id="El2"
+                        variant="default"
+                        className="flex h-10 items-center justify-center gap-[.5rem] rounded-[.625rem] bg-main-2 pr-[.5rem] pl-[.75rem] text-[1.25rem] font-semibold"
+                        onClick={() => {
+                            if (shift) {
+                                shiftToExcel(month, shift);
+                            }
+
+                            sendEvent(events.makePage.toolbar.downloadExcel);
+                        }}
+                    >
+                        다운로드
+                        <ShareIcon className="h-6 w-6" />
+                    </Button>
+                    <Button
+                        variant="outline"
+                        className="flex h-10 w-59 items-center justify-center gap-[.5rem] rounded-[.625rem] text-[1.25rem] font-semibold"
+                        onClick={() => {
+                            onCreateNextMonth();
+                            sendEvent(events.makePage.toolbar.editNextMonth);
+                        }}
+                    >
+                        다음달 근무표 만들기
+                        <DutyIconSelected className="h-6 w-6" />
+                    </Button>
+                </div>
+            ) : (
+                <div className="ml-5 flex gap-[.875rem]">
+                    <Button
+                        variant="default"
+                        className="h-10 w-33 rounded-[3.125rem] border-none bg-[rgba(171,171,180,0.80)] text-[1.25rem] font-semibold text-white"
+                        onClick={() => showValidationFeedback('아직 준비 중인 기능입니다.')}
+                    >
+                        자동 채우기
+                    </Button>
+                    <Button
+                        className="h-10 rounded-[3.125rem] border-main-1 bg-white px-5 text-[1.25rem] font-semibold text-main-1 transition-all hover:bg-main-1 hover:text-white"
+                        onClick={onToggleEditMode}
+                    >
+                        저장
+                    </Button>
+                </div>
+            )}
+        </>
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-layer-toggles.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-layer-toggles.tsx
@@ -1,0 +1,58 @@
+import {events, sendEvent} from '@/analytics';
+import {FaultDotIcon, RequestCheckIcon, RequestSlashIcon} from '@/shared/assets/svg';
+import {type TLayerFlags} from '../types';
+
+type TToolbarLayerTogglesProps = {
+    showLayer: TLayerFlags;
+    onToggleLayer: (layer: keyof TLayerFlags) => void;
+};
+
+const layerConfigs = [
+    {
+        key: 'fault',
+        label: '잘못된 근무',
+        borderClassName: 'border-[#FF0000]',
+        backgroundClassName: 'bg-[#ff000033]',
+        Icon: FaultDotIcon,
+    },
+    {
+        key: 'check',
+        label: '신청 근무 반영',
+        borderClassName: 'border-[#06E738]',
+        backgroundClassName: 'bg-[#06e73833]',
+        Icon: RequestCheckIcon,
+    },
+    {
+        key: 'slash',
+        label: '신청 근무 미반영',
+        borderClassName: 'border-[#0027F4]',
+        backgroundClassName: 'bg-[#0027f433]',
+        Icon: RequestSlashIcon,
+    },
+] as const;
+
+export function ToolbarLayerToggles({showLayer, onToggleLayer}: TToolbarLayerTogglesProps) {
+    return (
+        <div className="ml-12.5 flex gap-[.25rem]">
+            {layerConfigs.map(({key, label, borderClassName, backgroundClassName, Icon}) => (
+                <div
+                    key={key}
+                    className={`flex h-9 cursor-pointer items-center gap-[.5rem] rounded-[.3125rem] border-[.0313rem] border-sub-4 px-[.625rem] ${
+                        showLayer[key] ? 'white' : 'bg-sub-5'
+                    }`}
+                    onClick={() => {
+                        onToggleLayer(key);
+                        sendEvent(showLayer[key] ? events.makePage.toolbar.offLayer : events.makePage.toolbar.onLayer, key);
+                    }}
+                >
+                    <div
+                        className={`relative h-[.875rem] w-[.875rem] rounded-[.1875rem] border-[.0806rem] ${borderClassName} ${backgroundClassName}`}
+                    >
+                        <Icon className="absolute -top-2 -right-0.75 h-[.4rem] w-[.4rem]" />
+                    </div>
+                    <p className={`font-apple text-[.75rem] select-none ${showLayer[key] ? 'text-sub-2' : 'text-sub-3'}`}>{label}</p>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-settings-panel.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-settings-panel.tsx
@@ -1,0 +1,59 @@
+import {createPortal} from 'react-dom';
+import Draggable from 'react-draggable';
+import {type TWardConstraint} from '@/entities';
+import {CancelIcon} from '@/shared/assets/svg';
+import SetConstraint from '../editWard/set-constraint';
+import SetDesignTheme from '../editWard/set-design-theme';
+import SetShiftType from '../editWard/set-shift-type';
+import {type TToolbarSetupTab} from '../types';
+
+type TToolbarSettingsPanelProps = {
+    currentSetup: TToolbarSetupTab | null;
+    wardConstraint: TWardConstraint | null;
+    onSelectSetup: (setup: TToolbarSetupTab) => void;
+    onClose: () => void;
+    onUpdateConstraint: (constraint: TWardConstraint) => void;
+};
+
+const setupTabs: {key: TToolbarSetupTab; label: string}[] = [
+    {key: 'constraint', label: '제약 조건'},
+    {key: 'shiftType', label: '근무 유형'},
+    {key: 'designTheme', label: '디자인 테마'},
+];
+
+export function ToolbarSettingsPanel({
+    currentSetup,
+    wardConstraint,
+    onSelectSetup,
+    onClose,
+    onUpdateConstraint,
+}: TToolbarSettingsPanelProps) {
+    if (currentSetup === null) return null;
+
+    return createPortal(
+        <Draggable>
+            <div className="absolute top-22 left-70.5 z-1001 flex flex-col rounded-[1.25rem] bg-white shadow-shadow-3">
+                <div className="flex h-11 cursor-move items-center rounded-t-[1.25rem] bg-sub-5">
+                    {setupTabs.map((tab) => (
+                        <div
+                            key={tab.key}
+                            className={`flex h-full w-37.5 cursor-pointer items-center justify-center rounded-t-[1.25rem] font-apple text-base ${
+                                currentSetup === tab.key ? 'bg-white text-main-1' : 'text-sub-3'
+                            } `}
+                            onClick={() => onSelectSetup(tab.key)}
+                        >
+                            {tab.label}
+                        </div>
+                    ))}
+                    <CancelIcon className="absolute right-[.5rem] h-6 w-6 cursor-pointer" onClick={onClose} />
+                </div>
+                {currentSetup === 'constraint' && wardConstraint && (
+                    <SetConstraint wardConstraint={wardConstraint} onUpdateConstraint={onUpdateConstraint} />
+                )}
+                {currentSetup === 'shiftType' && <SetShiftType />}
+                {currentSetup === 'designTheme' && <SetDesignTheme />}
+            </div>
+        </Draggable>,
+        document.getElementById('edit-modal-root')!,
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-shift-info-panel.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-shift-info-panel.tsx
@@ -1,0 +1,37 @@
+import {createPortal} from 'react-dom';
+import Draggable from 'react-draggable';
+import {type TShift} from '@/entities';
+import ShiftBadge from '@/entities/shift/ui/shift-badge';
+import {CancelIcon} from '@/shared/assets/svg';
+
+type TToolbarShiftInfoPanelProps = {
+    shift: TShift | null;
+    open: boolean;
+    onClose: () => void;
+};
+
+export function ToolbarShiftInfoPanel({shift, open, onClose}: TToolbarShiftInfoPanelProps) {
+    if (!open) return null;
+
+    return createPortal(
+        <Draggable>
+            <div className="absolute top-22 left-70.5 z-1001 flex w-116.5 flex-col rounded-[.625rem] bg-white shadow-shadow-3">
+                <div className="flex h-6.5 cursor-move items-center rounded-t-[.625rem] bg-sub-5 pl-10">
+                    <p className="bottom-0 font-apple text-[.875rem] text-sub-2.5">근무 유형 보기</p>
+                    <CancelIcon className="absolute right-[.5rem] h-4.5 w-4.5 cursor-pointer" onClick={onClose} />
+                </div>
+                <div className="flex flex-wrap items-center justify-start gap-5 py-[.875rem] pl-10">
+                    {shift?.wardShiftTypes.map((shiftType, index) => (
+                        <div key={index} className="flex shrink-0 items-center gap-[.3125rem]">
+                            <ShiftBadge shiftType={shiftType} />
+                            <p className="font-apple text-[.875rem] text-sub-2">
+                                {shiftType.name}({shiftType.shortName})
+                            </p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </Draggable>,
+        document.getElementById('info-modal-root')!,
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/types.ts
+++ b/apps/app/src/features/shift-editor/ui/complex-view/types.ts
@@ -1,0 +1,5 @@
+export type TLayerFlags = {fault: boolean; check: boolean; slash: boolean};
+
+export type TShiftCalendarFocus = {shiftNurseId: number; day: number};
+
+export type TToolbarSetupTab = 'constraint' | 'shiftType' | 'designTheme';


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

[DUT-912](https://gom3.atlassian.net/browse/DUT-912)

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- `toolbar`를 조합 컴포넌트로 정리하고, 설정 패널/근무유형 정보 패널/레이어 토글/우측 액션을 개별 하위 컴포넌트로 분리했습니다.
- `shift-calendar`를 헤더, division 렌더, row 렌더, 셀 배경 helper로 분리해 화면 렌더 책임과 선택/상태 연결 책임의 경계를 더 명확하게 만들었습니다.
- `nurse-edit-modal`의 본체를 portal 및 상태 연결 위주로 줄이고, 폼 렌더와 저장 가능 여부 판정을 별도 모듈로 분리했습니다.

<br>

## To Reviewers

- 기능 동작은 유지하는 리팩터링이 목적이라, 근무표 작성 화면에서 툴바 패널 열기/닫기, 셀 선택, division 접기, 간호사 편집 drawer 동작을 중심으로 확인해주시면 됩니다.
- 이번 변경은 구조 분해가 중심이라 DUT-913, DUT-914에서 export/이미지 저장 관련 작업을 `toolbar` 하위 모듈 범위로 진행할 수 있도록 정리했습니다.


[DUT-912]: https://gom3.atlassian.net/browse/DUT-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ