### PR TITLE
[-]: 신규 패키지 changeset 추가

### DIFF
--- a/.changeset/calm-wolves-fix.md
+++ b/.changeset/calm-wolves-fix.md
@@ -1,0 +1,7 @@
+---
+'@dutying/config': minor
+'@dutying/docs': minor
+'@dutying/landing': minor
+---
+
+공용 설정 패키지와 별도 landing, docs 워크스페이스를 초기 분리합니다.

--- a/.changeset/fair-swans-kick.md
+++ b/.changeset/fair-swans-kick.md
@@ -1,5 +1,5 @@
 ---
-'dutying-web': minor
+'@dutying/app': minor
 ---
 
 근무표 확인 및 편집을 위한 duty 페이지를 추가하고 관련 편집 흐름을 개선합니다.

--- a/.changeset/smooth-crabs-doubt.md
+++ b/.changeset/smooth-crabs-doubt.md
@@ -1,5 +1,5 @@
 ---
-'dutying-web': minor
+'@dutying/app': minor
 ---
 
 센트리 추적 추가


### PR DESCRIPTION
## 변경 사항
- 기존 changeset 두 개의 대상 패키지를 실제 워크스페이스인 `@dutying/app`으로 수정
- 신규 패키지인 `@dutying/config`, `@dutying/docs`, `@dutying/landing`용 changeset 추가
- 다음 릴리스 PR에서 신규 패키지 changelog가 비지 않도록 보완

## 검증
- `/Users/inseo/Documents/github/dutying-web/node_modules/.bin/changeset status --verbose --since=develop`