### PR TITLE
[DUT-941]: 릴리즈 기반 마감 정리

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -11,4 +11,5 @@ We have a quick list of common questions to get you started engaging with this p
 
 - Pending `.changeset/*.md` files are the source of truth for the next root `CHANGELOG.md` entry.
 - Package-level changelogs stay disabled because this monorepo ships one fixed shared version across private workspaces.
+- Use `pnpm run release:verify` for the local preflight check that validates the changelog helpers, shows the pending workspace bump, and previews the next root changelog entry.
 - Use `pnpm run release:status` to inspect pending changesets and `pnpm run release:version` to version workspaces, sync the root version, and update the root changelog together.

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -36,6 +36,9 @@ jobs:
             - name: Install dependencies
               run: PUPPETEER_DOWNLOAD_BASE_URL="https://storage.googleapis.com/chrome-for-testing-public" pnpm install --frozen-lockfile
 
+            - name: Validate release changelog helpers
+              run: pnpm run release:test
+
             - name: Create or update release pull request
               uses: changesets/action@v1
               with:

--- a/README.md
+++ b/README.md
@@ -136,18 +136,19 @@ GitHub Actions:
 
 - 모든 workspace는 동일한 버전을 사용합니다.
 - Changesets는 workspace 버전을 올리고, 루트 `package.json` 및 루트 `CHANGELOG.md`를 함께 동기화합니다.
+- 로컬에서 release 기반을 점검할 때는 `pnpm run release:verify`를 먼저 실행합니다.
 - 일반적인 릴리즈 준비 순서:
 
 ```bash
 pnpm run changeset:add
-pnpm run changeset:status
-pnpm run release:changelog:preview
+pnpm run release:verify
 pnpm run changeset:version
 ```
 
 ### GitHub Actions Release Automation
 
 - Pushes to `develop` run the release PR automation in [`.github/workflows/release-pr.yml`](./.github/workflows/release-pr.yml). It creates or updates a single release PR by running `pnpm run release:version` on top of pending `.changeset/*.md` files.
+- The release PR workflow also runs `pnpm run release:test` first so the custom root changelog helpers fail fast before the PR branch is updated.
 - Pushes to `main` run the GitHub release automation in [`.github/workflows/github-release.yml`](./.github/workflows/github-release.yml). It reads the root version, extracts the matching root changelog section, and creates the `v{version}` GitHub Release.
 - The repository keeps the existing branch strategy: merge feature work into `develop`, merge the generated release PR into `develop` when the next version is ready, cut `release/{version}` for QA, and merge that branch into `main` to publish the GitHub Release.
 - Operational details and prerequisites are documented in [`docs/release-automation.md`](./docs/release-automation.md).

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -36,13 +36,14 @@
 ## Operator Flow
 
 1. Add a Changeset in every feature/fix PR that should be reflected in the next release.
-2. Merge the normal work into `develop`.
-3. Wait for the Release PR workflow to open or refresh the release PR.
-4. Review the generated version bumps and root changelog entry.
-5. Merge the release PR when you want to freeze the next release candidate.
-6. Create `release/<root-version>` from that `develop` commit and run QA as usual.
-7. Merge the release branch into `main`.
-8. Confirm that the GitHub Release workflow created `v<root-version>`.
+2. Before merging that work, run `pnpm run release:verify` locally when you need to confirm the current Changesets, planned version bump, and root changelog output in one pass.
+3. Merge the normal work into `develop`.
+4. Wait for the Release PR workflow to open or refresh the release PR.
+5. Review the generated version bumps and root changelog entry.
+6. Merge the release PR when you want to freeze the next release candidate.
+7. Create `release/<root-version>` from that `develop` commit and run QA as usual.
+8. Merge the release branch into `main`.
+9. Confirm that the GitHub Release workflow created `v<root-version>`.
 
 ## Required Repository Settings
 
@@ -56,3 +57,4 @@
 - If a change reaches `develop` without a `.changeset/*.md`, the release PR will not include it in the next version/changelog update.
 - If someone manually edits versions without the normal Changesets flow, the `main` release workflow can fail because the matching root `CHANGELOG.md` section is missing.
 - The GitHub Release is created only after `main` receives the release commit, not when the release PR is merged into `develop`.
+- `pnpm run release:verify` is a local preflight only. It validates the custom changelog helpers, prints the pending version bump, and previews the next root changelog entry, but it does not modify tracked files.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
         "changeset:version": "node ./scripts/release/version-with-changelog.mjs",
         "changeset:version:workspaces": "CI=1 pnpm exec changeset version",
         "changeset:sync-root-version": "node ./scripts/release/sync-root-version.mjs",
+        "release:test": "node --test scripts/release/changelog.test.mjs",
+        "release:verify": "pnpm run release:test && pnpm run release:status && pnpm run release:changelog:preview",
         "release:changelog:preview": "node ./scripts/release/preview-root-changelog.mjs",
         "release:status": "pnpm run changeset:status",
         "release:version": "pnpm run changeset:version",


### PR DESCRIPTION
## Motivation

버전 정책, Changesets, 루트 CHANGELOG, GitHub Actions 자동화가 각각 들어온 상태에서 현재 monorepo의 릴리즈 기반이 실제로 한 흐름으로 마감 가능한지 점검했습니다.

- 티켓: [DUT-941](https://gom3.atlassian.net/browse/DUT-941)
- 배경: 하위 티켓 DUT-942, DUT-943, DUT-944, DUT-945 결과가 서로 모순 없이 이어지는지 확인하고, 운영자가 이해하고 사용할 수 있는 최소 릴리즈 기반으로 정리할 필요가 있었습니다.
- 목표: 현재 release 체계를 확장하지 않고도 릴리즈 준비, release PR 생성, main 배포까지 이어지는 최소 운영 흐름을 검증 가능하게 만들고 마감 가능한 상태로 정리합니다.

<br>

## Key Changes

- 하위 티켓 산출물을 기준으로 버전 정책, Changesets, 루트 CHANGELOG, release workflow 연결 상태를 점검했습니다.
- `pnpm run release:verify` 스크립트를 추가해 changelog helper 테스트, pending version bump 확인, 다음 루트 changelog preview를 한 번에 확인할 수 있게 했습니다.
- release PR workflow에서 `pnpm run release:test`를 먼저 실행하도록 보강해 커스텀 changelog helper가 깨진 상태로 release PR 브랜치를 갱신하지 않도록 했습니다.
- README, release 운영 문서, `.changeset/README.md`에 현재 운영 순서와 로컬 preflight 검증 경로를 반영했습니다.

<br>

## To Reviewers

- 특히 봐야 할 파일: `package.json`, `.github/workflows/release-pr.yml`, `docs/release-automation.md`, `README.md`
- 중점적으로 봐야 할 로직: 로컬 preflight 검증 명령(`release:verify`)과 release PR workflow의 사전 검증 단계가 현재 운영 의도와 맞는지
- 우려되는 지점 / 확인이 필요한 부분: `changeset status`가 비대화형 환경에서 `/dev/tty` 경고를 출력하지만 명령 자체는 성공합니다. 동작상 blocker는 아니어서 follow-up으로만 남겼습니다.


[DUT-941]: https://gom3.atlassian.net/browse/DUT-941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ