### PR TITLE
[-]: docs Vercel output directory 설정 추가

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,3 @@
+{
+    "outputDirectory": ".vitepress/dist"
+}


### PR DESCRIPTION
## 변경 내용
-  추가
- Vercel이 docs 빌드 결과물을 에서 찾도록 설정

## 확인
- 
> @dutying/docs@0.1.0 build /Users/inseo/Documents/github/dutying-web-docs-vercel-output/apps/docs
> vitepress build .


  vitepress v1.6.4

build complete in 2.04s. 통과
- 빌드 산출물이 에 생성되는 것 확인