### PR TITLE
[DUT-942]: monorepo 버전 정책 정렬

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Current transition rules:
 - Root scripts now delegate through `*:root` aliases so a later ticket can retarget the top-level commands to `apps/app` without changing the developer entrypoints first.
 - New workspace packages should be created under `apps/*` or `packages/*`.
 
+## Monorepo Version Policy
+
+- The repository uses a single monorepo release version. The root `package.json` version is the canonical release number, and every workspace under `apps/*` and `packages/*` must keep the same value.
+- All current workspace packages are `private: true`, so they are not publish targets yet. Even so, each workspace still keeps an explicit aligned version because release notes, release branch naming, and future Changesets fixed-version groups need one consistent version source.
+- Future Changesets setup should treat the workspace packages as a fixed version group. The root package is not a publish target, but it should continue mirroring the same release number so the repository-level version stays readable in code and docs.
+- If a package later becomes publishable, it joins the same shared version policy unless the release policy is intentionally changed.
+
 ## Running Tests
 
 ### Unit Tests

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dutying/docs",
     "private": true,
-    "version": "0.1.0",
+    "version": "1.0.2",
     "type": "module",
     "scripts": {
         "dev": "vitepress dev . --host 0.0.0.0 --port 5173",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dutying/landing",
     "private": true,
-    "version": "0.1.0",
+    "version": "1.0.2",
     "type": "module",
     "scripts": {
         "dev": "astro dev",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dutying/api",
-    "version": "0.0.0",
+    "version": "1.0.2",
     "private": true,
     "type": "module",
     "exports": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dutying/config",
     "private": true,
-    "version": "0.0.0",
+    "version": "1.0.2",
     "type": "module",
     "exports": {
         "./eslint/react-app": "./eslint/react-app.mjs",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dutying/domain",
-    "version": "0.0.0",
+    "version": "1.0.2",
     "private": true,
     "type": "module",
     "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dutying/utils",
-    "version": "0.0.0",
+    "version": "1.0.2",
     "private": true,
     "type": "module",
     "exports": {


### PR DESCRIPTION
## Motivation

monorepo 릴리즈 버전 기준을 `root/app` 기준으로 하나로 고정하고, apps/packages에 남아 있던 분산된 버전 값을 DUT-943 전에 정리했습니다.

- 티켓: [DUT-942](https://gom3.atlassian.net/browse/DUT-942)
- 배경: root는 `1.0.2`, docs/landing은 `0.1.0`, shared packages는 `0.0.0`으로 나뉘어 있어 이후 Changesets fixed version 구성을 바로 이어가기 어려웠습니다.
- 목표: monorepo 단일 버전 정책을 문서와 코드 기준으로 확정하고 현재 workspace version 값을 일관되게 맞춥니다.

<br>

## Key Changes

- `README.md`에 monorepo version policy를 추가해 root version을 canonical release number로 두고 `apps/*`, `packages/*`가 동일 버전을 유지한다는 기준을 문서화했습니다.
- publish 대상이 아직 없고 모든 workspace가 `private: true`여도 fixed version 그룹과 릴리즈 메타데이터 정합성을 위해 동일 버전을 유지해야 한다는 운영 기준을 명시했습니다.
- `apps/docs`, `apps/landing`, `packages/api`, `packages/config`, `packages/domain`, `packages/utils`의 `version`을 모두 `1.0.2`로 정렬했습니다.

<br>

## To Reviewers

- 특히 봐야 할 파일: `README.md`, 각 workspace `package.json`
- 중점적으로 봐야 할 로직: 코드 로직 변경은 없고, 버전 정책 문구와 workspace version 정렬 범위가 DUT-943 선행 조건으로 충분한지 봐주시면 됩니다.
- 우려되는 지점 / 확인이 필요한 부분: 이번 PR은 changesets 초기화나 workflow 변경은 포함하지 않으므로 다음 단계에서 fixed version 그룹 설정만 이어서 진행하면 됩니다. 검증은 `pnpm run workspace:list`로 수행했습니다.


[DUT-942]: https://gom3.atlassian.net/browse/DUT-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ