### PR TITLE
[DUT-946]: 체험 계정 상태 표시 및 남은 시간 안내 강화

### DIFF
--- a/apps/app/src/features/auth/model/demo-session.ts
+++ b/apps/app/src/features/auth/model/demo-session.ts
@@ -1,0 +1,47 @@
+export const DEMO_SESSION_DURATION_MS = 3_540_000;
+export const DEMO_SESSION_EXPIRING_SOON_MS = 10 * 60 * 1000;
+
+export type TDemoSessionInfo = {
+    isActive: boolean;
+    isExpired: boolean;
+    isExpiringSoon: boolean;
+    remainingMs: number;
+    remainingMinutes: number;
+    remainingRoundedMinutes: number;
+    remainingSeconds: number;
+    countdownLabel: string;
+};
+
+const formatCountdown = (minutes: number, seconds: number) => `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+
+export const getDemoSessionInfo = (demoStartDate: string | null, now = Date.now()): TDemoSessionInfo | null => {
+    if (!demoStartDate) {
+        return null;
+    }
+
+    const startedAt = new Date(demoStartDate).getTime();
+
+    if (Number.isNaN(startedAt)) {
+        return null;
+    }
+
+    const remainingMs = startedAt + DEMO_SESSION_DURATION_MS - now;
+    const safeRemainingMs = Math.max(remainingMs, 0);
+    const remainingTotalSeconds = Math.ceil(safeRemainingMs / 1000);
+    const remainingMinutes = Math.floor(remainingTotalSeconds / 60);
+    const remainingSeconds = remainingTotalSeconds % 60;
+
+    return {
+        isActive: remainingMs > 0,
+        isExpired: remainingMs <= 0,
+        isExpiringSoon: safeRemainingMs > 0 && safeRemainingMs <= DEMO_SESSION_EXPIRING_SOON_MS,
+        remainingMs: safeRemainingMs,
+        remainingMinutes,
+        remainingRoundedMinutes: remainingTotalSeconds > 0 ? Math.ceil(remainingTotalSeconds / 60) : 0,
+        remainingSeconds,
+        countdownLabel: formatCountdown(remainingMinutes, remainingSeconds),
+    };
+};
+
+export const isDemoSessionExpired = (demoStartDate: string | null, now = Date.now()) =>
+    getDemoSessionInfo(demoStartDate, now)?.isExpired ?? false;

--- a/apps/app/src/features/auth/model/demo-session.ts
+++ b/apps/app/src/features/auth/model/demo-session.ts
@@ -44,4 +44,4 @@ export const getDemoSessionInfo = (demoStartDate: string | null, now = Date.now(
 };
 
 export const isDemoSessionExpired = (demoStartDate: string | null, now = Date.now()) =>
-    getDemoSessionInfo(demoStartDate, now)?.isExpired ?? false;
+    demoStartDate ? (getDemoSessionInfo(demoStartDate, now)?.isExpired ?? true) : false;

--- a/apps/app/src/shared/locales/en.ts
+++ b/apps/app/src/shared/locales/en.ts
@@ -396,6 +396,19 @@ export const en: TLocale = {
     feature: {
         auth: {
             sessionExpired: 'Your login has expired. Please sign in again.',
+            demoSession: {
+                badge: 'Trial account',
+                signupRequired: 'Sign-up required',
+                expiringSoon: 'Expiring soon',
+                title: 'You are currently editing with a temporary trial account.',
+                titleExpiringSoon: 'Your trial session is about to end.',
+                description: 'This trial runs in a limited temporary session. Sign up before it ends if you want to keep using Dutying.',
+                descriptionExpiringSoon: 'The trial will end soon. You will need to sign up to keep using Dutying afterward.',
+                remainingLabel: 'Time left',
+                remainingApprox: 'About {{minutes}} min left',
+                remainingFallback: 'Trial in progress',
+                documentTitle: 'Trial {{countdown}} | Dutying',
+            },
         },
         registerWard: {
             shiftTypes: {

--- a/apps/app/src/shared/locales/ko.ts
+++ b/apps/app/src/shared/locales/ko.ts
@@ -392,6 +392,19 @@ export const ko = {
     feature: {
         auth: {
             sessionExpired: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+            demoSession: {
+                badge: '체험 계정',
+                signupRequired: '회원가입 전환 필요',
+                expiringSoon: '곧 만료',
+                title: '지금은 체험용 임시 계정으로 근무표를 작성 중이에요.',
+                titleExpiringSoon: '체험 종료가 얼마 남지 않았어요.',
+                description: '체험은 제한 시간이 있는 임시 세션이에요. 계속 사용하려면 체험이 끝나기 전에 회원가입으로 전환해 주세요.',
+                descriptionExpiringSoon: '곧 체험이 종료돼요. 이후에도 계속 사용하려면 회원가입 전환이 필요해요.',
+                remainingLabel: '남은 시간',
+                remainingApprox: '약 {{minutes}}분 남음',
+                remainingFallback: '체험 진행 중',
+                documentTitle: '체험 {{countdown}} | 듀팅',
+            },
         },
         registerWard: {
             shiftTypes: {

--- a/apps/app/src/widgets/layouts/__tests__/auth-layout.test.tsx
+++ b/apps/app/src/widgets/layouts/__tests__/auth-layout.test.tsx
@@ -201,4 +201,35 @@ describe('AuthLayout', () => {
         expect(screen.getByText('약 30분 남음')).toBeInTheDocument();
         expect(mockedUseInterval).toHaveBeenCalledWith(expect.any(Function), 1000);
     });
+
+    it('logs out immediately when the persisted demo start date is malformed', async () => {
+        const handleLogout = vi.fn();
+
+        mockedUseAuth.mockReturnValue({
+            state: {
+                isAuth: true,
+                accountMe: {
+                    status: 'DEMO',
+                },
+                demoStartDate: 'not-a-date',
+            },
+            actions: {
+                handleLogout,
+            },
+        } as never);
+
+        render(
+            <MemoryRouter initialEntries={[ROUTE.MAKE]}>
+                <Routes>
+                    <Route element={<AuthLayout />}>
+                        <Route path={ROUTE.MAKE} element={<div>make page</div>} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(handleLogout).toHaveBeenCalled();
+        });
+    });
 });

--- a/apps/app/src/widgets/layouts/__tests__/auth-layout.test.tsx
+++ b/apps/app/src/widgets/layouts/__tests__/auth-layout.test.tsx
@@ -1,8 +1,9 @@
 import {MemoryRouter, Route, Routes} from 'react-router';
-import {describe, expect, it, vi, beforeEach} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import useAuth from '@/features/auth';
 import ROUTE from '@/shared/constant/path';
 import {render, screen, waitFor} from '@/shared/util/test-utils';
+import useInterval from '@/shared/util/useInterval';
 import {AuthLayout} from '../auth-layout';
 
 vi.mock('@/features/auth', () => ({
@@ -13,10 +14,41 @@ vi.mock('@/shared/util/useInterval', () => ({
     default: vi.fn(),
 }));
 
+const translationMap = {
+    'feature.auth.demoSession.badge': '체험 계정',
+    'feature.auth.demoSession.signupRequired': '회원가입 전환 필요',
+    'feature.auth.demoSession.expiringSoon': '곧 만료',
+    'feature.auth.demoSession.title': '지금은 체험용 임시 계정으로 근무표를 작성 중이에요.',
+    'feature.auth.demoSession.titleExpiringSoon': '체험 종료가 얼마 남지 않았어요.',
+    'feature.auth.demoSession.description':
+        '체험은 제한 시간이 있는 임시 세션이에요. 계속 사용하려면 체험이 끝나기 전에 회원가입으로 전환해 주세요.',
+    'feature.auth.demoSession.descriptionExpiringSoon': '곧 체험이 종료돼요. 이후에도 계속 사용하려면 회원가입 전환이 필요해요.',
+    'feature.auth.demoSession.remainingLabel': '남은 시간',
+    'feature.auth.demoSession.remainingFallback': '체험 진행 중',
+} as const;
+
+vi.mock('@/shared/hook/use-typed-translation', () => ({
+    useTypedTranslation: () => ({
+        t: (key: string, values?: Record<string, string | number>) => {
+            if (key === 'feature.auth.demoSession.remainingApprox') {
+                return `약 ${values?.minutes}분 남음`;
+            }
+
+            if (key === 'feature.auth.demoSession.documentTitle') {
+                return `체험 ${values?.countdown} | 듀팅`;
+            }
+
+            return translationMap[key as keyof typeof translationMap] ?? key;
+        },
+    }),
+}));
+
 const mockedUseAuth = vi.mocked(useAuth);
+const mockedUseInterval = vi.mocked(useInterval);
 
 describe('AuthLayout', () => {
     beforeEach(() => {
+        mockedUseInterval.mockImplementation(() => undefined);
         mockedUseAuth.mockReturnValue({
             state: {
                 isAuth: true,
@@ -29,6 +61,10 @@ describe('AuthLayout', () => {
                 handleLogout: vi.fn(),
             },
         } as never);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
     it('redirects unauthenticated users to login before rendering protected routes', async () => {
@@ -128,5 +164,41 @@ describe('AuthLayout', () => {
         });
 
         expect(screen.queryByText('register page')).not.toBeInTheDocument();
+    });
+
+    it('renders a prominent demo session banner with remaining time for demo users', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-03-25T00:00:00.000Z'));
+
+        mockedUseAuth.mockReturnValue({
+            state: {
+                isAuth: true,
+                accountMe: {
+                    status: 'DEMO',
+                },
+                demoStartDate: '2026-03-24T23:31:00.000Z',
+            },
+            actions: {
+                handleLogout: vi.fn(),
+            },
+        } as never);
+
+        render(
+            <MemoryRouter initialEntries={[ROUTE.MAKE]}>
+                <Routes>
+                    <Route element={<AuthLayout />}>
+                        <Route path={ROUTE.MAKE} element={<div>make page</div>} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('체험 계정')).toBeInTheDocument();
+        expect(screen.getByText('회원가입 전환 필요')).toBeInTheDocument();
+        expect(screen.getByText('지금은 체험용 임시 계정으로 근무표를 작성 중이에요.')).toBeInTheDocument();
+        expect(screen.getByText('남은 시간')).toBeInTheDocument();
+        expect(screen.getByText('30:00')).toBeInTheDocument();
+        expect(screen.getByText('약 30분 남음')).toBeInTheDocument();
+        expect(mockedUseInterval).toHaveBeenCalledWith(expect.any(Function), 1000);
     });
 });

--- a/apps/app/src/widgets/layouts/auth-layout.tsx
+++ b/apps/app/src/widgets/layouts/auth-layout.tsx
@@ -18,6 +18,7 @@ export const AuthLayout = () => {
         actions: {handleLogout},
     } = useAuth();
     const demoSessionInfo = getDemoSessionInfo(demoStartDate, currentTime);
+    const isDemoSessionExpiredNow = isDemoSessionExpired(demoStartDate, currentTime);
     const isDemoAccount = accountMe?.status === 'DEMO' || Boolean(demoStartDate);
 
     useEffect(() => {
@@ -35,10 +36,10 @@ export const AuthLayout = () => {
     }, [demoStartDate]);
 
     useEffect(() => {
-        if (demoSessionInfo?.isExpired) {
+        if (isDemoSessionExpiredNow) {
             void handleLogout();
         }
-    }, [demoSessionInfo?.isExpired, handleLogout]);
+    }, [handleLogout, isDemoSessionExpiredNow]);
 
     useInterval(
         () => {

--- a/apps/app/src/widgets/layouts/auth-layout.tsx
+++ b/apps/app/src/widgets/layouts/auth-layout.tsx
@@ -2,17 +2,23 @@ import {useEffect, useState} from 'react';
 import {Helmet} from 'react-helmet';
 import {Outlet, useLocation, useNavigate} from 'react-router';
 import useAuth from '@/features/auth';
+import {getDemoSessionInfo, isDemoSessionExpired} from '@/features/auth/model/demo-session';
 import ROUTE from '@/shared/constant/path';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import useInterval from '@/shared/util/useInterval';
+import DemoSessionBanner from './demo-session-banner';
 
 export const AuthLayout = () => {
-    const [demoRemainTime, setDemoRemainTime] = useState<string | null>(null);
+    const [currentTime, setCurrentTime] = useState(() => Date.now());
     const navigate = useNavigate();
     const {pathname} = useLocation();
+    const {t} = useTypedTranslation();
     const {
         state: {isAuth, accountMe, demoStartDate},
         actions: {handleLogout},
     } = useAuth();
+    const demoSessionInfo = getDemoSessionInfo(demoStartDate, currentTime);
+    const isDemoAccount = accountMe?.status === 'DEMO' || Boolean(demoStartDate);
 
     useEffect(() => {
         if (!isAuth) {
@@ -24,26 +30,45 @@ export const AuthLayout = () => {
         }
     }, [accountMe, isAuth, navigate, pathname]);
 
+    useEffect(() => {
+        setCurrentTime(Date.now());
+    }, [demoStartDate]);
+
+    useEffect(() => {
+        if (demoSessionInfo?.isExpired) {
+            void handleLogout();
+        }
+    }, [demoSessionInfo?.isExpired, handleLogout]);
+
     useInterval(
         () => {
-            if (demoStartDate && new Date(demoStartDate).getTime() + 3540000 - new Date().getTime() > 0) {
-                setDemoRemainTime(
-                    `듀팅 체험중 ${Math.ceil((new Date(demoStartDate).getTime() + 3540000 - new Date().getTime()) / 1000 / 60)}:${Math.ceil(
-                        ((new Date(demoStartDate).getTime() + 3540000 - new Date().getTime()) / 1000) % 60,
-                    )}`,
-                );
-            } else {
-                handleLogout();
+            const nextTime = Date.now();
+
+            if (isDemoSessionExpired(demoStartDate, nextTime)) {
+                void handleLogout();
+
+                return;
             }
+
+            setCurrentTime(nextTime);
         },
         demoStartDate ? 1000 : null,
     );
 
     return (
         isAuth && (
-            <div className="h-full w-full">
-                <Helmet title={demoRemainTime ?? '듀팅 | Dutying'} />
-                <Outlet />
+            <div className="flex h-full w-full flex-col">
+                <Helmet
+                    title={
+                        demoSessionInfo?.isActive
+                            ? t('feature.auth.demoSession.documentTitle', {countdown: demoSessionInfo.countdownLabel})
+                            : '듀팅 | Dutying'
+                    }
+                />
+                {isDemoAccount ? <DemoSessionBanner sessionInfo={demoSessionInfo} /> : null}
+                <div className="min-h-0 flex-1">
+                    <Outlet />
+                </div>
             </div>
         )
     );

--- a/apps/app/src/widgets/layouts/demo-session-banner.tsx
+++ b/apps/app/src/widgets/layouts/demo-session-banner.tsx
@@ -14,8 +14,6 @@ const DemoSessionBanner = ({sessionInfo}: TDemoSessionBannerProps) => {
 
     return (
         <section
-            role="status"
-            aria-live="polite"
             className={cn(
                 'border-b px-5 py-4 md:px-8',
                 isExpiringSoon ? 'border-[#FFD3D3] bg-[#FFF6F6]' : 'border-[#FFE0A3] bg-[linear-gradient(90deg,#FFF9EA_0%,#FFF3D6_100%)]',

--- a/apps/app/src/widgets/layouts/demo-session-banner.tsx
+++ b/apps/app/src/widgets/layouts/demo-session-banner.tsx
@@ -1,0 +1,73 @@
+import {cn} from '@dutying/utils/style';
+import {Clock3, TriangleAlert} from 'lucide-react';
+import type {TDemoSessionInfo} from '@/features/auth/model/demo-session';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import StatusBadge from '@/shared/ui/StatusBadge';
+
+type TDemoSessionBannerProps = {
+    sessionInfo: TDemoSessionInfo | null;
+};
+
+const DemoSessionBanner = ({sessionInfo}: TDemoSessionBannerProps) => {
+    const {t} = useTypedTranslation();
+    const isExpiringSoon = sessionInfo?.isExpiringSoon ?? false;
+
+    return (
+        <section
+            role="status"
+            aria-live="polite"
+            className={cn(
+                'border-b px-5 py-4 md:px-8',
+                isExpiringSoon ? 'border-[#FFD3D3] bg-[#FFF6F6]' : 'border-[#FFE0A3] bg-[linear-gradient(90deg,#FFF9EA_0%,#FFF3D6_100%)]',
+            )}
+        >
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                        <StatusBadge label={t('feature.auth.demoSession.badge')} tone="warning" size="md" />
+                        <StatusBadge
+                            label={t(isExpiringSoon ? 'feature.auth.demoSession.expiringSoon' : 'feature.auth.demoSession.signupRequired')}
+                            tone={isExpiringSoon ? 'danger' : 'brand'}
+                            size="sm"
+                        />
+                    </div>
+                    <p className="mt-3 font-apple text-[1.375rem] leading-[1.35] font-semibold tracking-[-0.02em] text-sub-1">
+                        {t(isExpiringSoon ? 'feature.auth.demoSession.titleExpiringSoon' : 'feature.auth.demoSession.title')}
+                    </p>
+                    <p className="mt-2 max-w-[780px] font-apple text-[0.9375rem] leading-6 text-sub-2.5">
+                        {t(isExpiringSoon ? 'feature.auth.demoSession.descriptionExpiringSoon' : 'feature.auth.demoSession.description')}
+                    </p>
+                </div>
+
+                <div
+                    className={cn(
+                        'flex min-w-[220px] shrink-0 items-center gap-3 self-start rounded-[20px] border bg-white/90 px-5 py-4 shadow-banner',
+                        isExpiringSoon ? 'border-[#FFD3D3]' : 'border-[#F3D28C]',
+                    )}
+                >
+                    <div
+                        className={cn(
+                            'flex size-12 shrink-0 items-center justify-center rounded-full',
+                            isExpiringSoon ? 'bg-[#FFF0F0] text-[#B42318]' : 'bg-[#FFF4D6] text-[#A56600]',
+                        )}
+                    >
+                        {isExpiringSoon ? <TriangleAlert className="size-6" /> : <Clock3 className="size-6" />}
+                    </div>
+                    <div>
+                        <p className="font-apple text-sm font-medium text-sub-2.5">{t('feature.auth.demoSession.remainingLabel')}</p>
+                        <p className="mt-1 font-apple text-[1.875rem] leading-none font-semibold tracking-[-0.04em] text-sub-1">
+                            {sessionInfo?.countdownLabel ?? '--:--'}
+                        </p>
+                        <p className="mt-1 font-apple text-sm text-sub-2.5">
+                            {sessionInfo
+                                ? t('feature.auth.demoSession.remainingApprox', {minutes: sessionInfo.remainingRoundedMinutes})
+                                : t('feature.auth.demoSession.remainingFallback')}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default DemoSessionBanner;


### PR DESCRIPTION
## Motivation

체험 계정 사용자가 현재 임시 세션이라는 사실과 남은 제한 시간을 더 분명하게 인지하도록 공통 레이아웃의 상태 표시를 강화했습니다.

- 티켓: [DUT-946](https://gom3.atlassian.net/browse/DUT-946)
- 배경: 기존에는 체험 상태 표시가 약해서 사용자가 정식 계정처럼 계속 사용하려는 혼란이 발생했습니다.
- 목표: 체험 계정 여부, 남은 시간, 회원가입 전환 필요성을 만료 전 단계부터 자연스럽게 이해할 수 있게 합니다.

<br>

## Key Changes

- 체험 세션 계산 로직을 helper로 분리해 `demoStartDate` 기준 남은 시간, 만료 여부, 곧 만료 상태를 공통으로 계산하도록 정리했습니다.
- 인증 레이아웃 상단에 체험 전용 배너를 추가해 `체험 계정`, `회원가입 전환 필요`, `남은 시간`을 한 번에 노출하도록 개선했습니다.
- 남은 시간을 큰 카운트다운과 `약 N분 남음` 문구로 함께 보여주고, 10분 이하 구간에서는 경고 톤 문구로 전환되도록 구성했습니다.
- 관련 레이아웃 테스트를 보강하고, 배너 문구용 다국어 키를 추가했습니다.

<br>

## To Reviewers

- 특히 봐야 할 파일: `apps/app/src/widgets/layouts/auth-layout.tsx`, `apps/app/src/widgets/layouts/demo-session-banner.tsx`
- 중점적으로 봐야 할 로직: `demoStartDate` 기반 남은 시간 계산과 만료 시 logout 유지 여부
- 우려되는 지점 / 확인이 필요한 부분: 체험 세션 지속시간은 기존과 동일하게 `3_540_000ms` 를 유지했습니다. 실제 의도된 체험 길이가 59분인지 운영 기준만 한 번 더 확인해 주세요.
- 실행한 검증: `pnpm --dir apps/app test:run src/widgets/layouts/__tests__/auth-layout.test.tsx src/features/auth/__tests__/index.test.tsx`, `pnpm --dir apps/app exec eslint src/widgets/layouts/auth-layout.tsx src/widgets/layouts/demo-session-banner.tsx src/widgets/layouts/__tests__/auth-layout.test.tsx src/features/auth/model/demo-session.ts`, `pnpm --dir apps/app type-check`


[DUT-946]: https://gom3.atlassian.net/browse/DUT-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ