### PR TITLE
[DUT-914]: excel export UX 정리

### DIFF
--- a/apps/app/src/features/shift-editor/model/__tests__/shift-to-excel.test.ts
+++ b/apps/app/src/features/shift-editor/model/__tests__/shift-to-excel.test.ts
@@ -1,0 +1,166 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {type TShift} from '@/entities/shift';
+import {buildShiftExcelFileName, shiftToExcel} from '../shift-to-excel';
+
+const shift = {
+    lastDays: [],
+    days: [
+        {day: 1, dayType: 'workday'},
+        {day: 2, dayType: 'saturday'},
+        {day: 3, dayType: 'holiday'},
+    ],
+    wardShiftTypes: [
+        {
+            wardShiftTypeId: 1,
+            name: 'Day',
+            shortName: 'D',
+            startTime: '07:00',
+            endTime: '15:00',
+            color: '#fff',
+            isDefault: true,
+            isOff: false,
+            isCounted: true,
+            classification: 'DAY',
+        },
+        {
+            wardShiftTypeId: 2,
+            name: 'Night',
+            shortName: 'N',
+            startTime: '22:00',
+            endTime: '07:00',
+            color: '#000',
+            isDefault: false,
+            isOff: false,
+            isCounted: true,
+            classification: 'NIGHT',
+        },
+        {
+            wardShiftTypeId: 3,
+            name: '오프',
+            shortName: 'O',
+            startTime: '00:00',
+            endTime: '00:00',
+            color: '#ccc',
+            isDefault: false,
+            isOff: true,
+            isCounted: false,
+            classification: 'OFF',
+        },
+    ],
+    divisionShiftNurses: [
+        [
+            {
+                shiftNurse: {
+                    shiftNurseId: 1,
+                    name: 'Kim',
+                    carried: 0,
+                    divisionNum: 0,
+                    priority: 0,
+                    isWorker: true,
+                    nurseId: 100,
+                },
+                lastWardShiftList: [1, 2],
+                lastWardReqShiftList: [],
+                wardShiftList: [1, 3, 2],
+                wardReqShiftList: [],
+            },
+            {
+                shiftNurse: {
+                    shiftNurseId: 2,
+                    name: 'Lee',
+                    carried: 0,
+                    divisionNum: 0,
+                    priority: 1,
+                    isWorker: true,
+                    nurseId: 101,
+                },
+                lastWardShiftList: [3],
+                lastWardReqShiftList: [],
+                wardShiftList: [null, 3, 1],
+                wardReqShiftList: [],
+            },
+        ],
+    ],
+} satisfies TShift;
+
+describe('shift-to-excel', () => {
+    const click = vi.fn();
+    const createObjectURL = vi.fn(() => 'blob:url');
+    const revokeObjectURL = vi.fn();
+    const anchor = {click, href: '', download: ''} as unknown as HTMLAnchorElement;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        anchor.href = '';
+        anchor.download = '';
+
+        vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+        Object.defineProperty(window.URL, 'createObjectURL', {
+            value: createObjectURL,
+            configurable: true,
+        });
+        Object.defineProperty(window.URL, 'revokeObjectURL', {
+            value: revokeObjectURL,
+            configurable: true,
+        });
+    });
+
+    it('월 기준 파일명을 만든다', () => {
+        expect(buildShiftExcelFileName(3)).toBe('3월 근무표.xlsx');
+    });
+
+    it('근무표 workbook을 만들고 같은 이름으로 다운로드한다', async () => {
+        const workbook = await shiftToExcel(3, shift);
+        const worksheet = workbook.getWorksheet('3월 근무표');
+
+        expect(worksheet).toBeDefined();
+        expect(worksheet?.getRow(1).getCell(1).value).toBe('3월 근무표');
+
+        expect(worksheet?.getRow(2).getCell(1).value).toBe('이름');
+        expect(worksheet?.getRow(2).getCell(2).value).toBe('전달 근무');
+        expect(worksheet?.getRow(2).getCell(3).value).toBe(1);
+        expect(worksheet?.getRow(2).getCell(4).value).toBe(2);
+        expect(worksheet?.getRow(2).getCell(5).value).toBe(3);
+        expect(worksheet?.getRow(2).getCell(3).font?.color?.argb).toBe('FF000000');
+        expect(worksheet?.getRow(2).getCell(4).font?.color?.argb).toBe('FF2029FA');
+        expect(worksheet?.getRow(2).getCell(5).font?.color?.argb).toBe('FFFA2D12');
+
+        expect(worksheet?.getRow(3).getCell(1).value).toBe('Kim');
+        expect(worksheet?.getRow(3).getCell(2).value).toBe('DN');
+        expect(worksheet?.getRow(3).getCell(3).value).toBe('D');
+        expect(worksheet?.getRow(3).getCell(4).value).toBe('O');
+        expect(worksheet?.getRow(3).getCell(5).value).toBe('N');
+        expect(worksheet?.getRow(3).getCell(6).value).toBe(1);
+        expect(worksheet?.getRow(3).getCell(7).value).toBe(1);
+        expect(worksheet?.getRow(3).getCell(8).value).toBe(1);
+        expect(worksheet?.getRow(3).getCell(9).value).toBe(1);
+
+        expect(worksheet?.getRow(4).getCell(1).value).toBe('Lee');
+        expect(worksheet?.getRow(4).getCell(2).value).toBe('O');
+        expect(worksheet?.getRow(4).getCell(3).value).toBe('');
+        expect(worksheet?.getRow(4).getCell(4).value).toBe('O');
+        expect(worksheet?.getRow(4).getCell(5).value).toBe('D');
+        expect(worksheet?.getRow(4).getCell(6).value).toBe(1);
+        expect(worksheet?.getRow(4).getCell(7).value).toBe(0);
+        expect(worksheet?.getRow(4).getCell(8).value).toBe(1);
+        expect(worksheet?.getRow(4).getCell(9).value).toBe(1);
+
+        expect(worksheet?.getRow(5).getCell(2).value).toBe('Day');
+        expect(worksheet?.getRow(5).getCell(3).value).toBe(1);
+        expect(worksheet?.getRow(5).getCell(4).value).toBe(0);
+        expect(worksheet?.getRow(5).getCell(5).value).toBe(1);
+        expect(worksheet?.getRow(6).getCell(2).value).toBe('Night');
+        expect(worksheet?.getRow(6).getCell(3).value).toBe(0);
+        expect(worksheet?.getRow(6).getCell(4).value).toBe(0);
+        expect(worksheet?.getRow(6).getCell(5).value).toBe(1);
+        expect(worksheet?.getRow(7).getCell(2).value).toBe('오프');
+        expect(worksheet?.getRow(7).getCell(3).value).toBe(0);
+        expect(worksheet?.getRow(7).getCell(4).value).toBe(2);
+        expect(worksheet?.getRow(7).getCell(5).value).toBe(0);
+
+        expect(createObjectURL).toHaveBeenCalledTimes(1);
+        expect(click).toHaveBeenCalledTimes(1);
+        expect(anchor.download).toBe('3월 근무표.xlsx');
+        expect(revokeObjectURL).toHaveBeenCalledWith('blob:url');
+    });
+});

--- a/apps/app/src/features/shift-editor/model/__tests__/useShiftExcelExport.test.tsx
+++ b/apps/app/src/features/shift-editor/model/__tests__/useShiftExcelExport.test.tsx
@@ -1,0 +1,123 @@
+import {act} from 'react';
+import toast from 'react-hot-toast';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {type TShift} from '@/entities/shift';
+import {renderHook, waitFor} from '@/shared/util/test-utils';
+import {useShiftExcelExport} from '../useShiftExcelExport';
+
+const mockShiftToExcel = vi.fn();
+
+vi.mock('../shift-to-excel', () => ({
+    shiftToExcel: (...args: unknown[]) => mockShiftToExcel(...args),
+}));
+
+vi.mock('react-hot-toast', () => ({
+    default: {
+        success: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const shift = {
+    lastDays: [],
+    days: [{day: 1, dayType: 'workday'}],
+    wardShiftTypes: [
+        {
+            wardShiftTypeId: 1,
+            name: 'Day',
+            shortName: 'D',
+            startTime: '07:00',
+            endTime: '15:00',
+            color: '#fff',
+            isDefault: true,
+            isOff: false,
+            isCounted: true,
+            classification: 'DAY',
+        },
+    ],
+    divisionShiftNurses: [
+        [
+            {
+                shiftNurse: {
+                    shiftNurseId: 1,
+                    name: 'Kim',
+                    carried: 0,
+                    divisionNum: 0,
+                    priority: 0,
+                    isWorker: true,
+                    nurseId: 100,
+                },
+                lastWardShiftList: [],
+                lastWardReqShiftList: [],
+                wardShiftList: [1],
+                wardReqShiftList: [],
+            },
+        ],
+    ],
+} satisfies TShift;
+
+describe('useShiftExcelExport', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('엑셀 저장 성공 시 진행 상태와 성공 토스트를 노출한다', async () => {
+        let resolveExport: (() => void) | null = null;
+
+        const exportPromise = new Promise<void>((resolve) => {
+            resolveExport = resolve;
+        });
+
+        mockShiftToExcel.mockReturnValue(exportPromise);
+
+        const {result} = renderHook(() => useShiftExcelExport({month: 3, shift}));
+
+        let pendingExport!: Promise<void>;
+
+        act(() => {
+            pendingExport = result.current.exportExcel();
+        });
+
+        await waitFor(() => {
+            expect(result.current.isExporting).toBe(true);
+        });
+
+        await act(async () => {
+            resolveExport?.();
+            await pendingExport;
+        });
+
+        expect(mockShiftToExcel).toHaveBeenCalledWith(3, shift);
+        expect(result.current.isExporting).toBe(false);
+        expect(toast.success).toHaveBeenCalledWith('근무표 엑셀 파일을 저장했어요.');
+        expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it('엑셀 저장 실패 시 에러 토스트를 노출한다', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        mockShiftToExcel.mockRejectedValue(new Error('write failed'));
+
+        const {result} = renderHook(() => useShiftExcelExport({month: 3, shift}));
+
+        await act(async () => {
+            await result.current.exportExcel();
+        });
+
+        expect(result.current.isExporting).toBe(false);
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(toast.error).toHaveBeenCalledWith('근무표 엑셀 파일을 저장하지 못했어요. 다시 시도해 주세요.');
+    });
+
+    it('disabled 상태에서는 엑셀 저장을 건너뛴다', async () => {
+        const {result} = renderHook(() => useShiftExcelExport({month: 3, shift, disabled: true}));
+
+        await act(async () => {
+            await result.current.exportExcel();
+        });
+
+        expect(mockShiftToExcel).not.toHaveBeenCalled();
+        expect(toast.success).not.toHaveBeenCalled();
+        expect(toast.error).not.toHaveBeenCalled();
+    });
+});

--- a/apps/app/src/features/shift-editor/model/index.ts
+++ b/apps/app/src/features/shift-editor/model/index.ts
@@ -4,6 +4,7 @@ export * from './shift-adapter';
 export * from './shift-to-excel';
 export * from './shift-to-image';
 export * from './useShiftEditorCommands';
+export * from './useShiftExcelExport';
 export * from './useShiftImageExport';
 export * from './useShiftEditorKeyBindings';
 export {buildViolationMap} from './validator';

--- a/apps/app/src/features/shift-editor/model/shift-to-excel.ts
+++ b/apps/app/src/features/shift-editor/model/shift-to-excel.ts
@@ -2,6 +2,25 @@
 
 import {type TShift} from '@/entities/shift';
 
+const SHIFT_EXCEL_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+export function buildShiftExcelFileName(month: number) {
+    return `${month}월 근무표.xlsx`;
+}
+
+export function downloadExcelBuffer(data: BlobPart, fileName: string) {
+    const blob = new Blob([data], {
+        type: SHIFT_EXCEL_MIME_TYPE,
+    });
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+
+    anchor.href = url;
+    anchor.download = fileName;
+    anchor.click();
+    window.URL.revokeObjectURL(url);
+}
+
 export const shiftToExcel = async (month: number, shift: TShift) => {
     const Excel = await import('exceljs');
     const flatRows = shift.divisionShiftNurses.flatMap((row) => row);
@@ -112,18 +131,9 @@ export const shiftToExcel = async (month: number, shift: TShift) => {
         });
     });
 
-    workbook.xlsx.writeBuffer().then((data) => {
-        const blob = new Blob([data], {
-            type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-        });
-        const url = window.URL.createObjectURL(blob);
-        const anchor = document.createElement('a');
+    const data = await workbook.xlsx.writeBuffer();
 
-        anchor.href = url;
-        anchor.download = `${month}월 근무표.xlsx`;
-        anchor.click();
-        window.URL.revokeObjectURL(url);
-    });
+    downloadExcelBuffer(data, buildShiftExcelFileName(month));
 
     return workbook;
 };

--- a/apps/app/src/features/shift-editor/model/useShiftExcelExport.ts
+++ b/apps/app/src/features/shift-editor/model/useShiftExcelExport.ts
@@ -1,0 +1,31 @@
+import {useCallback, useState} from 'react';
+import toast from 'react-hot-toast';
+import {type TShift} from '@/entities/shift';
+import {shiftToExcel} from './shift-to-excel';
+
+type TUseShiftExcelExportOptions = {
+    month: number;
+    shift: TShift | null;
+    disabled?: boolean;
+};
+
+export function useShiftExcelExport({month, shift, disabled = false}: TUseShiftExcelExportOptions) {
+    const [isExporting, setIsExporting] = useState(false);
+    const exportExcel = useCallback(async () => {
+        if (disabled || isExporting || !shift) return;
+
+        setIsExporting(true);
+
+        try {
+            await shiftToExcel(month, shift);
+            toast.success('근무표 엑셀 파일을 저장했어요.');
+        } catch (error) {
+            console.error(error);
+            toast.error('근무표 엑셀 파일을 저장하지 못했어요. 다시 시도해 주세요.');
+        } finally {
+            setIsExporting(false);
+        }
+    }, [disabled, isExporting, month, shift]);
+
+    return {isExporting, exportExcel};
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/make-shift-editor-view.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/make-shift-editor-view.tsx
@@ -1,9 +1,9 @@
 import {type ComponentProps, useRef} from 'react';
 import {type TShift} from '@/entities';
-import {type TDutyDoc, useShiftImageExport} from '@/features/shift-editor/model';
+import {type TDutyDoc, useShiftExcelExport, useShiftImageExport} from '@/features/shift-editor/model';
 import NurseEditModal from './nurse-edit-modal';
+import type ShiftCalendar from './shift-calendar';
 import {ShiftEditorCanvas} from './shift-editor-canvas';
-import ShiftCalendar from './shift-calendar';
 import Toolbar from './toolbar';
 
 interface IMakeShiftEditorViewProps {
@@ -18,7 +18,10 @@ interface IMakeShiftEditorViewProps {
     stickyBottom?: boolean;
     className?: string;
     calendarProps?: Omit<ComponentProps<typeof ShiftCalendar>, 'shift' | 'doc'>;
-    toolbarProps?: Omit<ComponentProps<typeof Toolbar>, 'shift' | 'onDownloadImage' | 'isDownloadingImage'>;
+    toolbarProps?: Omit<
+        ComponentProps<typeof Toolbar>,
+        'shift' | 'onDownloadImage' | 'isDownloadingImage' | 'onDownloadExcel' | 'isDownloadingExcel'
+    >;
 }
 
 export const MakeShiftEditorView = ({
@@ -41,13 +44,20 @@ export const MakeShiftEditorView = ({
         teamName: toolbarProps?.currentShiftTeam?.name ?? null,
         disabled: !shift,
     });
+    const {isExporting: isExportingExcel, exportExcel} = useShiftExcelExport({
+        month: toolbarProps?.month ?? 1,
+        shift,
+        disabled: !shift,
+    });
 
     return (
         <div className={`mx-auto flex w-fit flex-col ${className ?? ''}`}>
             {showToolbar && toolbarProps && (
                 <Toolbar
                     shift={shift}
+                    isDownloadingExcel={isExportingExcel}
                     isDownloadingImage={isExporting}
+                    onDownloadExcel={() => void exportExcel()}
                     onDownloadImage={() => void downloadImage()}
                     {...toolbarProps}
                 />

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar.tsx
@@ -25,10 +25,12 @@ interface IToolbarProps {
     onRedo: () => void;
     onPostShift: () => void;
     onToggleEditMode: () => void;
+    onDownloadExcel: () => void;
     onDownloadImage: () => void;
     onCreateNextMonth: () => void;
     onChangeShiftTeam: (shiftTeamId: number) => void;
     onUpdateConstraint: (constraint: TWardConstraint) => void;
+    isDownloadingExcel: boolean;
     isDownloadingImage: boolean;
 }
 
@@ -48,10 +50,12 @@ function Toolbar({
     onRedo,
     onPostShift,
     onToggleEditMode,
+    onDownloadExcel,
     onDownloadImage,
     onCreateNextMonth,
     onChangeShiftTeam,
     onUpdateConstraint,
+    isDownloadingExcel,
     isDownloadingImage,
 }: IToolbarProps) {
     const [openInfo, setOpenInfo] = useState(false);
@@ -123,7 +127,6 @@ function Toolbar({
             <ToolbarActionGroup
                 year={year}
                 month={month}
-                shift={shift}
                 readonly={readonly}
                 saveStatus={saveStatus}
                 currentShiftTeam={currentShiftTeam}
@@ -132,9 +135,11 @@ function Toolbar({
                 onRedo={onRedo}
                 onPostShift={onPostShift}
                 onToggleEditMode={onToggleEditMode}
+                onDownloadExcel={onDownloadExcel}
                 onDownloadImage={onDownloadImage}
                 onCreateNextMonth={onCreateNextMonth}
                 onChangeShiftTeam={onChangeShiftTeam}
+                isDownloadingExcel={isDownloadingExcel}
                 isDownloadingImage={isDownloadingImage}
             />
         </div>

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-action-group.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar/toolbar-action-group.tsx
@@ -1,7 +1,15 @@
 import {events, sendEvent} from '@/analytics';
-import {type TShift, type TShiftTeam} from '@/entities';
-import {shiftToExcel} from '@/features/shift-editor/model/shift-to-excel';
-import {CameraIcon, DutyIconSelected, HistoryBackIcon, HistoryNextIcon, PenIcon, SaveCompleteIcon, SavingIcon, ShareIcon} from '@/shared/assets/svg';
+import {type TShiftTeam} from '@/entities';
+import {
+    CameraIcon,
+    DutyIconSelected,
+    HistoryBackIcon,
+    HistoryNextIcon,
+    PenIcon,
+    SaveCompleteIcon,
+    SavingIcon,
+    ShareIcon,
+} from '@/shared/assets/svg';
 import Button from '@/shared/ui/form-controls/Button';
 import Select from '@/shared/ui/form-controls/Select';
 import {showValidationFeedback} from '@/shared/util/feedback';
@@ -9,7 +17,6 @@ import {showValidationFeedback} from '@/shared/util/feedback';
 type TToolbarActionGroupProps = {
     year: number;
     month: number;
-    shift: TShift | null;
     readonly: boolean;
     saveStatus: 'pending' | 'saved';
     currentShiftTeam: TShiftTeam | null;
@@ -18,16 +25,17 @@ type TToolbarActionGroupProps = {
     onRedo: () => void;
     onPostShift: () => void;
     onToggleEditMode: () => void;
+    onDownloadExcel: () => void;
     onDownloadImage: () => void;
     onCreateNextMonth: () => void;
     onChangeShiftTeam: (shiftTeamId: number) => void;
+    isDownloadingExcel: boolean;
     isDownloadingImage: boolean;
 };
 
 export function ToolbarActionGroup({
     year,
     month,
-    shift,
     readonly,
     saveStatus,
     currentShiftTeam,
@@ -36,9 +44,11 @@ export function ToolbarActionGroup({
     onRedo,
     onPostShift,
     onToggleEditMode,
+    onDownloadExcel,
     onDownloadImage,
     onCreateNextMonth,
     onChangeShiftTeam,
+    isDownloadingExcel,
     isDownloadingImage,
 }: TToolbarActionGroupProps) {
     return (
@@ -124,15 +134,13 @@ export function ToolbarActionGroup({
                         id="El3"
                         variant="default"
                         className="flex h-10 items-center justify-center gap-[.5rem] rounded-[.625rem] bg-main-2 pr-[.5rem] pl-[.75rem] text-[1.25rem] font-semibold"
+                        disabled={isDownloadingExcel}
                         onClick={() => {
-                            if (shift) {
-                                shiftToExcel(month, shift);
-                            }
-
+                            onDownloadExcel();
                             sendEvent(events.makePage.toolbar.downloadExcel);
                         }}
                     >
-                        엑셀 저장
+                        {isDownloadingExcel ? '엑셀 저장 중' : '엑셀 저장'}
                         <ShareIcon className="h-6 w-6" />
                     </Button>
                     <Button

--- a/apps/app/src/pages/duty/model/__tests__/dutyHook.test.tsx
+++ b/apps/app/src/pages/duty/model/__tests__/dutyHook.test.tsx
@@ -15,7 +15,7 @@ const {
     mockShiftToDoc,
     mockDocToWardShiftsDTO,
     mockBuildWorkKeyMap,
-    mockShiftToExcel,
+    mockExportExcel,
     mockHandleGetAccountMe,
     mockCommands,
 } = vi.hoisted(() => ({
@@ -28,7 +28,7 @@ const {
     mockShiftToDoc: vi.fn(),
     mockDocToWardShiftsDTO: vi.fn(),
     mockBuildWorkKeyMap: vi.fn(),
-    mockShiftToExcel: vi.fn(),
+    mockExportExcel: vi.fn(),
     mockHandleGetAccountMe: vi.fn(),
     mockCommands: {
         init: vi.fn(),
@@ -109,8 +109,15 @@ vi.mock('@/features/shift-editor', () => ({
     buildWorkKeyMap: (...args: unknown[]) => mockBuildWorkKeyMap(...args),
     docToWardShiftsDTO: (...args: unknown[]) => mockDocToWardShiftsDTO(...args),
     shiftToDoc: (...args: unknown[]) => mockShiftToDoc(...args),
-    shiftToExcel: (...args: unknown[]) => mockShiftToExcel(...args),
     useShiftEditorCommands: () => mockCommands,
+    useShiftExcelExport: (options: {disabled?: boolean}) => ({
+        isExporting: false,
+        exportExcel: () => {
+            if (!options.disabled) {
+                mockExportExcel();
+            }
+        },
+    }),
     useShiftEditorKeyBindings: () => ({onKeyDown: vi.fn(), onPaste: vi.fn()}),
     useShiftEditorStore: (selector: (state: typeof mockEditorState) => unknown) => selector(mockEditorState),
 }));
@@ -463,7 +470,7 @@ describe('useDutyHook', () => {
             result.current.handlers.exportExcel();
         });
 
-        expect(mockShiftToExcel).toHaveBeenCalledWith(7, shift);
+        expect(mockExportExcel).toHaveBeenCalledTimes(1);
     });
 
     it('skips excel export when there is no shift data', async () => {
@@ -481,7 +488,7 @@ describe('useDutyHook', () => {
             result.current.handlers.exportExcel();
         });
 
-        expect(mockShiftToExcel).not.toHaveBeenCalled();
+        expect(mockExportExcel).not.toHaveBeenCalled();
     });
 
     it('navigates to the current month make page with the selected shift team', async () => {

--- a/apps/app/src/pages/duty/model/dutyHook.ts
+++ b/apps/app/src/pages/duty/model/dutyHook.ts
@@ -7,10 +7,10 @@ import {
     buildWorkKeyMap,
     docToWardShiftsDTO,
     shiftToDoc,
-    shiftToExcel,
     type TDutyDoc,
     useShiftEditorCommands,
     useShiftEditorKeyBindings,
+    useShiftExcelExport,
     useShiftEditorStore,
 } from '@/features/shift-editor';
 import useLoadingUseCase from '@/features/ui/useLoading';
@@ -98,6 +98,11 @@ export function useDutyHook() {
     });
     const workKeyMap = useMemo(() => buildWorkKeyMap(shift ?? undefined), [shift]);
     const {onKeyDown, onPaste} = useShiftEditorKeyBindings({workKeyMap});
+    const {isExporting: isExportingExcel, exportExcel} = useShiftExcelExport({
+        month,
+        shift,
+        disabled: !shift,
+    });
     const currentShiftTeamName = shiftTeams.find((team) => team.shiftTeamId === currentShiftTeamId)?.name ?? '선택한 팀';
     const shiftTeamsStatus = shiftTeamsQuery.isPending ? 'pending' : shiftTeamsQuery.isError ? 'error' : 'success';
 
@@ -225,9 +230,7 @@ export function useDutyHook() {
         await queryClient.invalidateQueries({queryKey: dutyQueryKey});
     };
     const handleExportExcel = () => {
-        if (!shift) return;
-
-        void shiftToExcel(month, shift);
+        void exportExcel();
     };
     const handleRetry = () => {
         if (wardId === null) {
@@ -255,6 +258,7 @@ export function useDutyHook() {
             readonly,
             shift,
             status,
+            isExportingExcel,
             doc,
         },
         refs: {

--- a/apps/app/src/pages/duty/view/index.tsx
+++ b/apps/app/src/pages/duty/view/index.tsx
@@ -59,7 +59,7 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                                     onClick={handlers.exportExcel}
                                     disabled={!state.shift || state.isExportingExcel}
                                 >
-                                    {state.isExportingExcel ? '엑셀 저장 중' : t('page.duty.exportExcel')}
+                                    {state.isExportingExcel ? t('page.duty.exportExcelLoading') : t('page.duty.exportExcel')}
                                 </ManagementActionButton>
                                 <ManagementActionButton onClick={handlers.enableEdit} disabled={!state.shift}>
                                     {t('page.duty.editShift')}

--- a/apps/app/src/pages/duty/view/index.tsx
+++ b/apps/app/src/pages/duty/view/index.tsx
@@ -54,8 +54,12 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                                 <ManagementActionButton variant="neutral" onClick={handlers.postShift} disabled={!state.shift}>
                                     {t('page.duty.publish')}
                                 </ManagementActionButton>
-                                <ManagementActionButton variant="neutral" onClick={handlers.exportExcel} disabled={!state.shift}>
-                                    {t('page.duty.exportExcel')}
+                                <ManagementActionButton
+                                    variant="neutral"
+                                    onClick={handlers.exportExcel}
+                                    disabled={!state.shift || state.isExportingExcel}
+                                >
+                                    {state.isExportingExcel ? '엑셀 저장 중' : t('page.duty.exportExcel')}
                                 </ManagementActionButton>
                                 <ManagementActionButton onClick={handlers.enableEdit} disabled={!state.shift}>
                                     {t('page.duty.editShift')}
@@ -120,33 +124,33 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                         state.shiftTeamsStatus === 'success' &&
                         state.shiftTeams.length > 0 &&
                         state.status === 'error' && (
-                        <PageState
-                            tone="error"
-                            title={t('page.duty.error')}
-                            description={t('page.state.errorDescription')}
-                            action={{label: t('page.state.retry'), onClick: handlers.retry}}
-                            className="py-0"
-                        />
-                    )}
+                            <PageState
+                                tone="error"
+                                title={t('page.duty.error')}
+                                description={t('page.state.errorDescription')}
+                                action={{label: t('page.state.retry'), onClick: handlers.retry}}
+                                className="py-0"
+                            />
+                        )}
                     {!showBootstrapLoadingState &&
                         !showBootstrapErrorState &&
                         state.shiftTeamsStatus === 'success' &&
                         state.shiftTeams.length > 0 &&
                         state.status === 'success' &&
                         !state.shift && (
-                        <PageState
-                            tone="empty"
-                            title={t('page.duty.emptyTitle', {teamName: state.currentShiftTeamName, month: state.month})}
-                            description={t('page.duty.emptyDescription', {month: state.month})}
-                            className="py-0"
-                        >
-                            <div className="mt-1 flex justify-center">
-                                <ManagementActionButton variant="secondary" size="lg" onClick={handlers.goCurrentMonthMake}>
-                                    {t('page.duty.createCurrentMonth')}
-                                </ManagementActionButton>
-                            </div>
-                        </PageState>
-                    )}
+                            <PageState
+                                tone="empty"
+                                title={t('page.duty.emptyTitle', {teamName: state.currentShiftTeamName, month: state.month})}
+                                description={t('page.duty.emptyDescription', {month: state.month})}
+                                className="py-0"
+                            >
+                                <div className="mt-1 flex justify-center">
+                                    <ManagementActionButton variant="secondary" size="lg" onClick={handlers.goCurrentMonthMake}>
+                                        {t('page.duty.createCurrentMonth')}
+                                    </ManagementActionButton>
+                                </div>
+                            </PageState>
+                        )}
                     {!showBootstrapLoadingState && !showBootstrapErrorState && state.status === 'success' && state.shift && (
                         <div
                             ref={refs.editorRef}

--- a/apps/app/src/shared/locales/en.ts
+++ b/apps/app/src/shared/locales/en.ts
@@ -173,6 +173,7 @@ export const en: TLocale = {
             createNextMonth: 'Create next month schedule',
             publish: 'Publish',
             exportExcel: 'Export Excel',
+            exportExcelLoading: 'Exporting Excel...',
             editShift: 'Edit duty schedule',
             save: 'Save',
             cancel: 'Cancel',

--- a/apps/app/src/shared/locales/ko.ts
+++ b/apps/app/src/shared/locales/ko.ts
@@ -170,6 +170,7 @@ export const ko = {
             createNextMonth: '다음달 근무표 만들기',
             publish: '게시하기',
             exportExcel: '엑셀 내보내기',
+            exportExcelLoading: '엑셀 저장 중',
             editShift: '근무표 수정하기',
             save: '저장하기',
             cancel: '취소하기',


### PR DESCRIPTION
## Motivation

근무표 작성 흐름의 excel export는 동작 자체는 있었지만, 완료/실패를 UI에서 알기 어렵고 결과 형식도 테스트로 고정돼 있지 않았습니다.
이번 변경은 기존 포맷을 유지한 채 export 결과를 검증 가능하게 만들고, 사용자가 눌렀을 때 상태를 더 명확히 이해하도록 정리하는 데 초점을 맞췄습니다.

- 티켓: [DUT-914](https://gom3.atlassian.net/browse/DUT-914)
- 배경: 근무표 작성 편집기 2차 개선 이후 export 결과 검증과 사용자 피드백 정리가 남아 있었습니다.
- 목표: excel export 결과를 신뢰 가능하게 검증하고, 진입/진행/성공/실패 UX를 명확히 합니다.

<br>

## Key Changes

- `shiftToExcel`을 `await` 기반으로 정리해 export 완료 시점을 호출부에서 안정적으로 다룰 수 있게 했습니다.
- `useShiftExcelExport`를 추가해 make complex-view와 duty 페이지 모두에서 엑셀 저장 중 상태와 성공/실패 토스트를 일관되게 노출하도록 맞췄습니다.
- workbook 내용, 파일명, 다운로드 처리, duty export handler를 테스트로 고정해 export 포맷과 회귀 포인트를 검증했습니다.

<br>

## To Reviewers

- 특히 봐야 할 파일: `apps/app/src/features/shift-editor/model/shift-to-excel.ts`, `apps/app/src/features/shift-editor/model/useShiftExcelExport.ts`, `apps/app/src/pages/duty/model/dutyHook.ts`
- 중점적으로 봐야 할 로직: export 완료/실패를 기다리는 흐름과 duty/make UI에서의 disabled + 라벨 변경 처리
- 우려되는 지점 / 확인이 필요한 부분: `pnpm --dir apps/app type-check`는 기존 `html-to-image` 타입 선언 누락(`src/features/shift-editor/model/shift-to-image.ts`) 때문에 여전히 실패합니다. 이번 변경 경로의 targeted test/lint는 통과했습니다.

[DUT-914]: https://gom3.atlassian.net/browse/DUT-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ