### PR TITLE
[DUT-947]: 체험 만료 회원가입 전환 플로우 추가

### DIFF
--- a/apps/app/src/features/auth/__tests__/index.test.tsx
+++ b/apps/app/src/features/auth/__tests__/index.test.tsx
@@ -84,6 +84,7 @@ describe('useAuth', () => {
             accountMe: {accountId: 9, wardId: 99, nurseId: 19} as never,
             accountMeStatus: 'success',
             isAuth: true,
+            isDemoExpired: false,
             accessToken: 'old-token',
             accountId: 9,
             nurseId: 19,
@@ -149,5 +150,18 @@ describe('useAuth', () => {
             nurseId: 19,
             wardId: 99,
         });
+    });
+
+    it('marks the demo session as expired during bootstrap instead of logging out', () => {
+        useAuthStore.setState({
+            demoStartDate: '2026-02-01T00:00:00.000Z',
+            isDemoExpired: false,
+        });
+
+        vi.mocked(AccountAPI.getAccountMe).mockResolvedValueOnce({accountId: 9, wardId: 99, nurseId: 19} as never);
+
+        renderHook(() => useAuth(true));
+
+        expect(useAuthStore.getState().isDemoExpired).toBe(true);
     });
 });

--- a/apps/app/src/features/auth/index.ts
+++ b/apps/app/src/features/auth/index.ts
@@ -7,6 +7,7 @@ import useTutorialUseCase from '@/features/tutorial';
 import {AccountAPI, AuthAPI} from '@/shared/api';
 import {setAccessToken} from '@/shared/api/client';
 import ROUTE from '@/shared/constant/path';
+import {buildDemoSignupLoginPath, isDemoSessionExpired} from './model/demo-session';
 import {executeLoginRedirect, getLoginRedirectDecision} from './model/login-redirect';
 import useAuthStore from './model/store';
 
@@ -15,8 +16,20 @@ type THandleLoginOptions = {
 };
 
 const useAuth = (activeEffect = false) => {
-    const {accountMe, accountMeStatus, isAuth, accessToken, nurseId, accountId, wardId, demoStartDate, _loaded, setState, resetState} =
-        useAuthStore();
+    const {
+        accountMe,
+        accountMeStatus,
+        isAuth,
+        isDemoExpired,
+        accessToken,
+        nurseId,
+        accountId,
+        wardId,
+        demoStartDate,
+        _loaded,
+        setState,
+        resetState,
+    } = useAuthStore();
     const resetRequestShiftState = useRequestShiftStore((state) => state.resetState);
     const {pathname} = useLocation();
     const {setLoading} = useLoadingUseCase();
@@ -38,6 +51,7 @@ const useAuth = (activeEffect = false) => {
         setState('accountId', null);
         setState('nurseId', null);
         setState('wardId', null);
+        setState('isDemoExpired', false);
 
         if (!options?.preserveDemoStartDate) {
             setState('demoStartDate', null);
@@ -54,6 +68,12 @@ const useAuth = (activeEffect = false) => {
 
         sendEvent(events.auth.login);
     };
+    const setDemoExpired = (expired: boolean) => {
+        setState('isDemoExpired', expired);
+    };
+    const startDemoSignupTransition = (nextPath: string = ROUTE.REGISTER) => {
+        void handleLogout(buildDemoSignupLoginPath(nextPath));
+    };
     const demoTry = async () => {
         setLoading(true);
         initTutorial();
@@ -65,6 +85,7 @@ const useAuth = (activeEffect = false) => {
         setState('nurseId', data.accountResDto.nurseId);
         setState('wardId', data.accountResDto.wardId);
         setState('isAuth', true);
+        setState('isDemoExpired', false);
         setState('accountMeStatus', 'success');
         setState('demoStartDate', new Date().toISOString());
         navigate(ROUTE.MAKE);
@@ -96,11 +117,12 @@ const useAuth = (activeEffect = false) => {
 
     useEffect(() => {
         if (_loaded && activeEffect && accessToken) {
-            if (demoStartDate && new Date(demoStartDate).getTime() + 3540000 - new Date().getTime() <= 0) {
-                void handleLogout();
-            } else {
-                void handleGetAccountMe().catch(() => undefined);
-            }
+            setDemoExpired(isDemoSessionExpired(demoStartDate));
+            void handleGetAccountMe().catch(() => undefined);
+        }
+
+        if (_loaded && activeEffect && !accessToken) {
+            setDemoExpired(false);
         }
     }, [accessToken, activeEffect, demoStartDate, _loaded]);
 
@@ -109,6 +131,7 @@ const useAuth = (activeEffect = false) => {
             accountMe: accountMe === undefined ? null : accountMe,
             accountMeStatus,
             isAuth,
+            isDemoExpired,
             accessToken,
             nurseId,
             accountId,
@@ -120,6 +143,8 @@ const useAuth = (activeEffect = false) => {
             handleGetAccountMe,
             handleLogin,
             handleLogout,
+            setDemoExpired,
+            startDemoSignupTransition,
             demoTry,
         },
     };

--- a/apps/app/src/features/auth/model/__tests__/demo-session.test.ts
+++ b/apps/app/src/features/auth/model/__tests__/demo-session.test.ts
@@ -1,0 +1,23 @@
+import {describe, expect, it} from 'vitest';
+import ROUTE from '@/shared/constant/path';
+import {buildDemoSignupLoginPath, formatDemoSessionRemainingLabel, getDemoSessionRemainingMs, isDemoSessionExpired} from '../demo-session';
+
+describe('demo-session', () => {
+    it('calculates remaining time within the demo window', () => {
+        expect(getDemoSessionRemainingMs('2026-03-25T00:00:00.000Z', new Date('2026-03-25T00:30:00.000Z').getTime())).toBeGreaterThan(0);
+    });
+
+    it('treats the demo as expired once the duration passes', () => {
+        expect(isDemoSessionExpired('2026-03-25T00:00:00.000Z', new Date('2026-03-25T01:00:00.000Z').getTime())).toBe(true);
+    });
+
+    it('formats the remaining label with padded seconds', () => {
+        expect(formatDemoSessionRemainingLabel('2026-03-25T00:00:00.000Z', new Date('2026-03-25T00:58:01.000Z').getTime())).toBe(
+            '듀팅 체험중 0:59',
+        );
+    });
+
+    it('builds the login path for the demo conversion flow', () => {
+        expect(buildDemoSignupLoginPath()).toBe(`${ROUTE.LOGIN}?reason=demo-expired&next=%2Fregister`);
+    });
+});

--- a/apps/app/src/features/auth/model/demo-session.ts
+++ b/apps/app/src/features/auth/model/demo-session.ts
@@ -1,0 +1,47 @@
+import {sanitizeInternalPath} from '@/shared/config/runtime';
+import ROUTE from '@/shared/constant/path';
+
+export const DEMO_SESSION_DURATION_MS = 3540000;
+
+const DEMO_SIGNUP_REASON = 'demo-expired';
+const toTimestamp = (demoStartDate: string | null | undefined) => {
+    if (!demoStartDate) return null;
+
+    const timestamp = new Date(demoStartDate).getTime();
+
+    return Number.isNaN(timestamp) ? null : timestamp;
+};
+
+export const getDemoSessionRemainingMs = (demoStartDate: string | null | undefined, now: number = Date.now()) => {
+    const startedAt = toTimestamp(demoStartDate);
+
+    if (startedAt === null) return 0;
+
+    return Math.max(startedAt + DEMO_SESSION_DURATION_MS - now, 0);
+};
+
+export const isDemoSessionExpired = (demoStartDate: string | null | undefined, now: number = Date.now()) =>
+    Boolean(demoStartDate) && getDemoSessionRemainingMs(demoStartDate, now) === 0;
+
+export const formatDemoSessionRemainingLabel = (demoStartDate: string | null | undefined, now: number = Date.now()) => {
+    const remainingMs = getDemoSessionRemainingMs(demoStartDate, now);
+
+    if (remainingMs <= 0) return null;
+
+    const totalSeconds = Math.ceil(remainingMs / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = `${totalSeconds % 60}`.padStart(2, '0');
+
+    return `듀팅 체험중 ${minutes}:${seconds}`;
+};
+
+export const buildDemoSignupLoginPath = (nextPath: string = ROUTE.REGISTER) => {
+    const params = new URLSearchParams({
+        reason: DEMO_SIGNUP_REASON,
+        next: sanitizeInternalPath(nextPath, ROUTE.REGISTER),
+    });
+
+    return `${ROUTE.LOGIN}?${params.toString()}`;
+};
+
+export const getIsDemoSignupLoginReason = (search: string) => new URLSearchParams(search).get('reason') === DEMO_SIGNUP_REASON;

--- a/apps/app/src/features/auth/model/store.ts
+++ b/apps/app/src/features/auth/model/store.ts
@@ -8,6 +8,7 @@ interface IState {
     accountMe: TAccount | null;
     accountMeStatus: 'idle' | 'loading' | 'success' | 'error';
     isAuth: boolean;
+    isDemoExpired: boolean;
     accessToken: string | null;
     accountId: number | null;
     nurseId: number | null;
@@ -27,6 +28,7 @@ const initialState: IState = {
     accountMe: null,
     accountMeStatus: 'idle',
     isAuth: false,
+    isDemoExpired: false,
     accessToken: null,
     accountId: null,
     nurseId: null,

--- a/apps/app/src/features/refresh/index.ts
+++ b/apps/app/src/features/refresh/index.ts
@@ -6,7 +6,8 @@ import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 
 export default function useRefresh() {
     const {
-        actions: {handleLogout, handleLogin},
+        state: {isDemoExpired},
+        actions: {handleLogout, handleLogin, startDemoSignupTransition},
     } = useAuth();
     const {t} = useTypedTranslation();
     const refresh = useCallback(async () => {
@@ -20,11 +21,16 @@ export default function useRefresh() {
 
             return accessToken as string;
         } catch {
+            if (isDemoExpired) {
+                startDemoSignupTransition();
+                throw new Error('refresh_failed');
+            }
+
             toast.error(t('feature.auth.sessionExpired'));
             await handleLogout();
             throw new Error('refresh_failed');
         }
-    }, [handleLogin, handleLogout, t]);
+    }, [handleLogin, handleLogout, isDemoExpired, startDemoSignupTransition, t]);
 
     return {refresh};
 }

--- a/apps/app/src/features/refresh/index.ts
+++ b/apps/app/src/features/refresh/index.ts
@@ -4,6 +4,8 @@ import useAuth from '@/features/auth';
 import axiosInstance from '@/shared/api/client';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 
+export const REFRESH_DEMO_EXPIRED_REDIRECT_ERROR = 'refresh_demo_expired_redirect';
+
 export default function useRefresh() {
     const {
         state: {isDemoExpired},
@@ -23,7 +25,7 @@ export default function useRefresh() {
         } catch {
             if (isDemoExpired) {
                 startDemoSignupTransition();
-                throw new Error('refresh_failed');
+                throw new Error(REFRESH_DEMO_EXPIRED_REDIRECT_ERROR);
             }
 
             toast.error(t('feature.auth.sessionExpired'));

--- a/apps/app/src/pages/login/__tests__/index.test.tsx
+++ b/apps/app/src/pages/login/__tests__/index.test.tsx
@@ -1,0 +1,39 @@
+import type {ReactNode} from 'react';
+import {MemoryRouter, Route, Routes} from 'react-router';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import ROUTE from '@/shared/constant/path';
+import {render, screen} from '@/shared/util/test-utils';
+import LoginPage from '../index';
+
+vi.mock('react-responsive-carousel', () => ({
+    Carousel: ({children}: {children: ReactNode}) => <div>{children}</div>,
+}));
+
+describe('LoginPage', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    beforeEach(() => {
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.net');
+        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.net');
+    });
+
+    it('shows demo conversion guidance and keeps the requested next path', () => {
+        render(
+            <MemoryRouter initialEntries={[`${ROUTE.LOGIN}?reason=demo-expired&next=%2Fregister`]}>
+                <Routes>
+                    <Route path={ROUTE.LOGIN} element={<LoginPage />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('회원가입하고 이어서 사용하기')).toBeInTheDocument();
+
+        const kakaoLink = screen.getByRole('link', {name: '카카오 계정으로 시작하기'});
+        const url = new URL(kakaoLink.getAttribute('href') ?? '');
+
+        expect(url.pathname).toBe('/oauth2/authorization/kakao');
+        expect(url.searchParams.get('nextPageUrl')).toBe('https://app.dutying.net/register');
+    });
+});

--- a/apps/app/src/pages/login/__tests__/index.test.tsx
+++ b/apps/app/src/pages/login/__tests__/index.test.tsx
@@ -9,6 +9,31 @@ vi.mock('react-responsive-carousel', () => ({
     Carousel: ({children}: {children: ReactNode}) => <div>{children}</div>,
 }));
 
+vi.mock('@/shared/hook/use-typed-translation', () => ({
+    useTypedTranslation: () => ({
+        t: (key: string) => {
+            const translations: Record<string, string> = {
+                'page.login.title': '로그인',
+                'page.login.description': '소셜 계정으로 듀팅을 시작해 보세요.',
+                'page.login.kakaoCta': '카카오 계정으로 시작하기',
+                'page.login.appleCta': 'Apple 계정으로 시작하기',
+                'page.login.termsPrefix': '버튼을 누르면',
+                'page.login.termsOfService': '서비스 약관,',
+                'page.login.privacyPolicy': '개인정보 취급 방침',
+                'page.login.termsSuffix': '에 동의하신 것으로 간주합니다.',
+                'page.login.demoExpired.title': '회원가입하고 이어서 사용하기',
+                'page.login.demoExpired.description':
+                    '체험 시간은 종료되었지만, 지금 가입하면 정식 계정 등록 절차를 바로 시작할 수 있어요.',
+                'page.login.demoExpired.bannerTitle': '체험 종료 후 전환 안내',
+                'page.login.demoExpired.bannerDescription':
+                    '정식 전환 API는 준비 중이라, 이번 단계에서는 로그인 후 회원가입 절차로 연결해 드려요.',
+            };
+
+            return translations[key] ?? key;
+        },
+    }),
+}));
+
 describe('LoginPage', () => {
     afterEach(() => {
         vi.unstubAllEnvs();

--- a/apps/app/src/pages/login/index.tsx
+++ b/apps/app/src/pages/login/index.tsx
@@ -4,19 +4,19 @@ import {getIsDemoSignupLoginReason} from '@/features/auth/model/demo-session';
 import {AppleIcon, BackCircle, FullLogo, KakaoIcon, LogoSymbolFill, NextCircle} from '@/shared/assets/svg';
 import {buildAuthAuthorizeUrl, RUNTIME_CONFIG, sanitizeInternalPath} from '@/shared/config/runtime';
 import ROUTE from '@/shared/constant/path';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import 'react-responsive-carousel/lib/styles/carousel.min.css'; // requires a loader
 import './index.css';
 
 const LoginPage = () => {
     const navigate = useNavigate();
+    const {t} = useTypedTranslation();
     const {search} = useLocation();
     const params = new URLSearchParams(search);
     const nextPath = sanitizeInternalPath(params.get('next'), ROUTE.MAKE);
     const isDemoSignupFlow = getIsDemoSignupLoginReason(search);
-    const title = isDemoSignupFlow ? '회원가입하고 이어서 사용하기' : '로그인';
-    const description = isDemoSignupFlow
-        ? '체험 시간은 종료되었지만, 지금 가입하면 정식 계정 등록 절차를 바로 시작할 수 있어요.'
-        : '소셜 계정으로 듀팅을 시작해 보세요.';
+    const title = isDemoSignupFlow ? t('page.login.demoExpired.title') : t('page.login.title');
+    const description = isDemoSignupFlow ? t('page.login.demoExpired.description') : t('page.login.description');
 
     return (
         <div className="flex w-screen">
@@ -57,9 +57,9 @@ const LoginPage = () => {
                 <div className="flex flex-col">
                     {isDemoSignupFlow ? (
                         <div className="mb-6 rounded-[1.25rem] border border-main-3/40 bg-main-light px-6 py-5">
-                            <p className="font-apple text-sm font-semibold text-main-1">체험 종료 후 전환 안내</p>
+                            <p className="font-apple text-sm font-semibold text-main-1">{t('page.login.demoExpired.bannerTitle')}</p>
                             <p className="mt-2 font-apple text-[0.9375rem] leading-6 text-sub-2.5">
-                                정식 전환 API는 준비 중이라, 이번 단계에서는 로그인 후 회원가입 절차로 연결해 드려요.
+                                {t('page.login.demoExpired.bannerDescription')}
                             </p>
                         </div>
                     ) : null}
@@ -70,25 +70,25 @@ const LoginPage = () => {
                         className="mt-10.5 flex h-25 w-142.5 items-center justify-center rounded-[1.25rem] bg-[#FEE500] shadow-banner"
                     >
                         <KakaoIcon className="mr-12.5 h-8.5 w-9" />
-                        <div className="font-apple text-[2rem] text-sub-1">카카오 계정으로 시작하기</div>
+                        <div className="font-apple text-[2rem] text-sub-1">{t('page.login.kakaoCta')}</div>
                     </a>
                     <a
                         href={buildAuthAuthorizeUrl('apple', nextPath)}
                         className="mt-6 flex h-25 w-142.5 items-center justify-center rounded-[1.25rem] bg-[#231F20] shadow-banner"
                     >
                         <AppleIcon className="mr-12.5 h-8.5 w-9" />
-                        <div className="font-apple text-[2rem] text-white">Apple 계정으로 시작하기</div>
+                        <div className="font-apple text-[2rem] text-white">{t('page.login.appleCta')}</div>
                     </a>
                 </div>
                 <div className="flex font-apple text-[1rem] text-sub-3">
-                    버튼을 누르면
+                    {t('page.login.termsPrefix')}
                     <a href={RUNTIME_CONFIG.docs.termsOfService} className="ml-[.5rem] underline underline-offset-[.1875rem]">
-                        서비스 약관,
+                        {t('page.login.termsOfService')}
                     </a>
                     <a href={RUNTIME_CONFIG.docs.privacyPolicy} className="ml-[.5rem] underline underline-offset-[.1875rem]">
-                        개인정보 취급 방침
+                        {t('page.login.privacyPolicy')}
                     </a>
-                    에 동의하신 것으로 간주합니다.
+                    {t('page.login.termsSuffix')}
                 </div>
             </div>
         </div>

--- a/apps/app/src/pages/login/index.tsx
+++ b/apps/app/src/pages/login/index.tsx
@@ -1,13 +1,22 @@
 import {Carousel} from 'react-responsive-carousel';
-import {useNavigate} from 'react-router';
+import {useLocation, useNavigate} from 'react-router';
+import {getIsDemoSignupLoginReason} from '@/features/auth/model/demo-session';
 import {AppleIcon, BackCircle, FullLogo, KakaoIcon, LogoSymbolFill, NextCircle} from '@/shared/assets/svg';
-import {buildAuthAuthorizeUrl, RUNTIME_CONFIG} from '@/shared/config/runtime';
+import {buildAuthAuthorizeUrl, RUNTIME_CONFIG, sanitizeInternalPath} from '@/shared/config/runtime';
 import ROUTE from '@/shared/constant/path';
 import 'react-responsive-carousel/lib/styles/carousel.min.css'; // requires a loader
 import './index.css';
 
 const LoginPage = () => {
     const navigate = useNavigate();
+    const {search} = useLocation();
+    const params = new URLSearchParams(search);
+    const nextPath = sanitizeInternalPath(params.get('next'), ROUTE.MAKE);
+    const isDemoSignupFlow = getIsDemoSignupLoginReason(search);
+    const title = isDemoSignupFlow ? '회원가입하고 이어서 사용하기' : '로그인';
+    const description = isDemoSignupFlow
+        ? '체험 시간은 종료되었지만, 지금 가입하면 정식 계정 등록 절차를 바로 시작할 수 있어요.'
+        : '소셜 계정으로 듀팅을 시작해 보세요.';
 
     return (
         <div className="flex w-screen">
@@ -46,16 +55,25 @@ const LoginPage = () => {
                     <FullLogo className="h-12.5 w-45.25" />
                 </div>
                 <div className="flex flex-col">
-                    <h1 className="font-apple text-[2rem] font-semibold text-text-1">로그인</h1>
+                    {isDemoSignupFlow ? (
+                        <div className="mb-6 rounded-[1.25rem] border border-main-3/40 bg-main-light px-6 py-5">
+                            <p className="font-apple text-sm font-semibold text-main-1">체험 종료 후 전환 안내</p>
+                            <p className="mt-2 font-apple text-[0.9375rem] leading-6 text-sub-2.5">
+                                정식 전환 API는 준비 중이라, 이번 단계에서는 로그인 후 회원가입 절차로 연결해 드려요.
+                            </p>
+                        </div>
+                    ) : null}
+                    <h1 className="font-apple text-[2rem] font-semibold text-text-1">{title}</h1>
+                    <p className="mt-3 font-apple text-[1rem] leading-6 text-gray-3">{description}</p>
                     <a
-                        href={buildAuthAuthorizeUrl('kakao')}
+                        href={buildAuthAuthorizeUrl('kakao', nextPath)}
                         className="mt-10.5 flex h-25 w-142.5 items-center justify-center rounded-[1.25rem] bg-[#FEE500] shadow-banner"
                     >
                         <KakaoIcon className="mr-12.5 h-8.5 w-9" />
                         <div className="font-apple text-[2rem] text-sub-1">카카오 계정으로 시작하기</div>
                     </a>
                     <a
-                        href={buildAuthAuthorizeUrl('apple')}
+                        href={buildAuthAuthorizeUrl('apple', nextPath)}
                         className="mt-6 flex h-25 w-142.5 items-center justify-center rounded-[1.25rem] bg-[#231F20] shadow-banner"
                     >
                         <AppleIcon className="mr-12.5 h-8.5 w-9" />

--- a/apps/app/src/pages/refresh/__tests__/index.test.tsx
+++ b/apps/app/src/pages/refresh/__tests__/index.test.tsx
@@ -1,12 +1,13 @@
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import useRefresh from '@/features/refresh';
+import useRefresh, {REFRESH_DEMO_EXPIRED_REDIRECT_ERROR} from '@/features/refresh';
 import ROUTE from '@/shared/constant/path';
 import {render, waitFor} from '@/shared/util/test-utils';
 import RefreshPage from '../index';
 
 vi.mock('@/features/refresh', () => ({
     default: vi.fn(),
+    REFRESH_DEMO_EXPIRED_REDIRECT_ERROR: 'refresh_demo_expired_redirect',
 }));
 
 vi.mock('@/shared/hook/use-typed-translation', () => ({
@@ -99,5 +100,23 @@ describe('RefreshPage', () => {
         await waitFor(() => {
             expect(replaceSpy).toHaveBeenCalledWith(ROUTE.ROOT);
         });
+    });
+
+    it('does not overwrite the demo-expired signup redirect when refresh already redirected', async () => {
+        refreshSpy.mockRejectedValue(new Error(REFRESH_DEMO_EXPIRED_REDIRECT_ERROR));
+
+        render(
+            <MemoryRouter initialEntries={['/refresh?next=%2Fmake']}>
+                <Routes>
+                    <Route path={ROUTE.REFRESH} element={<RefreshPage />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(refreshSpy).toHaveBeenCalled();
+        });
+
+        expect(replaceSpy).not.toHaveBeenCalled();
     });
 });

--- a/apps/app/src/pages/refresh/index.tsx
+++ b/apps/app/src/pages/refresh/index.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 import {useLocation} from 'react-router-dom';
-import useRefresh from '@/features/refresh';
+import useRefresh, {REFRESH_DEMO_EXPIRED_REDIRECT_ERROR} from '@/features/refresh';
 import ROUTE from '@/shared/constant/path';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import PageState from '@/shared/ui/PageState';
@@ -22,8 +22,12 @@ function RefreshPage() {
                 if (cancelled) return;
 
                 location.replace(next ?? ROUTE.MAKE);
-            } catch {
+            } catch (error) {
                 if (cancelled) return;
+
+                if (error instanceof Error && error.message === REFRESH_DEMO_EXPIRED_REDIRECT_ERROR) {
+                    return;
+                }
 
                 location.replace(ROUTE.ROOT);
             }

--- a/apps/app/src/shared/locales/en.ts
+++ b/apps/app/src/shared/locales/en.ts
@@ -12,6 +12,23 @@ export const en: TLocale = {
         landing: {
             title: 'Duty Schedule\nNow Easier!',
         },
+        login: {
+            title: 'Sign in',
+            description: 'Start Dutying with your social account.',
+            kakaoCta: 'Continue with Kakao',
+            appleCta: 'Continue with Apple',
+            termsPrefix: 'By continuing, you agree to the',
+            termsOfService: 'Terms of Service,',
+            privacyPolicy: 'Privacy Policy',
+            termsSuffix: '.',
+            demoExpired: {
+                title: 'Sign up and keep going',
+                description: 'Your demo time has ended, but you can immediately continue with the full signup flow.',
+                bannerTitle: 'Demo ended',
+                bannerDescription:
+                    'The full conversion API is still in progress, so for now we will guide you through login and signup first.',
+            },
+        },
         register: {
             nurse: {
                 submitting: 'Processing...',

--- a/apps/app/src/shared/locales/ko.ts
+++ b/apps/app/src/shared/locales/ko.ts
@@ -10,6 +10,22 @@ export const ko = {
         landing: {
             title: '근무표\n이제 더 간편하게!',
         },
+        login: {
+            title: '로그인',
+            description: '소셜 계정으로 듀팅을 시작해 보세요.',
+            kakaoCta: '카카오 계정으로 시작하기',
+            appleCta: 'Apple 계정으로 시작하기',
+            termsPrefix: '버튼을 누르면',
+            termsOfService: '서비스 약관,',
+            privacyPolicy: '개인정보 취급 방침',
+            termsSuffix: '에 동의하신 것으로 간주합니다.',
+            demoExpired: {
+                title: '회원가입하고 이어서 사용하기',
+                description: '체험 시간은 종료되었지만, 지금 가입하면 정식 계정 등록 절차를 바로 시작할 수 있어요.',
+                bannerTitle: '체험 종료 후 전환 안내',
+                bannerDescription: '정식 전환 API는 준비 중이라, 이번 단계에서는 로그인 후 회원가입 절차로 연결해 드려요.',
+            },
+        },
         register: {
             nurse: {
                 submitting: '처리 중...',

--- a/apps/app/src/widgets/layouts/__tests__/auth-layout.test.tsx
+++ b/apps/app/src/widgets/layouts/__tests__/auth-layout.test.tsx
@@ -3,6 +3,7 @@ import {describe, expect, it, vi, beforeEach} from 'vitest';
 import useAuth from '@/features/auth';
 import ROUTE from '@/shared/constant/path';
 import {render, screen, waitFor} from '@/shared/util/test-utils';
+import useInterval from '@/shared/util/useInterval';
 import {AuthLayout} from '../auth-layout';
 
 vi.mock('@/features/auth', () => ({
@@ -14,19 +15,30 @@ vi.mock('@/shared/util/useInterval', () => ({
 }));
 
 const mockedUseAuth = vi.mocked(useAuth);
+const mockedUseInterval = vi.mocked(useInterval);
+const defaultHandleLogout = vi.fn();
+const defaultSetDemoExpired = vi.fn();
+const defaultStartDemoSignupTransition = vi.fn();
 
 describe('AuthLayout', () => {
     beforeEach(() => {
+        defaultHandleLogout.mockReset();
+        defaultSetDemoExpired.mockReset();
+        defaultStartDemoSignupTransition.mockReset();
+        mockedUseInterval.mockReset();
         mockedUseAuth.mockReturnValue({
             state: {
                 isAuth: true,
+                isDemoExpired: false,
                 accountMe: {
                     status: 'WARD_SELECT_PENDING',
                 },
                 demoStartDate: null,
             },
             actions: {
-                handleLogout: vi.fn(),
+                handleLogout: defaultHandleLogout,
+                setDemoExpired: defaultSetDemoExpired,
+                startDemoSignupTransition: defaultStartDemoSignupTransition,
             },
         } as never);
     });
@@ -35,11 +47,14 @@ describe('AuthLayout', () => {
         mockedUseAuth.mockReturnValue({
             state: {
                 isAuth: false,
+                isDemoExpired: false,
                 accountMe: null,
                 demoStartDate: null,
             },
             actions: {
-                handleLogout: vi.fn(),
+                handleLogout: defaultHandleLogout,
+                setDemoExpired: defaultSetDemoExpired,
+                startDemoSignupTransition: defaultStartDemoSignupTransition,
             },
         } as never);
 
@@ -102,13 +117,16 @@ describe('AuthLayout', () => {
         mockedUseAuth.mockReturnValue({
             state: {
                 isAuth: true,
+                isDemoExpired: false,
                 accountMe: {
                     status: 'LINKED',
                 },
                 demoStartDate: null,
             },
             actions: {
-                handleLogout: vi.fn(),
+                handleLogout: defaultHandleLogout,
+                setDemoExpired: defaultSetDemoExpired,
+                startDemoSignupTransition: defaultStartDemoSignupTransition,
             },
         } as never);
 
@@ -128,5 +146,37 @@ describe('AuthLayout', () => {
         });
 
         expect(screen.queryByText('register page')).not.toBeInTheDocument();
+    });
+
+    it('opens the demo conversion modal instead of logging out when demo time expires', async () => {
+        mockedUseAuth.mockReturnValue({
+            state: {
+                isAuth: true,
+                isDemoExpired: true,
+                accountMe: {
+                    status: 'DEMO',
+                },
+                demoStartDate: '2026-03-25T00:00:00.000Z',
+            },
+            actions: {
+                handleLogout: defaultHandleLogout,
+                setDemoExpired: defaultSetDemoExpired,
+                startDemoSignupTransition: defaultStartDemoSignupTransition,
+            },
+        } as never);
+
+        render(
+            <MemoryRouter initialEntries={[ROUTE.MAKE]}>
+                <Routes>
+                    <Route element={<AuthLayout />}>
+                        <Route path={ROUTE.MAKE} element={<div>make page</div>} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('회원가입하고 이어서 사용')).toBeInTheDocument();
+        expect(defaultHandleLogout).not.toHaveBeenCalled();
     });
 });

--- a/apps/app/src/widgets/layouts/auth-layout.tsx
+++ b/apps/app/src/widgets/layouts/auth-layout.tsx
@@ -2,16 +2,18 @@ import {useEffect, useState} from 'react';
 import {Helmet} from 'react-helmet';
 import {Outlet, useLocation, useNavigate} from 'react-router';
 import useAuth from '@/features/auth';
+import {formatDemoSessionRemainingLabel, getDemoSessionRemainingMs} from '@/features/auth/model/demo-session';
 import ROUTE from '@/shared/constant/path';
 import useInterval from '@/shared/util/useInterval';
+import {DemoExpiredModal} from './demo-expired-modal';
 
 export const AuthLayout = () => {
     const [demoRemainTime, setDemoRemainTime] = useState<string | null>(null);
     const navigate = useNavigate();
     const {pathname} = useLocation();
     const {
-        state: {isAuth, accountMe, demoStartDate},
-        actions: {handleLogout},
+        state: {isAuth, isDemoExpired, accountMe, demoStartDate},
+        actions: {handleLogout, setDemoExpired, startDemoSignupTransition},
     } = useAuth();
 
     useEffect(() => {
@@ -26,14 +28,32 @@ export const AuthLayout = () => {
 
     useInterval(
         () => {
-            if (demoStartDate && new Date(demoStartDate).getTime() + 3540000 - new Date().getTime() > 0) {
-                setDemoRemainTime(
-                    `듀팅 체험중 ${Math.ceil((new Date(demoStartDate).getTime() + 3540000 - new Date().getTime()) / 1000 / 60)}:${Math.ceil(
-                        ((new Date(demoStartDate).getTime() + 3540000 - new Date().getTime()) / 1000) % 60,
-                    )}`,
-                );
-            } else {
-                handleLogout();
+            if (!demoStartDate) {
+                setDemoRemainTime(null);
+
+                if (isDemoExpired) {
+                    setDemoExpired(false);
+                }
+
+                return;
+            }
+
+            const remainingMs = getDemoSessionRemainingMs(demoStartDate);
+
+            if (remainingMs > 0) {
+                setDemoRemainTime(formatDemoSessionRemainingLabel(demoStartDate));
+
+                if (isDemoExpired) {
+                    setDemoExpired(false);
+                }
+
+                return;
+            }
+
+            setDemoRemainTime(null);
+
+            if (!isDemoExpired) {
+                setDemoExpired(true);
             }
         },
         demoStartDate ? 1000 : null,
@@ -42,7 +62,12 @@ export const AuthLayout = () => {
     return (
         isAuth && (
             <div className="h-full w-full">
-                <Helmet title={demoRemainTime ?? '듀팅 | Dutying'} />
+                <Helmet title={isDemoExpired ? '체험이 종료되었어요 | Dutying' : (demoRemainTime ?? '듀팅 | Dutying')} />
+                <DemoExpiredModal
+                    open={isDemoExpired}
+                    onPrimaryAction={() => startDemoSignupTransition()}
+                    onSecondaryAction={() => void handleLogout(ROUTE.ROOT)}
+                />
                 <Outlet />
             </div>
         )

--- a/apps/app/src/widgets/layouts/demo-expired-modal.tsx
+++ b/apps/app/src/widgets/layouts/demo-expired-modal.tsx
@@ -1,0 +1,54 @@
+import Button from '@/shared/ui/form-controls/Button';
+
+interface IDemoExpiredModalProps {
+    open: boolean;
+    onPrimaryAction: () => void;
+    onSecondaryAction: () => void;
+}
+
+export function DemoExpiredModal({open, onPrimaryAction, onSecondaryAction}: IDemoExpiredModalProps) {
+    if (!open) return null;
+
+    return (
+        <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-[#121726]/58 px-6 py-10 backdrop-blur-[2px]">
+            <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="demo-expired-modal-title"
+                aria-describedby="demo-expired-modal-description"
+                className="w-full max-w-[34rem] rounded-[28px] border border-main-3/30 bg-white px-8 py-9 shadow-[0_24px_80px_rgba(18,23,38,0.18)]"
+            >
+                <div className="inline-flex rounded-full bg-main-light px-4 py-2 font-apple text-sm font-semibold text-main-1">
+                    체험 종료
+                </div>
+                <h2 id="demo-expired-modal-title" className="mt-5 font-apple text-[2rem] font-semibold tracking-[-0.02em] text-sub-1">
+                    체험 시간이 종료되었어요
+                </h2>
+                <p id="demo-expired-modal-description" className="mt-3 font-apple text-base leading-7 text-gray-3">
+                    지금 회원가입을 진행하면 정식 계정 등록 절차를 바로 이어갈 수 있어요. 체험 계정 전환 API는 준비 중이라, 이번 단계에서는
+                    로그인 후 회원가입 흐름으로 안내해 드릴게요.
+                </p>
+                <div className="mt-6 rounded-[20px] border border-gray-6 bg-[#F8F9FC] px-5 py-4">
+                    <p className="font-apple text-sm font-semibold text-sub-2.5">지금 가능한 다음 단계</p>
+                    <p className="mt-2 font-apple text-sm leading-6 text-gray-3">
+                        회원가입 또는 로그인 후 병동 연결 절차를 진행할 수 있어요. 체험 데이터 승계는 DUT-948 연동 이후 이어질 예정입니다.
+                    </p>
+                </div>
+                <div className="mt-7 flex flex-col gap-3 sm:flex-row">
+                    <Button type="button" size="md" className="h-13 flex-1 rounded-[16px] text-lg" onClick={onPrimaryAction}>
+                        회원가입하고 이어서 사용
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="md"
+                        className="h-13 flex-1 rounded-[16px] text-lg"
+                        onClick={onSecondaryAction}
+                    >
+                        로그아웃
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Motivation

체험 계정 만료 시점에 프론트가 즉시 로그아웃을 시켜 사용자가 다음 행동을 이해하기 어려웠습니다.
이번 변경은 만료 상태를 공통으로 판단하고, 회원가입 전환 모달과 로그인 유입 문구를 추가해 DUT-948 API 연동 전에도 자연스럽게 전환 플로우를 이어갈 수 있게 하는 데 목적이 있습니다.

- 티켓: [DUT-947](https://gom3.atlassian.net/browse/DUT-947)
- 배경: 체험 시간이 끝나면 별도 안내 없이 접근이 끊기던 흐름을 정리해야 했습니다.
- 목표: 자동 로그아웃 대신 회원가입 전환 모달과 최소 범위 접근 제어를 제공하고, 이후 API 연동 경계를 미리 만들어 둡니다.

<br>

## Key Changes

- 체험 만료 계산 로직을 `demo-session` 모델로 분리하고, auth store에 `isDemoExpired` 상태와 `startDemoSignupTransition` 액션을 추가했습니다.
- `AuthLayout`의 자동 로그아웃을 제거하고, 만료 시 전체 화면 전환 모달을 띄워 `회원가입하고 이어서 사용` 또는 `로그아웃`만 가능하도록 막았습니다.
- 로그인 페이지가 `demo-expired` 유입 이유와 `next=/register`를 해석해, 전환 안내 문구와 회원가입용 OAuth 진입 링크를 보여주도록 변경했습니다.
- refresh 실패가 데모 만료 상태에서 발생하면 일반 세션 만료 토스트 대신 전환 로그인 플로우로 보내도록 맞췄습니다.
- 관련 단위 테스트를 추가해 만료 계산, auth bootstrap, 레이아웃 모달 노출, 로그인 유입 링크를 검증했습니다.

<br>

## To Reviewers

- 특히 봐야 할 파일: `apps/app/src/features/auth/index.ts`, `apps/app/src/widgets/layouts/auth-layout.tsx`, `apps/app/src/widgets/layouts/demo-expired-modal.tsx`, `apps/app/src/pages/login/index.tsx`
- 중점적으로 봐야 할 로직: 데모 만료 판정 시점, 만료 후 허용 액션을 모달 CTA로 제한한 부분, `startDemoSignupTransition` 경계가 DUT-948 API 연동 지점으로 적절한지
- 우려되는 지점 / 확인이 필요한 부분: 실제 전환 API가 아직 없어 현재 CTA는 로그인/회원가입 화면으로 보내는 수준이며, 체험 데이터 승계는 후속 티켓에서 연결해야 합니다.


[DUT-947]: https://gom3.atlassian.net/browse/DUT-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ