### PR TITLE
[DUT-913]: 근무표 이미지 저장 기능 구현

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -38,6 +38,7 @@
         "class-variance-authority": "^0.7.1",
         "exceljs": "^4.4.0",
         "history": "^5.3.0",
+        "html-to-image": "^1.11.13",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "immer": "^11.0.1",

--- a/apps/app/src/features/shift-editor/model/__tests__/shift-to-image.test.ts
+++ b/apps/app/src/features/shift-editor/model/__tests__/shift-to-image.test.ts
@@ -1,0 +1,69 @@
+import {toBlob} from 'html-to-image';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {buildShiftImageFileName, downloadBlobAsFile, shiftToImage} from '../shift-to-image';
+
+vi.mock('html-to-image', () => ({
+    toBlob: vi.fn(),
+}));
+
+describe('shift-to-image', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('팀 이름과 연월을 기준으로 파일명을 만든다', () => {
+        expect(buildShiftImageFileName({year: 2026, month: 3, teamName: 'ICU/1팀'})).toBe('ICU 1팀 2026년 3월 근무표.png');
+        expect(buildShiftImageFileName({year: 2026, month: 3, teamName: null})).toBe('2026년 3월 근무표.png');
+    });
+
+    it('blob을 object url로 내려받는다', () => {
+        const blob = new Blob(['test'], {type: 'image/png'});
+        const click = vi.fn();
+        const anchor = {click, href: '', download: ''};
+        const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue(anchor as unknown as HTMLAnchorElement);
+        const createObjectURLSpy = vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:url');
+        const revokeObjectURLSpy = vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+
+        downloadBlobAsFile(blob, 'duty.png');
+
+        expect(anchor.href).toBe('blob:url');
+        expect(anchor.download).toBe('duty.png');
+        expect(click).toHaveBeenCalledTimes(1);
+        expect(createObjectURLSpy).toHaveBeenCalledWith(blob);
+        expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:url');
+
+        createElementSpy.mockRestore();
+        createObjectURLSpy.mockRestore();
+        revokeObjectURLSpy.mockRestore();
+    });
+
+    it('캡처 blob을 생성해 다운로드한다', async () => {
+        const blob = new Blob(['image'], {type: 'image/png'});
+        const element = document.createElement('div');
+
+        Object.defineProperty(element, 'scrollWidth', {value: 720});
+        Object.defineProperty(element, 'scrollHeight', {value: 480});
+        Object.defineProperty(element, 'clientWidth', {value: 700});
+        Object.defineProperty(element, 'clientHeight', {value: 460});
+
+        vi.mocked(toBlob).mockResolvedValue(blob);
+
+        const downloadSpy = vi.spyOn(document, 'createElement').mockReturnValue({click: vi.fn(), href: '', download: ''} as unknown as HTMLAnchorElement);
+        const createObjectURLSpy = vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:url');
+        const revokeObjectURLSpy = vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+
+        await expect(shiftToImage({element, year: 2026, month: 3, teamName: '중환자실'})).resolves.toBe('중환자실 2026년 3월 근무표.png');
+        expect(toBlob).toHaveBeenCalledWith(
+            element,
+            expect.objectContaining({
+                width: 720,
+                height: 480,
+                pixelRatio: 2,
+            }),
+        );
+
+        downloadSpy.mockRestore();
+        createObjectURLSpy.mockRestore();
+        revokeObjectURLSpy.mockRestore();
+    });
+});

--- a/apps/app/src/features/shift-editor/model/index.ts
+++ b/apps/app/src/features/shift-editor/model/index.ts
@@ -2,6 +2,8 @@ export * from './types';
 export * from './store';
 export * from './shift-adapter';
 export * from './shift-to-excel';
+export * from './shift-to-image';
 export * from './useShiftEditorCommands';
+export * from './useShiftImageExport';
 export * from './useShiftEditorKeyBindings';
 export {buildViolationMap} from './validator';

--- a/apps/app/src/features/shift-editor/model/shift-to-image.ts
+++ b/apps/app/src/features/shift-editor/model/shift-to-image.ts
@@ -1,0 +1,56 @@
+import {toBlob} from 'html-to-image';
+
+type TBuildShiftImageFileNameOptions = {
+    year: number;
+    month: number;
+    teamName?: string | null;
+};
+
+type TShiftToImageOptions = TBuildShiftImageFileNameOptions & {
+    element: HTMLElement;
+};
+
+function sanitizeFileNameSegment(value: string) {
+    return value
+        .replace(/[\\/:*?"<>|]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+export function buildShiftImageFileName({year, month, teamName}: TBuildShiftImageFileNameOptions) {
+    const safeTeamName = teamName ? sanitizeFileNameSegment(teamName) : '';
+    const baseName = `${year}년 ${month}월 근무표`;
+
+    return safeTeamName ? `${safeTeamName} ${baseName}.png` : `${baseName}.png`;
+}
+
+export function downloadBlobAsFile(blob: Blob, fileName: string) {
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+
+    anchor.href = url;
+    anchor.download = fileName;
+    anchor.click();
+
+    window.URL.revokeObjectURL(url);
+}
+
+export async function shiftToImage({element, year, month, teamName}: TShiftToImageOptions) {
+    const blob = await toBlob(element, {
+        backgroundColor: '#FDFCFE',
+        cacheBust: true,
+        pixelRatio: 2,
+        width: Math.max(element.scrollWidth, element.clientWidth),
+        height: Math.max(element.scrollHeight, element.clientHeight),
+    });
+
+    if (!blob) {
+        throw new Error('SHIFT_IMAGE_EXPORT_FAILED');
+    }
+
+    const fileName = buildShiftImageFileName({year, month, teamName});
+
+    downloadBlobAsFile(blob, fileName);
+
+    return fileName;
+}

--- a/apps/app/src/features/shift-editor/model/useShiftImageExport.ts
+++ b/apps/app/src/features/shift-editor/model/useShiftImageExport.ts
@@ -1,0 +1,49 @@
+import {useCallback, useState, type RefObject} from 'react';
+import toast from 'react-hot-toast';
+import {shiftToImage} from './shift-to-image';
+
+type TUseShiftImageExportOptions = {
+    targetRef: RefObject<HTMLElement | null>;
+    year: number;
+    month: number;
+    teamName?: string | null;
+    disabled?: boolean;
+};
+
+function waitForNextPaint() {
+    return new Promise<void>((resolve) => {
+        window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(() => resolve());
+        });
+    });
+}
+
+export function useShiftImageExport({targetRef, year, month, teamName, disabled = false}: TUseShiftImageExportOptions) {
+    const [isExporting, setIsExporting] = useState(false);
+    const downloadImage = useCallback(async () => {
+        if (disabled || isExporting) return;
+
+        const target = targetRef.current;
+
+        if (!target) {
+            toast.error('저장할 근무표 화면을 찾지 못했어요.');
+
+            return;
+        }
+
+        setIsExporting(true);
+
+        try {
+            await waitForNextPaint();
+            await shiftToImage({element: target, year, month, teamName});
+            toast.success('근무표 이미지를 저장했어요.');
+        } catch (error) {
+            console.error(error);
+            toast.error('근무표 이미지를 저장하지 못했어요. 다시 시도해 주세요.');
+        } finally {
+            setIsExporting(false);
+        }
+    }, [disabled, isExporting, month, targetRef, teamName, year]);
+
+    return {isExporting, downloadImage};
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/make-shift-editor-view.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/make-shift-editor-view.tsx
@@ -1,8 +1,8 @@
-import {type ComponentProps} from 'react';
+import {type ComponentProps, useRef} from 'react';
 import {type TShift} from '@/entities';
-import {type TDutyDoc} from '@/features/shift-editor/model';
-import CountDutyByDay from './count-duty-by-day';
+import {type TDutyDoc, useShiftImageExport} from '@/features/shift-editor/model';
 import NurseEditModal from './nurse-edit-modal';
+import {ShiftEditorCanvas} from './shift-editor-canvas';
 import ShiftCalendar from './shift-calendar';
 import Toolbar from './toolbar';
 
@@ -18,7 +18,7 @@ interface IMakeShiftEditorViewProps {
     stickyBottom?: boolean;
     className?: string;
     calendarProps?: Omit<ComponentProps<typeof ShiftCalendar>, 'shift' | 'doc'>;
-    toolbarProps?: Omit<ComponentProps<typeof Toolbar>, 'shift'>;
+    toolbarProps?: Omit<ComponentProps<typeof Toolbar>, 'shift' | 'onDownloadImage' | 'isDownloadingImage'>;
 }
 
 export const MakeShiftEditorView = ({
@@ -33,23 +33,35 @@ export const MakeShiftEditorView = ({
     calendarProps,
     toolbarProps,
 }: IMakeShiftEditorViewProps) => {
-    const countedShiftTypeCount = shift.wardShiftTypes.filter((x) => x.isCounted).length;
-    const bottomHeight = shift ? `${countedShiftTypeCount * 2.5 + 2.5}rem` : '0';
+    const exportRef = useRef<HTMLDivElement>(null);
+    const {isExporting, downloadImage} = useShiftImageExport({
+        targetRef: exportRef,
+        year: toolbarProps?.year ?? new Date().getFullYear(),
+        month: toolbarProps?.month ?? 1,
+        teamName: toolbarProps?.currentShiftTeam?.name ?? null,
+        disabled: !shift,
+    });
 
     return (
         <div className={`mx-auto flex w-fit flex-col ${className ?? ''}`}>
-            {showToolbar && toolbarProps && <Toolbar shift={shift} {...toolbarProps} />}
-            {showCalendar && <ShiftCalendar shift={shift} doc={doc} {...calendarProps} />}
-            {showCountByDay && (
-                <div
-                    className={`${stickyBottom ? 'sticky bottom-0' : ''} z-20 flex items-stretch gap-5 py-5 pl-55.25`}
-                    style={{
-                        height: bottomHeight,
-                    }}
-                >
-                    {showCountByDay && <CountDutyByDay shift={shift} doc={doc} />}
-                    {/* {showPanel && <Panel shift={shift} readonly={readonly} />} @deprecated 근무표 작성 기능 개편 중으로 인해 deprecated 예정 */}
-                </div>
+            {showToolbar && toolbarProps && (
+                <Toolbar
+                    shift={shift}
+                    isDownloadingImage={isExporting}
+                    onDownloadImage={() => void downloadImage()}
+                    {...toolbarProps}
+                />
+            )}
+            {showCalendar && (
+                <ShiftEditorCanvas
+                    shift={shift}
+                    doc={doc}
+                    showCountByDay={showCountByDay}
+                    stickyBottom={stickyBottom}
+                    exportMode={isExporting}
+                    exportRef={exportRef}
+                    calendarProps={calendarProps}
+                />
             )}
             {showNurseEditModal && <NurseEditModal />}
         </div>

--- a/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/shift-calendar.tsx
@@ -1,4 +1,5 @@
 import {DragDropContext, type DropResult} from '@hello-pangea/dnd';
+import {cn} from '@dutying/utils/style';
 import {type ComponentProps, useEffect, useMemo, useRef} from 'react';
 import useOnclickOutside from 'react-cool-onclickoutside';
 import {type TWardShiftType, type TShift} from '@/entities';
@@ -30,6 +31,7 @@ interface IShiftCalendarProps {
     enableDivisionManagement?: boolean;
     onEditDivision?: (opts: {shiftNurseId: number; level: number; direction: 1 | -1}) => void;
     clearSelectionOnClickAway?: boolean;
+    exportMode?: boolean;
 }
 
 function ShiftCalendar({
@@ -50,6 +52,7 @@ function ShiftCalendar({
     enableDivisionManagement = false,
     onEditDivision,
     clearSelectionOnClickAway = true,
+    exportMode = false,
 }: IShiftCalendarProps) {
     const {separateWeekendColor, shiftTypeColorStyle} = useUIConfigStore();
     const commands = useShiftEditorCommands();
@@ -162,7 +165,7 @@ function ShiftCalendar({
     };
 
     return (
-        <div id="calendar" ref={clickAwayRef} className="flex w-full flex-col overflow-hidden">
+        <div id="calendar" ref={clickAwayRef} className={cn('flex w-full flex-col', exportMode ? 'overflow-visible' : 'overflow-hidden')}>
             <ShiftCalendarHeader
                 shift={shift}
                 effectiveFocusDay={effectiveFocus?.day}
@@ -171,7 +174,10 @@ function ShiftCalendar({
             />
             <DragDropContext onDragEnd={handleDragEnd}>
                 <div
-                    className="-mt-5 scrollbar-hide flex flex-col gap-[.3125rem] overflow-x-hidden overflow-y-scroll pt-5 pr-4 pb-8"
+                    className={cn(
+                        '-mt-5 scrollbar-hide flex flex-col gap-[.3125rem] pt-5 pr-4 pb-8',
+                        exportMode ? 'overflow-visible' : 'overflow-x-hidden overflow-y-scroll',
+                    )}
                     ref={containerRef}
                 >
                     {divisions.map((division, level) => (

--- a/apps/app/src/features/shift-editor/ui/complex-view/shift-editor-canvas.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/shift-editor-canvas.tsx
@@ -1,0 +1,47 @@
+import {cn} from '@dutying/utils/style';
+import {type ComponentProps, type RefObject} from 'react';
+import {type TShift} from '@/entities';
+import {type TDutyDoc} from '@/features/shift-editor/model';
+import CountDutyByDay from './count-duty-by-day';
+import ShiftCalendar from './shift-calendar';
+
+type TShiftEditorCanvasProps = {
+    shift: TShift;
+    doc: TDutyDoc;
+    className?: string;
+    showCountByDay?: boolean;
+    stickyBottom?: boolean;
+    exportMode?: boolean;
+    exportRef?: RefObject<HTMLDivElement | null>;
+    calendarProps?: Omit<ComponentProps<typeof ShiftCalendar>, 'shift' | 'doc' | 'exportMode'>;
+};
+
+export function ShiftEditorCanvas({
+    shift,
+    doc,
+    className,
+    showCountByDay = true,
+    stickyBottom = true,
+    exportMode = false,
+    exportRef,
+    calendarProps,
+}: TShiftEditorCanvasProps) {
+    const countedShiftTypeCount = shift.wardShiftTypes.filter((x) => x.isCounted).length;
+    const bottomHeight = `${countedShiftTypeCount * 2.5 + 2.5}rem`;
+
+    return (
+        <div ref={exportRef} className={cn('mx-auto flex w-fit flex-col', className)}>
+            <ShiftCalendar shift={shift} doc={doc} exportMode={exportMode} {...calendarProps} />
+            {showCountByDay && (
+                <div
+                    className={cn('z-20 flex items-stretch gap-5 py-5 pl-55.25', stickyBottom && !exportMode && 'sticky bottom-0')}
+                    style={{
+                        height: bottomHeight,
+                    }}
+                >
+                    <CountDutyByDay shift={shift} doc={doc} />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar.tsx
@@ -25,9 +25,11 @@ interface IToolbarProps {
     onRedo: () => void;
     onPostShift: () => void;
     onToggleEditMode: () => void;
+    onDownloadImage: () => void;
     onCreateNextMonth: () => void;
     onChangeShiftTeam: (shiftTeamId: number) => void;
     onUpdateConstraint: (constraint: TWardConstraint) => void;
+    isDownloadingImage: boolean;
 }
 
 function Toolbar({
@@ -46,9 +48,11 @@ function Toolbar({
     onRedo,
     onPostShift,
     onToggleEditMode,
+    onDownloadImage,
     onCreateNextMonth,
     onChangeShiftTeam,
     onUpdateConstraint,
+    isDownloadingImage,
 }: IToolbarProps) {
     const [openInfo, setOpenInfo] = useState(false);
     const [currentSetup, setCurrentSetup] = useState<TToolbarSetupTab | null>(null);
@@ -128,8 +132,10 @@ function Toolbar({
                 onRedo={onRedo}
                 onPostShift={onPostShift}
                 onToggleEditMode={onToggleEditMode}
+                onDownloadImage={onDownloadImage}
                 onCreateNextMonth={onCreateNextMonth}
                 onChangeShiftTeam={onChangeShiftTeam}
+                isDownloadingImage={isDownloadingImage}
             />
         </div>
     );

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-action-group.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-action-group.tsx
@@ -1,7 +1,7 @@
 import {events, sendEvent} from '@/analytics';
 import {type TShift, type TShiftTeam} from '@/entities';
 import {shiftToExcel} from '@/features/shift-editor/model/shift-to-excel';
-import {DutyIconSelected, HistoryBackIcon, HistoryNextIcon, PenIcon, SaveCompleteIcon, SavingIcon, ShareIcon} from '@/shared/assets/svg';
+import {CameraIcon, DutyIconSelected, HistoryBackIcon, HistoryNextIcon, PenIcon, SaveCompleteIcon, SavingIcon, ShareIcon} from '@/shared/assets/svg';
 import Button from '@/shared/ui/form-controls/Button';
 import Select from '@/shared/ui/form-controls/Select';
 import {showValidationFeedback} from '@/shared/util/feedback';
@@ -18,8 +18,10 @@ type TToolbarActionGroupProps = {
     onRedo: () => void;
     onPostShift: () => void;
     onToggleEditMode: () => void;
+    onDownloadImage: () => void;
     onCreateNextMonth: () => void;
     onChangeShiftTeam: (shiftTeamId: number) => void;
+    isDownloadingImage: boolean;
 };
 
 export function ToolbarActionGroup({
@@ -34,8 +36,10 @@ export function ToolbarActionGroup({
     onRedo,
     onPostShift,
     onToggleEditMode,
+    onDownloadImage,
     onCreateNextMonth,
     onChangeShiftTeam,
+    isDownloadingImage,
 }: TToolbarActionGroupProps) {
     return (
         <>
@@ -107,6 +111,19 @@ export function ToolbarActionGroup({
                         id="El2"
                         variant="default"
                         className="flex h-10 items-center justify-center gap-[.5rem] rounded-[.625rem] bg-main-2 pr-[.5rem] pl-[.75rem] text-[1.25rem] font-semibold"
+                        disabled={isDownloadingImage}
+                        onClick={() => {
+                            onDownloadImage();
+                            sendEvent(events.makePage.toolbar.downloadImage);
+                        }}
+                    >
+                        {isDownloadingImage ? '이미지 저장 중' : '이미지 저장'}
+                        <CameraIcon className="h-6 w-6 stroke-white" />
+                    </Button>
+                    <Button
+                        id="El3"
+                        variant="default"
+                        className="flex h-10 items-center justify-center gap-[.5rem] rounded-[.625rem] bg-main-2 pr-[.5rem] pl-[.75rem] text-[1.25rem] font-semibold"
                         onClick={() => {
                             if (shift) {
                                 shiftToExcel(month, shift);
@@ -115,7 +132,7 @@ export function ToolbarActionGroup({
                             sendEvent(events.makePage.toolbar.downloadExcel);
                         }}
                     >
-                        다운로드
+                        엑셀 저장
                         <ShareIcon className="h-6 w-6" />
                     </Button>
                     <Button

--- a/apps/app/src/pages/make-shift/view/steps/ai-auto-fill.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/ai-auto-fill.tsx
@@ -2,9 +2,9 @@ import {cn} from '@dutying/utils/style';
 import {useCallback, useRef, useState} from 'react';
 import toast from 'react-hot-toast';
 import useAuth from '@/features/auth/useAuth';
-import {docToWardShiftsDTO, useShiftEditorCommands, useShiftEditorStore} from '@/features/shift-editor';
+import {docToWardShiftsDTO, useShiftEditorCommands, useShiftEditorStore, useShiftImageExport} from '@/features/shift-editor';
 import WardAPI from '@/shared/api/ward';
-import {HistoryBackIcon, HistoryNextIcon, InfoIcon, PlusIcon, SaveCompleteIcon, SavingIcon} from '@/shared/assets/svg';
+import {CameraIcon, HistoryBackIcon, HistoryNextIcon, InfoIcon, PlusIcon, SaveCompleteIcon, SavingIcon} from '@/shared/assets/svg';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import {renderMultilineText} from '@/shared/util/string';
 import {
@@ -28,6 +28,7 @@ export function AiAutofill() {
     const year = useMakeShiftStore((s) => s.year);
     const month = useMakeShiftStore((s) => s.month);
     const currentShiftTeamId = useMakeShiftStore((s) => s.currentShiftTeamId);
+    const currentShiftTeamName = useMakeShiftStore((s) => s.shiftTeams.find((team) => team.shiftTeamId === s.currentShiftTeamId)?.name ?? null);
     const commands = useShiftEditorCommands();
     const editorDoc = useShiftEditorStore((s) => s.doc);
     const history = useShiftEditorStore((s) => s.history);
@@ -54,8 +55,16 @@ export function AiAutofill() {
     } = useDutyEditorStep({
         onContextChanged: resetAiStatus,
     });
+    const exportRef = useRef<HTMLDivElement>(null);
     const aiRequestSeqRef = useRef(0);
     const currentAiContextRef = useRef({wardId, shiftTeamId: currentShiftTeamId, year, month});
+    const {isExporting, downloadImage} = useShiftImageExport({
+        targetRef: exportRef,
+        year,
+        month,
+        teamName: currentShiftTeamName,
+        disabled: !dutyQuery.data || dutyQuery.isLoading || dutyQuery.isError,
+    });
 
     currentAiContextRef.current = {wardId, shiftTeamId: currentShiftTeamId, year, month};
 
@@ -187,6 +196,15 @@ export function AiAutofill() {
                         </button>
                     </div>
                     <button
+                        className="flex h-[42px] items-center gap-2 rounded-[10px] border border-sub-4.5 bg-white px-4 font-apple text-base font-semibold text-sub-1 disabled:opacity-50"
+                        disabled={!dutyQuery.data || dutyQuery.isLoading || dutyQuery.isError || isExporting}
+                        onClick={() => void downloadImage()}
+                        type="button"
+                    >
+                        <CameraIcon className="h-5 w-5 stroke-sub-1" />
+                        {isExporting ? '이미지 저장 중' : '이미지 저장'}
+                    </button>
+                    <button
                         className="flex h-[42px] items-center rounded-[10px] bg-gray-6 px-5 font-apple text-base font-semibold text-gray-3 disabled:opacity-50"
                         disabled={!canPrev || isAiGenerating || isWorking}
                         onClick={() => useCase.prev()}
@@ -263,6 +281,8 @@ export function AiAutofill() {
                 onPaste={onPaste}
                 onFocusEditor={focusEditor}
                 showFaults={showFaults}
+                exportRef={exportRef}
+                exportMode={isExporting}
             />
         </div>
     );

--- a/apps/app/src/pages/make-shift/view/steps/fixed-shifts.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/fixed-shifts.tsx
@@ -17,13 +17,14 @@ export function FixedShifts() {
     const canNext = useMakeShiftStore((s) => canGoNext(s));
     const currentShiftTeamName = useMakeShiftStore((s) => s.shiftTeams.find((team) => team.shiftTeamId === s.currentShiftTeamId)?.name ?? null);
     const {dutyQuery, editorDoc, violationMap, editorRef, onKeyDown, onPaste, focusEditor} = useDutyEditorStep();
+    const canExportImage = Boolean(dutyQuery.data) && !dutyQuery.isLoading && !dutyQuery.isError;
     const exportRef = useRef<HTMLDivElement>(null);
     const {isExporting, downloadImage} = useShiftImageExport({
         targetRef: exportRef,
         year,
         month,
         teamName: currentShiftTeamName,
-        disabled: !dutyQuery.data,
+        disabled: !canExportImage,
     });
 
     return (
@@ -34,7 +35,7 @@ export function FixedShifts() {
                 </div>
 
                 <div className="flex items-center gap-3">
-                    <ManagementActionButton variant="outline" size="sm" onClick={() => void downloadImage()} disabled={!dutyQuery.data || isExporting}>
+                    <ManagementActionButton variant="outline" size="sm" onClick={() => void downloadImage()} disabled={!canExportImage || isExporting}>
                         <span className="flex items-center gap-2">
                             <CameraIcon className="h-5 w-5 stroke-main-1" />
                             {isExporting ? '이미지 저장 중' : '이미지 저장'}

--- a/apps/app/src/pages/make-shift/view/steps/fixed-shifts.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/fixed-shifts.tsx
@@ -1,4 +1,7 @@
+import {useRef} from 'react';
+import {CameraIcon} from '@/shared/assets/svg';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import {useShiftImageExport} from '@/features/shift-editor';
 import {ManagementActionButton} from '@/widgets/duty-management/ui';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
@@ -8,9 +11,20 @@ import {useDutyEditorStep} from './shared/use-duty-editor-step';
 export function FixedShifts() {
     const {t} = useTypedTranslation();
     const useCase = useMakeShiftUseCase();
+    const year = useMakeShiftStore((s) => s.year);
+    const month = useMakeShiftStore((s) => s.month);
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
     const canNext = useMakeShiftStore((s) => canGoNext(s));
+    const currentShiftTeamName = useMakeShiftStore((s) => s.shiftTeams.find((team) => team.shiftTeamId === s.currentShiftTeamId)?.name ?? null);
     const {dutyQuery, editorDoc, violationMap, editorRef, onKeyDown, onPaste, focusEditor} = useDutyEditorStep();
+    const exportRef = useRef<HTMLDivElement>(null);
+    const {isExporting, downloadImage} = useShiftImageExport({
+        targetRef: exportRef,
+        year,
+        month,
+        teamName: currentShiftTeamName,
+        disabled: !dutyQuery.data,
+    });
 
     return (
         <div className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-scroll">
@@ -20,6 +34,12 @@ export function FixedShifts() {
                 </div>
 
                 <div className="flex items-center gap-3">
+                    <ManagementActionButton variant="outline" size="sm" onClick={() => void downloadImage()} disabled={!dutyQuery.data || isExporting}>
+                        <span className="flex items-center gap-2">
+                            <CameraIcon className="h-5 w-5 stroke-main-1" />
+                            {isExporting ? '이미지 저장 중' : '이미지 저장'}
+                        </span>
+                    </ManagementActionButton>
                     <ManagementActionButton variant="neutral" size="sm" onClick={() => useCase.prev()} disabled={!canPrev}>
                         이전
                     </ManagementActionButton>
@@ -42,6 +62,8 @@ export function FixedShifts() {
                 onPaste={onPaste}
                 onFocusEditor={focusEditor}
                 showFaults
+                exportRef={exportRef}
+                exportMode={isExporting}
             />
         </div>
     );

--- a/apps/app/src/pages/make-shift/view/steps/shared/duty-editor-step-canvas.tsx
+++ b/apps/app/src/pages/make-shift/view/steps/shared/duty-editor-step-canvas.tsx
@@ -1,6 +1,7 @@
 import {type ClipboardEventHandler, type ComponentProps, type KeyboardEventHandler, type RefObject} from 'react';
 import {type TShift} from '@/entities';
-import CountDutyByDay from '@/features/shift-editor/ui/complex-view/count-duty-by-day';
+import {type TDutyDoc} from '@/features/shift-editor';
+import {ShiftEditorCanvas} from '@/features/shift-editor/ui/complex-view/shift-editor-canvas';
 import ShiftCalendar from '@/features/shift-editor/ui/complex-view/shift-calendar';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import PageState from '@/shared/ui/PageState';
@@ -14,13 +15,15 @@ type TDutyEditorStepCanvasProps = {
     onRetry: () => void;
     loadingTitle: string;
     errorTitle: string;
-    editorDoc: ComponentProps<typeof ShiftCalendar>['doc'];
+    editorDoc: TDutyDoc;
     violationMap: TShiftCalendarViolations;
     editorRef: RefObject<HTMLDivElement | null>;
     onKeyDown: KeyboardEventHandler<HTMLDivElement>;
     onPaste: ClipboardEventHandler<HTMLDivElement>;
     onFocusEditor: () => void;
     showFaults: boolean;
+    exportRef?: RefObject<HTMLDivElement | null>;
+    exportMode?: boolean;
 };
 
 export function DutyEditorStepCanvas({
@@ -37,6 +40,8 @@ export function DutyEditorStepCanvas({
     onPaste,
     onFocusEditor,
     showFaults,
+    exportRef,
+    exportMode = false,
 }: TDutyEditorStepCanvasProps) {
     const {t} = useTypedTranslation();
 
@@ -53,24 +58,19 @@ export function DutyEditorStepCanvas({
             )}
             {!isLoading && !isError && duty && (
                 <div className="flex min-h-0 flex-1" onClick={onFocusEditor}>
-                    <div className="mx-auto flex w-fit min-w-418.5 flex-col">
-                        <ShiftCalendar
-                            shift={duty}
-                            doc={editorDoc}
-                            onCellClick={onFocusEditor}
-                            disableInitialSelection
-                            violations={violationMap}
-                            showLayer={{fault: showFaults, check: false, slash: false}}
-                        />
-                        <div
-                            className="sticky bottom-0 z-20 flex items-stretch gap-5 py-5 pl-55.25"
-                            style={{
-                                height: `${duty.wardShiftTypes.filter((shiftType) => shiftType.isCounted).length * 2.5 + 2.5}rem`,
-                            }}
-                        >
-                            <CountDutyByDay shift={duty} doc={editorDoc} />
-                        </div>
-                    </div>
+                    <ShiftEditorCanvas
+                        shift={duty}
+                        doc={editorDoc}
+                        className="min-w-418.5"
+                        exportRef={exportRef}
+                        exportMode={exportMode}
+                        calendarProps={{
+                            onCellClick: onFocusEditor,
+                            disableInitialSelection: true,
+                            violations: violationMap,
+                            showLayer: {fault: showFaults, check: false, slash: false},
+                        }}
+                    />
                 </div>
             )}
         </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       history:
         specifier: ^5.3.0
         version: 5.3.0
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       i18next:
         specifier: ^25.7.3
         version: 25.7.3(typescript@5.9.3)
@@ -4762,6 +4765,9 @@ packages:
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -12879,6 +12885,8 @@ snapshots:
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  html-to-image@1.11.13: {}
 
   html-void-elements@3.0.0: {}
 


### PR DESCRIPTION
## Motivation

complex-view toolbar에 남아 있던 이미지 저장 TODO를 실제 사용자 기능으로 연결했습니다.
근무표 작성 단계와 reusable editor canvas 모두에서 같은 방식으로 근무표 화면을 PNG로 저장할 수 있도록 export 흐름을 정리했습니다.

- 티켓: [DUT-913](https://gom3.atlassian.net/browse/DUT-913)
- 배경: 근무표 편집기 구조 정리 이후 저장 대상 DOM과 toolbar 책임이 명확해졌고, 사용자 가치가 큰 이미지 저장 기능이 비어 있었습니다.
- 목표: 근무표 화면을 자연스럽게 이미지로 저장하고, 로딩/실패 피드백까지 포함한 실제 동작 흐름을 완성합니다.

<br>

## Key Changes

- `html-to-image` 기반 export 유틸과 `useShiftImageExport` 훅을 추가해 PNG 저장, 파일명 생성, 성공/실패 토스트를 공통 처리하도록 했습니다.
- 캡처 중에는 calendar/count 영역의 sticky/scroll 레이아웃을 export-friendly 상태로 바꾸는 `ShiftEditorCanvas`를 도입해 잘린 화면 없이 저장되도록 정리했습니다.
- complex-view toolbar readonly 액션에 이미지 저장 버튼을 추가했고, 실제 근무표 작성 단계인 `fixed-shifts` / `ai-auto-fill` 화면에서도 같은 기능을 바로 사용할 수 있게 연결했습니다.
- 저장 기능 회귀를 막기 위해 파일명/다운로드/캡처 옵션을 검증하는 unit test를 추가했습니다.

<br>

## To Reviewers

- 특히 봐야 할 파일: `apps/app/src/features/shift-editor/model/shift-to-image.ts`, `apps/app/src/features/shift-editor/model/useShiftImageExport.ts`, `apps/app/src/features/shift-editor/ui/complex-view/shift-editor-canvas.tsx`, `apps/app/src/pages/make-shift/view/steps/ai-auto-fill.tsx`
- 중점적으로 봐야 할 로직: export 시 `exportMode`로 sticky/overflow를 잠깐 해제한 뒤 `html-to-image`로 캡처하는 흐름과, toolbar/step 화면에서 공통 훅을 재사용하는 방식
- 우려되는 지점 / 확인이 필요한 부분: unit test는 통과했고 실제 브라우저 저장 UX는 구현했지만, 레포 전역 type-check와 eslint는 기존 워크스페이스/타입 이슈(`implicit any`, `@eslint/js` 해석 문제 등) 때문에 이번 브랜치에서도 전체 통과하지 못했습니다.
- 실행한 검증: `pnpm --dir apps/app test:run src/features/shift-editor/model/__tests__/shift-to-image.test.ts`


[DUT-913]: https://gom3.atlassian.net/browse/DUT-913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ