### PR TITLE
[DUT-945]: GitHub Actions version 및 release 자동화

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,97 @@
+name: GitHub Release
+
+on:
+    push:
+        branches:
+            - main
+
+concurrency:
+    group: github-release-${{ github.ref }}
+    cancel-in-progress: false
+
+jobs:
+    github-release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Resolve release metadata
+              id: metadata
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const {readFileSync} = require("node:fs");
+
+                      const packageJson = JSON.parse(readFileSync(`${process.env.GITHUB_WORKSPACE}/package.json`, "utf8"));
+                      const version = packageJson.version;
+                      const tag = `v${version}`;
+
+                      core.setOutput("version", version);
+                      core.setOutput("tag", tag);
+
+                      try {
+                        await github.rest.repos.getReleaseByTag({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          tag,
+                        });
+
+                        core.setOutput("release_exists", "true");
+                      } catch (error) {
+                        if (error.status === 404) {
+                          core.setOutput("release_exists", "false");
+                          return;
+                        }
+
+                        throw error;
+                      }
+
+            - name: Extract release notes from root changelog
+              if: steps.metadata.outputs.release_exists != 'true'
+              env:
+                  RELEASE_VERSION: ${{ steps.metadata.outputs.version }}
+              run: |
+                  node --input-type=module <<'EOF'
+                  import {readFileSync, writeFileSync} from 'node:fs';
+
+                  const version = process.env.RELEASE_VERSION;
+                  const changelog = readFileSync('CHANGELOG.md', 'utf8');
+                  const versionHeading = `## ${version} - `;
+                  const sectionStart = changelog.indexOf(versionHeading);
+
+                  if (sectionStart === -1) {
+                      throw new Error(`Missing CHANGELOG.md entry for ${version}.`);
+                  }
+
+                  const nextSectionStart = changelog.indexOf('\n## ', sectionStart + versionHeading.length);
+                  const releaseNotes = changelog.slice(
+                      sectionStart,
+                      nextSectionStart === -1 ? changelog.length : nextSectionStart,
+                  ).trim();
+
+                  writeFileSync('release-notes.md', `${releaseNotes}\n`);
+                  EOF
+
+            - name: Create GitHub release
+              if: steps.metadata.outputs.release_exists != 'true'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const {readFileSync} = require("node:fs");
+
+                      await github.rest.repos.createRelease({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        tag_name: process.env.RELEASE_TAG,
+                        name: process.env.RELEASE_TAG,
+                        body: readFileSync(`${process.env.GITHUB_WORKSPACE}/release-notes.md`, "utf8"),
+                        target_commitish: context.sha,
+                      });
+              env:
+                  RELEASE_TAG: ${{ steps.metadata.outputs.tag }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,47 @@
+name: Release PR
+
+on:
+    push:
+        branches:
+            - develop
+
+concurrency:
+    group: release-pr-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    release-pr:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10.12.4
+
+            - name: Use Node.js 22.x
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22.x
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: PUPPETEER_DOWNLOAD_BASE_URL="https://storage.googleapis.com/chrome-for-testing-public" pnpm install --frozen-lockfile
+
+            - name: Create or update release pull request
+              uses: changesets/action@v1
+              with:
+                  version: pnpm run release:version
+                  title: 'chore: release packages'
+                  commit: 'chore: release packages'
+                  createGithubReleases: false
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Current transition rules:
 - `pnpm run release:version` is kept as the same official release command if you prefer a release-prefixed entrypoint.
 - `pnpm run changeset:version:workspaces` remains a low-level helper for internal scripting only; do not use it for normal releases because it skips the root changelog step.
 
+### GitHub Actions Release Automation
+
+- Pushes to `develop` run the release PR automation in [`.github/workflows/release-pr.yml`](./.github/workflows/release-pr.yml). It creates or updates a single release PR by running `pnpm run release:version` on top of pending `.changeset/*.md` files.
+- Pushes to `main` run the GitHub release automation in [`.github/workflows/github-release.yml`](./.github/workflows/github-release.yml). It reads the root version, extracts the matching root changelog section, and creates the `v{version}` GitHub Release.
+- The repository keeps the existing branch strategy: merge feature work into `develop`, merge the generated release PR into `develop` when the next version is ready, cut `release/{version}` for QA, and merge that branch into `main` to publish the GitHub Release.
+- Operational details and prerequisites are documented in [`docs/release-automation.md`](./docs/release-automation.md).
+
 ## Running Tests
 
 ### Unit Tests

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -1,0 +1,58 @@
+# Release Automation
+
+`dutying-web` release automation is intentionally minimal and follows the current branch strategy:
+
+1. Feature work lands on `develop` with one or more `.changeset/*.md` files.
+2. GitHub Actions opens or updates one release PR on top of `develop`.
+3. When the team is ready to cut a release, merge that release PR into `develop`.
+4. Create `release/x.y.z` from the updated `develop` commit for QA.
+5. After QA, merge `release/x.y.z` into `main`.
+6. A second GitHub Actions workflow creates the GitHub Release and `vx.y.z` tag from the merged `main` commit.
+
+## Workflows
+
+### 1. Release PR (`.github/workflows/release-pr.yml`)
+
+- Trigger: every push to `develop`
+- Purpose: connect pending Changesets to a single release PR
+- Action:
+    - runs `pnpm run release:version`
+    - bumps aligned workspace versions through Changesets
+    - syncs the root `package.json` version
+    - prepends the root `CHANGELOG.md`
+    - removes consumed `.changeset/*.md` files in the release PR branch
+- Result: the repository always has one reviewable "release prep" PR instead of a manual version/changelog commit flow
+
+### 2. GitHub Release (`.github/workflows/github-release.yml`)
+
+- Trigger: every push to `main`
+- Purpose: convert the already-approved release commit into a GitHub Release
+- Action:
+    - reads the root `package.json` version
+    - skips when a GitHub Release already exists for `v<version>`
+    - extracts the matching root `CHANGELOG.md` section
+    - creates the GitHub Release and tag
+
+## Operator Flow
+
+1. Add a Changeset in every feature/fix PR that should be reflected in the next release.
+2. Merge the normal work into `develop`.
+3. Wait for the Release PR workflow to open or refresh the release PR.
+4. Review the generated version bumps and root changelog entry.
+5. Merge the release PR when you want to freeze the next release candidate.
+6. Create `release/<root-version>` from that `develop` commit and run QA as usual.
+7. Merge the release branch into `main`.
+8. Confirm that the GitHub Release workflow created `v<root-version>`.
+
+## Required Repository Settings
+
+- GitHub Actions must be enabled for the repository.
+- The repository-level `GITHUB_TOKEN` permission must allow write access so workflows can push the release PR branch and create releases.
+- No extra npm publishing secret is required because all workspaces are still `private: true`.
+- Existing Cypress secrets (`TESTING_ID`, `TESTING_PW`, `TESTING_HOST`) are unchanged and stay owned by the current test workflow.
+
+## Failure Modes To Watch
+
+- If a change reaches `develop` without a `.changeset/*.md`, the release PR will not include it in the next version/changelog update.
+- If someone manually edits versions without the normal Changesets flow, the `main` release workflow can fail because the matching root `CHANGELOG.md` section is missing.
+- The GitHub Release is created only after `main` receives the release commit, not when the release PR is merged into `develop`.


### PR DESCRIPTION
## Motivation

changesets 기반의 버전 상승/루트 changelog 흐름은 이미 정리되어 있었지만, 운영자가 매번 직접 version/release 절차를 실행해야 했습니다.

- 티켓: [DUT-945](https://gom3.atlassian.net/browse/DUT-945)
- 배경: 현재 monorepo에 맞는 최소한의 version/release automation 기반이 필요합니다.
- 목표: `develop` 기준 release PR 생성과 `main` 기준 GitHub Release 생성을 GitHub Actions로 연결합니다.

<br>

## Key Changes

- `develop` push 시 pending changesets를 기반으로 release PR을 자동 생성/갱신하는 `.github/workflows/release-pr.yml`을 추가했습니다.
- `main` push 시 루트 `package.json` 버전과 `CHANGELOG.md` 항목을 사용해 GitHub Release/tag를 생성하는 `.github/workflows/github-release.yml`을 추가했습니다.
- 운영자가 따라야 할 흐름과 필요한 저장소 전제 조건을 `docs/release-automation.md`와 `README.md`에 문서화했습니다.

<br>

## To Reviewers

- 특히 봐야 할 파일: `.github/workflows/release-pr.yml`, `.github/workflows/github-release.yml`, `docs/release-automation.md`
- 중점적으로 봐야 할 로직: release PR 전략이 현재 `develop -> release/{version} -> main` 흐름과 충돌 없이 이어지는지
- 우려되는 지점 / 확인이 필요한 부분: 저장소 Actions 설정에서 `GITHUB_TOKEN` write 권한이 허용되어 있어야 release PR 브랜치 push와 GitHub Release 생성이 정상 동작합니다.


[DUT-945]: https://gom3.atlassian.net/browse/DUT-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ