### PR TITLE
[DUT-973]: 사이드바 계정 관리 탭 반영

### DIFF
--- a/apps/app/src/shared/assets/svg/AccountIcon.tsx
+++ b/apps/app/src/shared/assets/svg/AccountIcon.tsx
@@ -1,0 +1,15 @@
+import type {SVGProps} from 'react';
+
+const SvgAccountIcon = (props: SVGProps<SVGSVGElement>) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 34 34" {...props}>
+        <path
+            stroke="#ABABB4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2.4}
+            d="M11.333 12.75a5.667 5.667 0 1 0 11.334 0 5.667 5.667 0 0 0-11.334 0ZM6.375 29.75v-3.542a7.083 7.083 0 0 1 7.083-7.083h7.084a7.083 7.083 0 0 1 7.083 7.083v3.542"
+        />
+    </svg>
+);
+
+export default SvgAccountIcon;

--- a/apps/app/src/shared/assets/svg/AccountIconSelected.tsx
+++ b/apps/app/src/shared/assets/svg/AccountIconSelected.tsx
@@ -1,0 +1,16 @@
+import type {SVGProps} from 'react';
+
+const SvgAccountIconSelected = (props: SVGProps<SVGSVGElement>) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 34 34" {...props}>
+        <circle cx="17" cy="17" r="14" fill="#844AFF" />
+        <path
+            stroke="#FDFCFE"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2.2}
+            d="M12.75 14.167a4.25 4.25 0 1 0 8.5 0 4.25 4.25 0 0 0-8.5 0ZM9.031 26.917V24.26a5.313 5.313 0 0 1 5.313-5.313h5.312a5.313 5.313 0 0 1 5.313 5.313v2.656"
+        />
+    </svg>
+);
+
+export default SvgAccountIconSelected;

--- a/apps/app/src/shared/assets/svg/index.ts
+++ b/apps/app/src/shared/assets/svg/index.ts
@@ -2,6 +2,8 @@ export {default as LogoV2} from './LogoV2';
 export {default as LogoV2Black} from './LogoV2Black';
 export {default as AppstoreGrayIcon} from './AppstoreGrayIcon';
 export {default as AppstoreIcon} from './AppstoreIcon';
+export {default as AccountIcon} from './AccountIcon';
+export {default as AccountIconSelected} from './AccountIconSelected';
 export {default as ArrowDownIcon} from './ArrowDownIcon';
 export {default as BackIcon} from './BackIcon';
 export {default as CancelIcon} from './CancelIcon';

--- a/apps/app/src/shared/locales/en.ts
+++ b/apps/app/src/shared/locales/en.ts
@@ -9,6 +9,22 @@ export const en: TLocale = {
             errorDescription: 'Please try again shortly. If the issue continues, refresh and check again.',
             retry: 'Retry',
         },
+        navigationBar: {
+            expandAria: 'Expand sidebar',
+            foldAria: 'Collapse sidebar',
+            home: 'Schedule',
+            sections: {
+                schedule: 'Schedule',
+                settings: 'Settings',
+            },
+            items: {
+                make: 'Create schedule',
+                request: 'Request shift management',
+                member: 'Member management',
+                wardSettings: 'Duty management',
+                account: 'Account management',
+            },
+        },
         landing: {
             title: 'Duty Schedule\nNow Easier!',
         },

--- a/apps/app/src/shared/locales/ko.ts
+++ b/apps/app/src/shared/locales/ko.ts
@@ -7,6 +7,22 @@ export const ko = {
             errorDescription: '잠시 후 다시 시도해 주세요. 문제가 계속되면 새로고침 후 다시 확인해 주세요.',
             retry: '다시 시도',
         },
+        navigationBar: {
+            expandAria: '사이드바 펼치기',
+            foldAria: '사이드바 접기',
+            home: '근무표',
+            sections: {
+                schedule: '근무표',
+                settings: '근무 설정',
+            },
+            items: {
+                make: '근무표 만들기',
+                request: '신청근무 관리',
+                member: '근무자 관리',
+                wardSettings: '근무 관리',
+                account: '계정 관리',
+            },
+        },
         landing: {
             title: '근무표\n이제 더 간편하게!',
         },

--- a/apps/app/src/widgets/navigation-bar/NavigationBarItemGroup.tsx
+++ b/apps/app/src/widgets/navigation-bar/NavigationBarItemGroup.tsx
@@ -11,78 +11,81 @@ import {
     SettingIconSelected,
 } from '@/shared/assets/svg';
 import ROUTE, {type TRoute} from '@/shared/constant/path';
+import {type TI18nKey, useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import NavigationBarItem from './NavigationBarItem';
 
 type TNavItem = {
     path?: TRoute;
     icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
     selectedIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-    text: string;
+    textKey: TI18nKey;
     disabled?: boolean;
 };
 
 type TNavSection = {
-    label: string;
+    labelKey: TI18nKey;
     items: TNavItem[];
 };
 
 const sections: TNavSection[] = [
     {
-        label: '근무표',
+        labelKey: 'page.navigationBar.sections.schedule',
         items: [
             {
                 path: ROUTE.MAKE,
                 icon: DutyIcon,
                 selectedIcon: DutyIconSelected,
-                text: '근무표 만들기',
+                textKey: 'page.navigationBar.items.make',
             },
             {
                 path: ROUTE.REQUEST,
                 icon: RequestIcon,
                 selectedIcon: RequestIconSelected,
-                text: '신청근무 관리',
+                textKey: 'page.navigationBar.items.request',
             },
         ],
     },
     {
-        label: '근무 설정',
+        labelKey: 'page.navigationBar.sections.settings',
         items: [
             {
                 path: ROUTE.MEMBER,
                 icon: NurseIcon,
                 selectedIcon: NurseIconSelected,
-                text: '근무자 관리',
+                textKey: 'page.navigationBar.items.member',
             },
             {
                 path: ROUTE.WARD_SETTINGS,
                 icon: SettingIcon,
                 selectedIcon: SettingIconSelected,
-                text: '근무 관리',
+                textKey: 'page.navigationBar.items.wardSettings',
             },
             {
                 path: ROUTE.PROFILE,
                 icon: AccountIcon,
                 selectedIcon: AccountIconSelected,
-                text: '계정 관리',
+                textKey: 'page.navigationBar.items.account',
             },
         ],
     },
 ];
 const NavigationBarItemGroups = () => {
+    const {t} = useTypedTranslation();
+
     return (
         <nav className="w-full">
             {sections.map((section) => (
-                <div key={section.label}>
+                <div key={section.labelKey}>
                     <div className="my-6 h-px w-full bg-gray-6" />
-                    <div className="px-[20px] pb-[14px] text-[14px] font-medium text-gray-4">{section.label}</div>
+                    <div className="px-[20px] pb-[14px] text-[14px] font-medium text-gray-4">{t(section.labelKey)}</div>
                     <div className="mt-2 flex flex-col gap-2 px-[2px]">
                         {section.items.map((item) => (
                             <NavigationBarItem
-                                key={item.path ?? item.text}
+                                key={item.path ?? item.textKey}
                                 path={item.path}
                                 Icon={item.icon}
                                 SelectedIcon={item.selectedIcon}
-                                text={item.text}
+                                text={t(item.textKey)}
                                 disabled={item.disabled}
                             />
                         ))}

--- a/apps/app/src/widgets/navigation-bar/NavigationBarItemGroup.tsx
+++ b/apps/app/src/widgets/navigation-bar/NavigationBarItemGroup.tsx
@@ -1,4 +1,6 @@
 import {
+    AccountIcon,
+    AccountIconSelected,
     DutyIcon,
     DutyIconSelected,
     NurseIcon,
@@ -56,6 +58,12 @@ const sections: TNavSection[] = [
                 icon: SettingIcon,
                 selectedIcon: SettingIconSelected,
                 text: '근무 관리',
+            },
+            {
+                path: ROUTE.PROFILE,
+                icon: AccountIcon,
+                selectedIcon: AccountIconSelected,
+                text: '계정 관리',
             },
         ],
     },

--- a/apps/app/src/widgets/navigation-bar/__tests__/index.test.tsx
+++ b/apps/app/src/widgets/navigation-bar/__tests__/index.test.tsx
@@ -1,8 +1,40 @@
 import {MemoryRouter, Route, Routes} from 'react-router';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import ROUTE from '@/shared/constant/path';
 import {render, screen, userEvent} from '@/shared/util/test-utils';
 import NavigationBar from '..';
+
+vi.mock('@/shared/hook/use-typed-translation', () => ({
+    useTypedTranslation: () => ({
+        t: (key: string) =>
+            (
+                ({
+                    'page.navigationBar.expandAria': '사이드바 펼치기',
+                    'page.navigationBar.foldAria': '사이드바 접기',
+                    'page.navigationBar.home': '근무표',
+                    'page.navigationBar.sections.schedule': '근무표',
+                    'page.navigationBar.sections.settings': '근무 설정',
+                    'page.navigationBar.items.make': '근무표 만들기',
+                    'page.navigationBar.items.request': '신청근무 관리',
+                    'page.navigationBar.items.member': '근무자 관리',
+                    'page.navigationBar.items.wardSettings': '근무 관리',
+                    'page.navigationBar.items.account': '계정 관리',
+                }) as const
+            )[
+                key as
+                    | 'page.navigationBar.expandAria'
+                    | 'page.navigationBar.foldAria'
+                    | 'page.navigationBar.home'
+                    | 'page.navigationBar.sections.schedule'
+                    | 'page.navigationBar.sections.settings'
+                    | 'page.navigationBar.items.make'
+                    | 'page.navigationBar.items.request'
+                    | 'page.navigationBar.items.member'
+                    | 'page.navigationBar.items.wardSettings'
+                    | 'page.navigationBar.items.account'
+            ] ?? key,
+    }),
+}));
 
 describe('NavigationBar', () => {
     it('설정 섹션에 계정 관리 메뉴를 노출하고 하단 프로필 영역은 렌더링하지 않는다', () => {

--- a/apps/app/src/widgets/navigation-bar/__tests__/index.test.tsx
+++ b/apps/app/src/widgets/navigation-bar/__tests__/index.test.tsx
@@ -1,0 +1,51 @@
+import {MemoryRouter, Route, Routes} from 'react-router';
+import {describe, expect, it} from 'vitest';
+import ROUTE from '@/shared/constant/path';
+import {render, screen, userEvent} from '@/shared/util/test-utils';
+import NavigationBar from '..';
+
+describe('NavigationBar', () => {
+    it('설정 섹션에 계정 관리 메뉴를 노출하고 하단 프로필 영역은 렌더링하지 않는다', () => {
+        render(
+            <MemoryRouter initialEntries={[ROUTE.MAKE]}>
+                <NavigationBar />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByRole('button', {name: '계정 관리'})).toBeInTheDocument();
+        expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    });
+
+    it('계정 관리 메뉴를 클릭하면 프로필 페이지로 이동한다', async () => {
+        render(
+            <MemoryRouter initialEntries={[ROUTE.MAKE]}>
+                <Routes>
+                    <Route
+                        path={ROUTE.MAKE}
+                        element={
+                            <div className="flex">
+                                <NavigationBar />
+                                <div>make page</div>
+                            </div>
+                        }
+                    />
+                    <Route
+                        path={ROUTE.PROFILE}
+                        element={
+                            <div className="flex">
+                                <NavigationBar />
+                                <div>profile page</div>
+                            </div>
+                        }
+                    />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('make page')).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', {name: '계정 관리'}));
+
+        expect(await screen.findByText('profile page')).toBeInTheDocument();
+    });
+});

--- a/apps/app/src/widgets/navigation-bar/index.tsx
+++ b/apps/app/src/widgets/navigation-bar/index.tsx
@@ -3,10 +3,12 @@ import {useNavigate} from 'react-router';
 import {events, sendEvent} from '@/analytics';
 import {FoldIcon, LogoV2} from '@/shared/assets/svg';
 import ROUTE from '@/shared/constant/path';
+import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import NavigationBarItemGroups from './NavigationBarItemGroup';
 
 const NavigationBar = () => {
     const navigate = useNavigate();
+    const {t} = useTypedTranslation();
     const [isFold, setIsFold] = useState(false);
 
     // 펼친 상태: 사이드바는 숨기고 좌측 상단에 fixed 버튼만 유지
@@ -15,7 +17,7 @@ const NavigationBar = () => {
             <button
                 data-testid="navigation-bar-fold-trigger"
                 type="button"
-                aria-label="사이드바 펼치기"
+                aria-label={t('page.navigationBar.expandAria')}
                 className="fixed top-[7px] left-[14px] z-997 flex size-[42px] items-center justify-center rounded-[10px] border border-[#BFC7D4] bg-white p-[6px]"
                 onClick={() => {
                     setIsFold(false);
@@ -36,7 +38,7 @@ const NavigationBar = () => {
                 <div className="px-[20px]">
                     <button
                         type="button"
-                        aria-label="사이드바 접기"
+                        aria-label={t('page.navigationBar.foldAria')}
                         className="absolute top-[13px] right-[9px] flex size-[30px] items-center justify-center"
                         onClick={() => {
                             setIsFold(true);
@@ -54,7 +56,7 @@ const NavigationBar = () => {
                             className="w-full cursor-pointer rounded-[7px] border border-gray-6 bg-gray-7 py-[11px] text-[16px] font-medium text-gray-3"
                             onClick={() => navigate(ROUTE.DUTY)}
                         >
-                            근무표
+                            {t('page.navigationBar.home')}
                         </button>
                     </div>
                 </div>

--- a/apps/app/src/widgets/navigation-bar/index.tsx
+++ b/apps/app/src/widgets/navigation-bar/index.tsx
@@ -1,20 +1,15 @@
 import {useState} from 'react';
 import {useNavigate} from 'react-router';
 import {events, sendEvent} from '@/analytics';
-import {ProfileImage} from '@/entities/account/ui/profile-image';
-import useAuth from '@/features/auth';
 import {FoldIcon, LogoV2} from '@/shared/assets/svg';
 import ROUTE from '@/shared/constant/path';
 import NavigationBarItemGroups from './NavigationBarItemGroup';
 
 const NavigationBar = () => {
-    const {
-        state: {accountMe},
-    } = useAuth();
     const navigate = useNavigate();
     const [isFold, setIsFold] = useState(false);
 
-    // 접힘 상태: 사이드바는 숨기고 좌상단 fixed 버튼만 남김
+    // 펼친 상태: 사이드바는 숨기고 좌측 상단에 fixed 버튼만 유지
     if (isFold) {
         return (
             <button
@@ -65,15 +60,6 @@ const NavigationBar = () => {
                 </div>
 
                 <NavigationBarItemGroups />
-
-                <div className="flex-1" />
-
-                <div className="pb-[52px]">
-                    <button type="button" className="mx-auto flex w-full flex-col items-center" onClick={() => navigate(ROUTE.PROFILE)}>
-                        <ProfileImage className="h-[50px] w-[50px]" profileImg={{profileImgUrl: accountMe?.profileImgUrl}} />
-                        <div className="text-[16px] text-gray-4">{accountMe?.name}</div>
-                    </button>
-                </div>
             </div>
         </aside>
     );


### PR DESCRIPTION
## Motivation

메인 레이아웃 사이드바 구조를 신규 디자인 기준으로 정리했습니다.

- 티켓: [DUT-973](https://gom3.atlassian.net/browse/DUT-973)
- 배경: 하단 프로필 사진/이름 영역을 제거하고 설정 섹션에 계정 관리 탭을 추가해야 했습니다.
- 목표: 기존 프로필 진입 경로를 사이드바 메뉴 구조로 옮기고 관련 회귀를 방지합니다.

<br>

## Key Changes

- 사이드바 하단의 프로필 사진 및 회원 이름 CTA를 제거했습니다.
- 근무 설정 섹션에 `계정 관리` 메뉴를 추가하고 `/profile`로 연결했습니다.
- 네비게이션용 계정 관리 아이콘 selected/unselected variant를 추가했습니다.
- 계정 관리 메뉴 노출과 라우팅 이동을 검증하는 테스트를 추가했습니다.

<br>

## To Reviewers

- 봐줬으면 좋겠는 파일: `apps/app/src/widgets/navigation-bar/*`, `apps/app/src/shared/assets/svg/*`
- 중점적으로 봐줬으면 하는 로직: 사이드바 메뉴 순서와 `/profile` 진입 동선이 디자인 의도와 맞는지
- 고려하는 지점 / 확인이 필요한 부분: 계정 관리 아이콘의 선택 상태 비주얼이 디자인 시안과 어긋나지 않는지 확인 부탁드립니다.

[DUT-973]: https://gom3.atlassian.net/browse/DUT-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ