### PR TITLE
[DUT-975]: shared store 표준 API 정리

### DIFF
--- a/apps/app/src/entities/ui/useUIConfig/index.ts
+++ b/apps/app/src/entities/ui/useUIConfig/index.ts
@@ -1,14 +1,14 @@
-import {useUIConfigStore} from './store';
-
-type TShiftTypeColorStyle = 'background' | 'text';
+import {type TShiftTypeColorStyle, useUIConfigStore} from './store';
 
 const useUIConfigUseCase = () => {
-    const setState = useUIConfigStore((state) => state.setState);
+    const setSeparateWeekendColor = useUIConfigStore((state) => state.setSeparateWeekendColor);
+    const setShiftTypeColorStyle = useUIConfigStore((state) => state.setShiftTypeColorStyle);
+
     const handleChangeSeparateWeekendColor = (value: boolean) => {
-        setState('separateWeekendColor', value);
+        setSeparateWeekendColor(value);
     };
     const handleShiftTypeColorStyle = (value: TShiftTypeColorStyle) => {
-        setState('shiftTypeColorStyle', value);
+        setShiftTypeColorStyle(value);
     };
 
     return {

--- a/apps/app/src/entities/ui/useUIConfig/store.ts
+++ b/apps/app/src/entities/ui/useUIConfig/store.ts
@@ -1,10 +1,16 @@
 import {createStore} from '@/shared/util/create-store';
 
+export type TShiftTypeColorStyle = 'background' | 'text';
+
 const initialState = {
     separateWeekendColor: false,
-    shiftTypeColorStyle: 'background',
+    shiftTypeColorStyle: 'background' as TShiftTypeColorStyle,
 };
 
 export const useUIConfigStore = createStore(initialState, {
     name: 'useUIConfigStore',
+    actions: ({set}) => ({
+        setSeparateWeekendColor: (value: boolean) => set('separateWeekendColor', value),
+        setShiftTypeColorStyle: (value: TShiftTypeColorStyle) => set('shiftTypeColorStyle', value),
+    }),
 });

--- a/apps/app/src/features/auth/__tests__/index.test.tsx
+++ b/apps/app/src/features/auth/__tests__/index.test.tsx
@@ -165,7 +165,12 @@ describe('useAuth', () => {
             await Promise.resolve();
         });
 
-        expect(useAuthStore.getState().isDemoExpired).toBe(true);
+        expect(useAuthStore.getState()).toMatchObject({
+            isAuth: true,
+            accessToken: 'old-token',
+            isDemoExpired: true,
+        });
+        expect(mockResetRequestShiftState).not.toHaveBeenCalled();
     });
 
     it('turns loading off again when demo bootstrap fails', async () => {
@@ -181,5 +186,53 @@ describe('useAuth', () => {
 
         expect(mockSetLoading).toHaveBeenNthCalledWith(1, true);
         expect(mockSetLoading).toHaveBeenNthCalledWith(2, false);
+    });
+
+    it('turns loading off again when tutorial initialization fails during demo bootstrap', async () => {
+        mockInitTutorial.mockImplementationOnce(() => {
+            throw new Error('tutorial failed');
+        });
+
+        const {result} = renderHook(() => useAuth());
+
+        await expect(
+            act(async () => {
+                await result.current.actions.demoTry();
+            }),
+        ).rejects.toThrow('tutorial failed');
+
+        expect(mockSetLoading).toHaveBeenNthCalledWith(1, true);
+        expect(mockSetLoading).toHaveBeenNthCalledWith(2, false);
+        expect(AuthAPI.demoStart).not.toHaveBeenCalled();
+    });
+
+    it('syncs the api client token before navigating after demo bootstrap', async () => {
+        vi.mocked(AuthAPI.demoStart).mockResolvedValueOnce({
+            accessToken: 'demo-token',
+            accountResDto: {
+                accountId: 12,
+                nurseId: 34,
+                wardId: 56,
+            },
+        } as never);
+
+        const {result} = renderHook(() => useAuth());
+
+        await act(async () => {
+            await result.current.actions.demoTry();
+        });
+
+        expect(useAuthStore.getState()).toMatchObject({
+            accountMe: null,
+            accessToken: 'demo-token',
+            accountId: 12,
+            nurseId: 34,
+            wardId: 56,
+            isAuth: true,
+            isDemoExpired: false,
+        });
+        expect(setAccessTokenMock).toHaveBeenCalledWith('demo-token');
+        expect(mockNavigate).toHaveBeenCalled();
+        expect(setAccessTokenMock.mock.invocationCallOrder[0]).toBeLessThan(mockNavigate.mock.invocationCallOrder[0]);
     });
 });

--- a/apps/app/src/features/auth/__tests__/index.test.tsx
+++ b/apps/app/src/features/auth/__tests__/index.test.tsx
@@ -152,7 +152,7 @@ describe('useAuth', () => {
         });
     });
 
-    it('marks the demo session as expired during bootstrap instead of logging out', () => {
+    it('marks the demo session as expired during bootstrap instead of logging out', async () => {
         useAuthStore.setState({
             demoStartDate: '2026-02-01T00:00:00.000Z',
             isDemoExpired: false,
@@ -160,7 +160,10 @@ describe('useAuth', () => {
 
         vi.mocked(AccountAPI.getAccountMe).mockResolvedValueOnce({accountId: 9, wardId: 99, nurseId: 19} as never);
 
-        renderHook(() => useAuth(true));
+        await act(async () => {
+            renderHook(() => useAuth(true));
+            await Promise.resolve();
+        });
 
         expect(useAuthStore.getState().isDemoExpired).toBe(true);
     });

--- a/apps/app/src/features/auth/__tests__/index.test.tsx
+++ b/apps/app/src/features/auth/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import {act, renderHook} from '@testing-library/react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {AccountAPI} from '@/shared/api';
+import {AccountAPI, AuthAPI} from '@/shared/api';
 import useAuth from '../index';
 import useAuthStore from '../model/store';
 
@@ -166,5 +166,20 @@ describe('useAuth', () => {
         });
 
         expect(useAuthStore.getState().isDemoExpired).toBe(true);
+    });
+
+    it('turns loading off again when demo bootstrap fails', async () => {
+        vi.mocked(AuthAPI.demoStart).mockRejectedValueOnce(new Error('demo failed'));
+
+        const {result} = renderHook(() => useAuth());
+
+        await expect(
+            act(async () => {
+                await result.current.actions.demoTry();
+            }),
+        ).rejects.toThrow('demo failed');
+
+        expect(mockSetLoading).toHaveBeenNthCalledWith(1, true);
+        expect(mockSetLoading).toHaveBeenNthCalledWith(2, false);
     });
 });

--- a/apps/app/src/features/auth/index.ts
+++ b/apps/app/src/features/auth/index.ts
@@ -71,17 +71,20 @@ const useAuth = (activeEffect = false) => {
         setLoading(true);
         initTutorial();
 
-        const data = await AuthAPI.demoStart();
+        try {
+            const data = await AuthAPI.demoStart();
 
-        applyDemoSession({
-            accessToken: data.accessToken,
-            accountId: data.accountResDto.accountId,
-            nurseId: data.accountResDto.nurseId,
-            wardId: data.accountResDto.wardId,
-            demoStartDate: new Date().toISOString(),
-        });
-        navigate(ROUTE.MAKE);
-        setLoading(false);
+            applyDemoSession({
+                accessToken: data.accessToken,
+                accountId: data.accountResDto.accountId,
+                nurseId: data.accountResDto.nurseId,
+                wardId: data.accountResDto.wardId,
+                demoStartDate: new Date().toISOString(),
+            });
+            navigate(ROUTE.MAKE);
+        } finally {
+            setLoading(false);
+        }
     };
     const handleGetAccountMe = async () => {
         setAccountMeLoading();

--- a/apps/app/src/features/auth/index.ts
+++ b/apps/app/src/features/auth/index.ts
@@ -69,9 +69,9 @@ const useAuth = (activeEffect = false) => {
     };
     const demoTry = async () => {
         setLoading(true);
-        initTutorial();
 
         try {
+            initTutorial();
             const data = await AuthAPI.demoStart();
 
             applyDemoSession({
@@ -81,6 +81,7 @@ const useAuth = (activeEffect = false) => {
                 wardId: data.accountResDto.wardId,
                 demoStartDate: new Date().toISOString(),
             });
+            setAccessToken(data.accessToken);
             navigate(ROUTE.MAKE);
         } finally {
             setLoading(false);

--- a/apps/app/src/features/auth/index.ts
+++ b/apps/app/src/features/auth/index.ts
@@ -27,7 +27,12 @@ const useAuth = (activeEffect = false) => {
         wardId,
         demoStartDate,
         _loaded,
-        setState,
+        beginLogin,
+        applyDemoSession,
+        setAccountMeLoading,
+        setAccountMeSuccess,
+        setAccountMeError,
+        setDemoExpired: setAuthDemoExpired,
         resetState,
     } = useAuthStore();
     const resetRequestShiftState = useRequestShiftStore((state) => state.resetState);
@@ -47,19 +52,7 @@ const useAuth = (activeEffect = false) => {
         if (fallBackPath && pathname !== fallBackPath) navigate(fallBackPath);
     };
     const handleLogin = (accessToken: string, nextPageUrl?: string | null, options?: THandleLoginOptions) => {
-        setState('accountMe', null);
-        setState('accountId', null);
-        setState('nurseId', null);
-        setState('wardId', null);
-        setState('isDemoExpired', false);
-
-        if (!options?.preserveDemoStartDate) {
-            setState('demoStartDate', null);
-        }
-
-        setState('isAuth', true);
-        setState('accessToken', accessToken);
-        setState('accountMeStatus', 'loading');
+        beginLogin(accessToken, {preserveDemoStartDate: options?.preserveDemoStartDate});
         setAccessToken(accessToken);
 
         const redirectDecision = getLoginRedirectDecision(nextPageUrl);
@@ -69,7 +62,7 @@ const useAuth = (activeEffect = false) => {
         sendEvent(events.auth.login);
     };
     const setDemoExpired = (expired: boolean) => {
-        setState('isDemoExpired', expired);
+        setAuthDemoExpired(expired);
     };
     const startDemoSignupTransition = (nextPath: string = ROUTE.REGISTER) => {
         void handleLogout(buildDemoSignupLoginPath(nextPath));
@@ -80,31 +73,25 @@ const useAuth = (activeEffect = false) => {
 
         const data = await AuthAPI.demoStart();
 
-        setState('accessToken', data.accessToken);
-        setState('accountId', data.accountResDto.accountId);
-        setState('nurseId', data.accountResDto.nurseId);
-        setState('wardId', data.accountResDto.wardId);
-        setState('isAuth', true);
-        setState('isDemoExpired', false);
-        setState('accountMeStatus', 'success');
-        setState('demoStartDate', new Date().toISOString());
+        applyDemoSession({
+            accessToken: data.accessToken,
+            accountId: data.accountResDto.accountId,
+            nurseId: data.accountResDto.nurseId,
+            wardId: data.accountResDto.wardId,
+            demoStartDate: new Date().toISOString(),
+        });
         navigate(ROUTE.MAKE);
         setLoading(false);
     };
     const handleGetAccountMe = async () => {
-        setState('accountMeStatus', 'loading');
+        setAccountMeLoading();
 
         try {
             const account = await AccountAPI.getAccountMe();
 
-            setState('accountMe', account);
-            setState('wardId', account.wardId);
-            setState('accountId', account.accountId);
-            setState('nurseId', account.nurseId);
-            setState('isAuth', true);
-            setState('accountMeStatus', 'success');
+            setAccountMeSuccess(account);
         } catch (error) {
-            setState('accountMeStatus', 'error');
+            setAccountMeError();
             throw error;
         }
     };

--- a/apps/app/src/features/auth/model/store.ts
+++ b/apps/app/src/features/auth/model/store.ts
@@ -91,6 +91,7 @@ const useAuthStore = create<IStore>()(
                         })),
                     applyDemoSession: ({accessToken, accountId, nurseId, wardId, demoStartDate}) =>
                         patch({
+                            accountMe: null,
                             accessToken,
                             accountId,
                             nurseId,

--- a/apps/app/src/features/auth/model/store.ts
+++ b/apps/app/src/features/auth/model/store.ts
@@ -1,8 +1,8 @@
-import {type TValues} from '@dutying/utils';
 import {create} from 'zustand';
 import {devtools, persist, type PersistStorage, type StorageValue} from 'zustand/middleware';
 import {type TAccount} from '@/entities/account';
 import {setAccessToken} from '@/shared/api/client';
+import {createStoreWriteHelpers} from '@/shared/util/create-store';
 
 interface IState {
     accountMe: TAccount | null;
@@ -18,7 +18,19 @@ interface IState {
 }
 
 interface IStore extends IState {
-    setState: (key: keyof IState, value: TValues<IState>) => void;
+    beginLogin: (accessToken: string, options?: {preserveDemoStartDate?: boolean}) => void;
+    applyDemoSession: (payload: {
+        accessToken: string;
+        accountId: number | null;
+        nurseId: number | null;
+        wardId: number | null;
+        demoStartDate: string;
+    }) => void;
+    setAccountMeLoading: () => void;
+    setAccountMeSuccess: (account: TAccount) => void;
+    setAccountMeError: () => void;
+    setDemoExpired: (expired: boolean) => void;
+    markHydrated: () => void;
     resetState: () => void;
 }
 
@@ -56,11 +68,58 @@ const authStoreStorage: PersistStorage<TPersistedAuthState> = {
 const useAuthStore = create<IStore>()(
     devtools(
         persist(
-            (set) => ({
-                ...initialState,
-                setState: (state, value) => set((prev) => ({...prev, [state]: value})),
-                resetState: () => set({...initialState, _loaded: true}),
-            }),
+            (set, get) => {
+                const {set: setField, patch} = createStoreWriteHelpers<IState, IStore>({
+                    set,
+                    get,
+                    initialState,
+                });
+
+                return {
+                    ...initialState,
+                    beginLogin: (accessToken, options) =>
+                        patch((prev) => ({
+                            accountMe: null,
+                            accountMeStatus: 'loading',
+                            isAuth: true,
+                            isDemoExpired: false,
+                            accessToken,
+                            accountId: null,
+                            nurseId: null,
+                            wardId: null,
+                            demoStartDate: options?.preserveDemoStartDate ? prev.demoStartDate : null,
+                        })),
+                    applyDemoSession: ({accessToken, accountId, nurseId, wardId, demoStartDate}) =>
+                        patch({
+                            accessToken,
+                            accountId,
+                            nurseId,
+                            wardId,
+                            isAuth: true,
+                            isDemoExpired: false,
+                            accountMeStatus: 'success',
+                            demoStartDate,
+                        }),
+                    setAccountMeLoading: () => setField('accountMeStatus', 'loading'),
+                    setAccountMeSuccess: (account) =>
+                        patch({
+                            accountMe: account,
+                            wardId: account.wardId,
+                            accountId: account.accountId,
+                            nurseId: account.nurseId,
+                            isAuth: true,
+                            accountMeStatus: 'success',
+                        }),
+                    setAccountMeError: () => setField('accountMeStatus', 'error'),
+                    setDemoExpired: (expired) => setField('isDemoExpired', expired),
+                    markHydrated: () => setField('_loaded', true),
+                    resetState: () =>
+                        patch({
+                            ...initialState,
+                            _loaded: true,
+                        }),
+                };
+            },
             {
                 name: 'useAuthStore',
                 storage: authStoreStorage,
@@ -77,7 +136,7 @@ const useAuthStore = create<IStore>()(
                     };
                 },
                 onRehydrateStorage: (state) => (rehydratedState) => {
-                    (rehydratedState ?? state).setState('_loaded', true);
+                    (rehydratedState ?? state).markHydrated();
                 },
             },
         ),

--- a/apps/app/src/features/edit-shift-team/__tests__/index.test.tsx
+++ b/apps/app/src/features/edit-shift-team/__tests__/index.test.tsx
@@ -99,11 +99,8 @@ describe('useEditShiftTeam', () => {
     });
 
     it('keeps the draft dirty and exposes an error save status when updateNurse fails with an unknown error shape', async () => {
-        useEditNurseStore.getState().unsafePatch({
-            selectedNurseId: 11,
-            selectedNurseDrawerMode: 'create',
-            isNurseDraftDirty: true,
-        });
+        useEditNurseStore.getState().selectNurse(11, 'create');
+        useEditNurseStore.getState().setNurseDraftDirty(true);
         mockUpdateNurse.mockRejectedValue({response: {status: 500}});
 
         const {result} = renderHook(() => useEditShiftTeam());
@@ -138,9 +135,7 @@ describe('useEditShiftTeam', () => {
     });
 
     it('resets the deleting flag and preserves the current selection after deleteNurse fails', async () => {
-        useEditNurseStore.getState().unsafePatch({
-            selectedNurseId: 11,
-        });
+        useEditNurseStore.getState().selectNurse(11);
         mockRemoveNurseFromShiftTeam.mockRejectedValue({message: 'server error'});
 
         const {result} = renderHook(() => useEditShiftTeam());

--- a/apps/app/src/features/edit-shift-team/__tests__/index.test.tsx
+++ b/apps/app/src/features/edit-shift-team/__tests__/index.test.tsx
@@ -99,7 +99,7 @@ describe('useEditShiftTeam', () => {
     });
 
     it('keeps the draft dirty and exposes an error save status when updateNurse fails with an unknown error shape', async () => {
-        useEditNurseStore.getState().patch({
+        useEditNurseStore.getState().unsafePatch({
             selectedNurseId: 11,
             selectedNurseDrawerMode: 'create',
             isNurseDraftDirty: true,
@@ -138,7 +138,7 @@ describe('useEditShiftTeam', () => {
     });
 
     it('resets the deleting flag and preserves the current selection after deleteNurse fails', async () => {
-        useEditNurseStore.getState().patch({
+        useEditNurseStore.getState().unsafePatch({
             selectedNurseId: 11,
         });
         mockRemoveNurseFromShiftTeam.mockRejectedValue({message: 'server error'});

--- a/apps/app/src/features/edit-shift-team/__tests__/index.test.tsx
+++ b/apps/app/src/features/edit-shift-team/__tests__/index.test.tsx
@@ -134,6 +134,41 @@ describe('useEditShiftTeam', () => {
         expect(mockToastSuccess).not.toHaveBeenCalled();
     });
 
+    it('keeps the adding flag on until ward invalidation finishes after addNurse succeeds', async () => {
+        let resolveInvalidate: (() => void) | undefined;
+
+        mockAddNurseIntoShiftTeam.mockResolvedValue({
+            nurseId: 22,
+        });
+        mockInvalidateQueries.mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveInvalidate = resolve;
+                }),
+        );
+
+        const {result} = renderHook(() => useEditShiftTeam());
+
+        let actionPromise: Promise<void> | undefined;
+
+        await act(async () => {
+            actionPromise = result.current.actions.addNurse(10);
+            await Promise.resolve();
+        });
+
+        expect(result.current.state.isAddingNurse).toBe(true);
+        expect(useEditNurseStore.getState().selectedNurseId).toBe(22);
+        expect(result.current.state.selectedNurseDrawerMode).toBe('create');
+
+        await act(async () => {
+            resolveInvalidate?.();
+            await actionPromise;
+        });
+
+        expect(result.current.state.isAddingNurse).toBe(false);
+        expect(mockToastSuccess).toHaveBeenCalledWith('새 간호사를 추가했어요. 이름과 연락처를 확인한 뒤 저장해 주세요.');
+    });
+
     it('resets the deleting flag and preserves the current selection after deleteNurse fails', async () => {
         useEditNurseStore.getState().selectNurse(11);
         mockRemoveNurseFromShiftTeam.mockRejectedValue({message: 'server error'});
@@ -148,5 +183,38 @@ describe('useEditShiftTeam', () => {
         expect(result.current.state.selectedNurse?.nurseId).toBe(11);
         expect(mockToastError).toHaveBeenCalledWith('간호사 삭제에 실패했습니다.');
         expect(mockToastSuccess).not.toHaveBeenCalled();
+    });
+
+    it('keeps the deleting flag on until ward invalidation finishes after deleteNurse succeeds', async () => {
+        let resolveInvalidate: (() => void) | undefined;
+
+        useEditNurseStore.getState().selectNurse(11);
+        mockRemoveNurseFromShiftTeam.mockResolvedValue(undefined);
+        mockInvalidateQueries.mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveInvalidate = resolve;
+                }),
+        );
+
+        const {result} = renderHook(() => useEditShiftTeam());
+
+        let actionPromise: Promise<void> | undefined;
+
+        await act(async () => {
+            actionPromise = result.current.actions.deleteNurse(10, 11);
+            await Promise.resolve();
+        });
+
+        expect(result.current.state.isDeletingNurse).toBe(true);
+        expect(result.current.state.selectedNurse).toBeUndefined();
+
+        await act(async () => {
+            resolveInvalidate?.();
+            await actionPromise;
+        });
+
+        expect(result.current.state.isDeletingNurse).toBe(false);
+        expect(mockToastSuccess).toHaveBeenCalledWith('간호사를 삭제했어요.');
     });
 });

--- a/apps/app/src/features/edit-shift-team/index.ts
+++ b/apps/app/src/features/edit-shift-team/index.ts
@@ -23,10 +23,10 @@ const useEditShiftTeam = () => {
         isDeletingNurse,
         beginAddingNurse,
         completeAddingNurse,
-        failAddingNurse,
+        finishAddingNurse,
         beginDeletingNurse,
         completeDeletingNurse,
-        failDeletingNurse,
+        finishDeletingNurse,
         selectNurse: selectNurseState,
         beginSavingNurse,
         completeSavingNurse,
@@ -80,10 +80,10 @@ const useEditShiftTeam = () => {
             } catch (error) {
                 showActionErrorFeedback(error, '간호사 추가에 실패했습니다.');
             } finally {
-                failAddingNurse();
+                finishAddingNurse();
             }
         },
-        [beginAddingNurse, completeAddingNurse, failAddingNurse, invalidateWard, wardId],
+        [beginAddingNurse, completeAddingNurse, finishAddingNurse, invalidateWard, wardId],
     );
     const deleteNurse = useCallback(
         async (shiftTeamId: number, nurseId: number) => {
@@ -99,10 +99,10 @@ const useEditShiftTeam = () => {
             } catch (error) {
                 showActionErrorFeedback(error, '간호사 삭제에 실패했습니다.');
             } finally {
-                failDeletingNurse();
+                finishDeletingNurse();
             }
         },
-        [beginDeletingNurse, completeDeletingNurse, failDeletingNurse, invalidateWard, wardId],
+        [beginDeletingNurse, completeDeletingNurse, finishDeletingNurse, invalidateWard, wardId],
     );
     const selectNurse = useCallback(
         (nurseId: number | null, mode: 'create' | 'edit' = 'edit') => {

--- a/apps/app/src/features/edit-shift-team/index.ts
+++ b/apps/app/src/features/edit-shift-team/index.ts
@@ -14,8 +14,25 @@ import {showActionErrorFeedback} from '@/shared/util/feedback';
 import useEditNurseStore from './model/store';
 
 const useEditShiftTeam = () => {
-    const {selectedNurseId, selectedNurseDrawerMode, isNurseDraftDirty, nurseSaveStatus, isAddingNurse, isDeletingNurse, unsafePatch} =
-        useEditNurseStore();
+    const {
+        selectedNurseId,
+        selectedNurseDrawerMode,
+        isNurseDraftDirty,
+        nurseSaveStatus,
+        isAddingNurse,
+        isDeletingNurse,
+        beginAddingNurse,
+        completeAddingNurse,
+        failAddingNurse,
+        beginDeletingNurse,
+        completeDeletingNurse,
+        failDeletingNurse,
+        selectNurse: selectNurseState,
+        beginSavingNurse,
+        completeSavingNurse,
+        failSavingNurse,
+        setNurseDraftDirty: setNurseDraftDirtyState,
+    } = useEditNurseStore();
     const {
         state: {wardId},
     } = useAuth();
@@ -42,9 +59,7 @@ const useEditShiftTeam = () => {
         async (shiftTeamId: number) => {
             if (!wardId) return;
 
-            unsafePatch({
-                isAddingNurse: true,
-            });
+            beginAddingNurse();
 
             try {
                 const nurse = await WardAPI.addNurseIntoShiftTeam(wardId, shiftTeamId, {
@@ -58,52 +73,36 @@ const useEditShiftTeam = () => {
                     memo: '',
                 });
 
-                unsafePatch({
-                    selectedNurseId: nurse.nurseId,
-                    selectedNurseDrawerMode: 'create',
-                    isNurseDraftDirty: false,
-                    nurseSaveStatus: 'idle',
-                });
+                completeAddingNurse(nurse.nurseId);
 
                 toast.success('새 간호사를 추가했어요. 이름과 연락처를 확인한 뒤 저장해 주세요.');
                 await invalidateWard();
             } catch (error) {
                 showActionErrorFeedback(error, '간호사 추가에 실패했습니다.');
             } finally {
-                unsafePatch({
-                    isAddingNurse: false,
-                });
+                failAddingNurse();
             }
         },
-        [invalidateWard, unsafePatch, wardId],
+        [beginAddingNurse, completeAddingNurse, failAddingNurse, invalidateWard, wardId],
     );
     const deleteNurse = useCallback(
         async (shiftTeamId: number, nurseId: number) => {
             if (!wardId) return;
 
-            unsafePatch({
-                isDeletingNurse: true,
-            });
+            beginDeletingNurse();
 
             try {
                 await WardAPI.removeNurseFromShiftTeam(wardId, shiftTeamId, nurseId);
-                unsafePatch({
-                    selectedNurseId: null,
-                    selectedNurseDrawerMode: 'edit',
-                    isNurseDraftDirty: false,
-                    nurseSaveStatus: 'idle',
-                });
+                completeDeletingNurse();
                 toast.success('간호사를 삭제했어요.');
                 await invalidateWard();
             } catch (error) {
                 showActionErrorFeedback(error, '간호사 삭제에 실패했습니다.');
             } finally {
-                unsafePatch({
-                    isDeletingNurse: false,
-                });
+                failDeletingNurse();
             }
         },
-        [invalidateWard, unsafePatch, wardId],
+        [beginDeletingNurse, completeDeletingNurse, failDeletingNurse, invalidateWard, wardId],
     );
     const selectNurse = useCallback(
         (nurseId: number | null, mode: 'create' | 'edit' = 'edit') => {
@@ -120,45 +119,32 @@ const useEditShiftTeam = () => {
                 if (!isConfirmed) return false;
             }
 
-            unsafePatch({
-                selectedNurseId: nurseId,
-                selectedNurseDrawerMode: nurseId === null ? 'edit' : mode,
-                isNurseDraftDirty: false,
-                nurseSaveStatus: 'idle',
-            });
+            selectNurseState(nurseId, mode);
 
             return true;
         },
-        [isNurseDraftDirty, selectedNurseId, unsafePatch],
+        [isNurseDraftDirty, selectNurseState, selectedNurseId],
     );
     const updateNurse = useCallback(
         async (nurseId: number, updateNurseDTO: TUpdateNurseDTO) => {
-            unsafePatch({
-                nurseSaveStatus: 'saving',
-            });
+            beginSavingNurse();
 
             try {
                 await NurseAPI.updateNurse(nurseId, updateNurseDTO);
-                unsafePatch({
-                    isNurseDraftDirty: false,
-                    nurseSaveStatus: 'success',
-                    selectedNurseDrawerMode: 'edit',
-                });
+                completeSavingNurse();
 
                 await invalidateWardShiftAndRequest();
 
                 return true;
             } catch (error) {
-                unsafePatch({
-                    nurseSaveStatus: 'error',
-                });
+                failSavingNurse();
 
                 showActionErrorFeedback(error, '간호사 정보 수정에 실패했습니다.');
 
                 return false;
             }
         },
-        [invalidateWardShiftAndRequest, unsafePatch],
+        [beginSavingNurse, completeSavingNurse, failSavingNurse, invalidateWardShiftAndRequest],
     );
     const updateNurseShift = useCallback(
         async (nurseId: number, nurseShiftTypeId: number, change: TUpdateNurseShiftTypeRequest) => {
@@ -347,18 +333,9 @@ const useEditShiftTeam = () => {
     );
     const setNurseDraftDirty = useCallback(
         (isDirty: boolean) => {
-            unsafePatch((prev) => {
-                if (prev.isNurseDraftDirty === isDirty) {
-                    return {};
-                }
-
-                return {
-                    isNurseDraftDirty: isDirty,
-                    nurseSaveStatus: isDirty && prev.nurseSaveStatus !== 'saving' ? 'idle' : prev.nurseSaveStatus,
-                };
-            });
+            setNurseDraftDirtyState(isDirty);
         },
-        [unsafePatch],
+        [setNurseDraftDirtyState],
     );
 
     return {

--- a/apps/app/src/features/edit-shift-team/index.ts
+++ b/apps/app/src/features/edit-shift-team/index.ts
@@ -14,7 +14,7 @@ import {showActionErrorFeedback} from '@/shared/util/feedback';
 import useEditNurseStore from './model/store';
 
 const useEditShiftTeam = () => {
-    const {selectedNurseId, selectedNurseDrawerMode, isNurseDraftDirty, nurseSaveStatus, isAddingNurse, isDeletingNurse, patch} =
+    const {selectedNurseId, selectedNurseDrawerMode, isNurseDraftDirty, nurseSaveStatus, isAddingNurse, isDeletingNurse, unsafePatch} =
         useEditNurseStore();
     const {
         state: {wardId},
@@ -42,7 +42,7 @@ const useEditShiftTeam = () => {
         async (shiftTeamId: number) => {
             if (!wardId) return;
 
-            patch({
+            unsafePatch({
                 isAddingNurse: true,
             });
 
@@ -58,7 +58,7 @@ const useEditShiftTeam = () => {
                     memo: '',
                 });
 
-                patch({
+                unsafePatch({
                     selectedNurseId: nurse.nurseId,
                     selectedNurseDrawerMode: 'create',
                     isNurseDraftDirty: false,
@@ -70,24 +70,24 @@ const useEditShiftTeam = () => {
             } catch (error) {
                 showActionErrorFeedback(error, '간호사 추가에 실패했습니다.');
             } finally {
-                patch({
+                unsafePatch({
                     isAddingNurse: false,
                 });
             }
         },
-        [invalidateWard, patch, wardId],
+        [invalidateWard, unsafePatch, wardId],
     );
     const deleteNurse = useCallback(
         async (shiftTeamId: number, nurseId: number) => {
             if (!wardId) return;
 
-            patch({
+            unsafePatch({
                 isDeletingNurse: true,
             });
 
             try {
                 await WardAPI.removeNurseFromShiftTeam(wardId, shiftTeamId, nurseId);
-                patch({
+                unsafePatch({
                     selectedNurseId: null,
                     selectedNurseDrawerMode: 'edit',
                     isNurseDraftDirty: false,
@@ -98,12 +98,12 @@ const useEditShiftTeam = () => {
             } catch (error) {
                 showActionErrorFeedback(error, '간호사 삭제에 실패했습니다.');
             } finally {
-                patch({
+                unsafePatch({
                     isDeletingNurse: false,
                 });
             }
         },
-        [invalidateWard, patch, wardId],
+        [invalidateWard, unsafePatch, wardId],
     );
     const selectNurse = useCallback(
         (nurseId: number | null, mode: 'create' | 'edit' = 'edit') => {
@@ -120,7 +120,7 @@ const useEditShiftTeam = () => {
                 if (!isConfirmed) return false;
             }
 
-            patch({
+            unsafePatch({
                 selectedNurseId: nurseId,
                 selectedNurseDrawerMode: nurseId === null ? 'edit' : mode,
                 isNurseDraftDirty: false,
@@ -129,17 +129,17 @@ const useEditShiftTeam = () => {
 
             return true;
         },
-        [isNurseDraftDirty, patch, selectedNurseId],
+        [isNurseDraftDirty, selectedNurseId, unsafePatch],
     );
     const updateNurse = useCallback(
         async (nurseId: number, updateNurseDTO: TUpdateNurseDTO) => {
-            patch({
+            unsafePatch({
                 nurseSaveStatus: 'saving',
             });
 
             try {
                 await NurseAPI.updateNurse(nurseId, updateNurseDTO);
-                patch({
+                unsafePatch({
                     isNurseDraftDirty: false,
                     nurseSaveStatus: 'success',
                     selectedNurseDrawerMode: 'edit',
@@ -149,7 +149,7 @@ const useEditShiftTeam = () => {
 
                 return true;
             } catch (error) {
-                patch({
+                unsafePatch({
                     nurseSaveStatus: 'error',
                 });
 
@@ -158,7 +158,7 @@ const useEditShiftTeam = () => {
                 return false;
             }
         },
-        [invalidateWardShiftAndRequest, patch],
+        [invalidateWardShiftAndRequest, unsafePatch],
     );
     const updateNurseShift = useCallback(
         async (nurseId: number, nurseShiftTypeId: number, change: TUpdateNurseShiftTypeRequest) => {
@@ -347,7 +347,7 @@ const useEditShiftTeam = () => {
     );
     const setNurseDraftDirty = useCallback(
         (isDirty: boolean) => {
-            patch((prev) => {
+            unsafePatch((prev) => {
                 if (prev.isNurseDraftDirty === isDirty) {
                     return {};
                 }
@@ -358,7 +358,7 @@ const useEditShiftTeam = () => {
                 };
             });
         },
-        [patch],
+        [unsafePatch],
     );
 
     return {

--- a/apps/app/src/features/edit-shift-team/model/store.ts
+++ b/apps/app/src/features/edit-shift-team/model/store.ts
@@ -68,17 +68,18 @@ const useEditNurseStore = createStore(initialState, {
             patch({
                 nurseSaveStatus: 'error',
             }),
-        setNurseDraftDirty: (isDirty: boolean) =>
-            patch((prev) => {
-                if (prev.isNurseDraftDirty === isDirty) {
-                    return {};
-                }
+        setNurseDraftDirty: (isDirty: boolean) => {
+            const prev = useEditNurseStore.getState();
 
-                return {
-                    isNurseDraftDirty: isDirty,
-                    nurseSaveStatus: isDirty && prev.nurseSaveStatus !== 'saving' ? 'idle' : prev.nurseSaveStatus,
-                };
-            }),
+            if (prev.isNurseDraftDirty === isDirty) {
+                return;
+            }
+
+            patch({
+                isNurseDraftDirty: isDirty,
+                nurseSaveStatus: isDirty && prev.nurseSaveStatus !== 'saving' ? 'idle' : prev.nurseSaveStatus,
+            });
+        },
     }),
 });
 

--- a/apps/app/src/features/edit-shift-team/model/store.ts
+++ b/apps/app/src/features/edit-shift-team/model/store.ts
@@ -14,7 +14,72 @@ const initialState = {
 const useEditNurseStore = createStore(initialState, {
     name: 'useEditNurseStore',
     persist: false,
-    unsafeMutators: true,
+    actions: ({patch}) => ({
+        beginAddingNurse: () =>
+            patch({
+                isAddingNurse: true,
+            }),
+        completeAddingNurse: (selectedNurseId: number) =>
+            patch({
+                isAddingNurse: false,
+                selectedNurseId,
+                selectedNurseDrawerMode: 'create',
+                isNurseDraftDirty: false,
+                nurseSaveStatus: 'idle',
+            }),
+        failAddingNurse: () =>
+            patch({
+                isAddingNurse: false,
+            }),
+        beginDeletingNurse: () =>
+            patch({
+                isDeletingNurse: true,
+            }),
+        completeDeletingNurse: () =>
+            patch({
+                isDeletingNurse: false,
+                selectedNurseId: null,
+                selectedNurseDrawerMode: 'edit',
+                isNurseDraftDirty: false,
+                nurseSaveStatus: 'idle',
+            }),
+        failDeletingNurse: () =>
+            patch({
+                isDeletingNurse: false,
+            }),
+        selectNurse: (selectedNurseId: number | null, selectedNurseDrawerMode: TNurseDrawerMode = 'edit') =>
+            patch({
+                selectedNurseId,
+                selectedNurseDrawerMode: selectedNurseId === null ? 'edit' : selectedNurseDrawerMode,
+                isNurseDraftDirty: false,
+                nurseSaveStatus: 'idle',
+            }),
+        beginSavingNurse: () =>
+            patch({
+                nurseSaveStatus: 'saving',
+            }),
+        completeSavingNurse: () =>
+            patch({
+                isNurseDraftDirty: false,
+                nurseSaveStatus: 'success',
+                selectedNurseDrawerMode: 'edit',
+            }),
+        failSavingNurse: () =>
+            patch({
+                nurseSaveStatus: 'error',
+            }),
+        setNurseDraftDirty: (isDirty: boolean) =>
+            patch((prev) => {
+                if (prev.isNurseDraftDirty === isDirty) {
+                    return {};
+                }
+
+                return {
+                    isNurseDraftDirty: isDirty,
+                    nurseSaveStatus: isDirty && prev.nurseSaveStatus !== 'saving' ? 'idle' : prev.nurseSaveStatus,
+                };
+            }),
+    }),
 });
 
 export default useEditNurseStore;

--- a/apps/app/src/features/edit-shift-team/model/store.ts
+++ b/apps/app/src/features/edit-shift-team/model/store.ts
@@ -14,6 +14,7 @@ const initialState = {
 const useEditNurseStore = createStore(initialState, {
     name: 'useEditNurseStore',
     persist: false,
+    unsafeMutators: true,
 });
 
 export default useEditNurseStore;

--- a/apps/app/src/features/edit-shift-team/model/store.ts
+++ b/apps/app/src/features/edit-shift-team/model/store.ts
@@ -21,13 +21,12 @@ const useEditNurseStore = createStore(initialState, {
             }),
         completeAddingNurse: (selectedNurseId: number) =>
             patch({
-                isAddingNurse: false,
                 selectedNurseId,
                 selectedNurseDrawerMode: 'create',
                 isNurseDraftDirty: false,
                 nurseSaveStatus: 'idle',
             }),
-        failAddingNurse: () =>
+        finishAddingNurse: () =>
             patch({
                 isAddingNurse: false,
             }),
@@ -37,13 +36,12 @@ const useEditNurseStore = createStore(initialState, {
             }),
         completeDeletingNurse: () =>
             patch({
-                isDeletingNurse: false,
                 selectedNurseId: null,
                 selectedNurseDrawerMode: 'edit',
                 isNurseDraftDirty: false,
                 nurseSaveStatus: 'idle',
             }),
-        failDeletingNurse: () =>
+        finishDeletingNurse: () =>
             patch({
                 isDeletingNurse: false,
             }),

--- a/apps/app/src/features/loading/index.ts
+++ b/apps/app/src/features/loading/index.ts
@@ -1,10 +1,10 @@
 import {useLoadingStore} from './model/store';
 
 const useLoadingUseCase = () => {
-    const setState = useLoadingStore((state) => state.setState);
+    const setLoading = useLoadingStore((state) => state.setLoading);
 
     return {
-        setLoading: (loading: boolean) => setState('loading', loading),
+        setLoading,
     };
 };
 

--- a/apps/app/src/features/loading/model/store.ts
+++ b/apps/app/src/features/loading/model/store.ts
@@ -7,4 +7,7 @@ const initialState = {
 export const useLoadingStore = createStore(initialState, {
     name: 'useLoadingStore',
     persist: false,
+    actions: ({set}) => ({
+        setLoading: (loading: boolean) => set('loading', loading),
+    }),
 });

--- a/apps/app/src/features/tutorial/index.ts
+++ b/apps/app/src/features/tutorial/index.ts
@@ -2,20 +2,16 @@ import {useCallback} from 'react';
 import {useTutorialStore} from './model/store';
 
 const useTutorialUseCase = () => {
-    const setState = useTutorialStore((state) => state.setState);
-    const initState = useTutorialStore((state) => state.reset);
-    const setMakeTutorial = useCallback((showMakeTutorial: boolean) => setState('showMakeTutorial', showMakeTutorial), [setState]);
-    const setMemberTutorial = useCallback((showMemberTutorial: boolean) => setState('showMemberTutorial', showMemberTutorial), [setState]);
-    const setRequestTutorial = useCallback(
-        (showRequestTutorial: boolean) => setState('showRequestTutorial', showRequestTutorial),
-        [setState],
-    );
+    const initTutorial = useTutorialStore((state) => state.resetTutorial);
+    const setMakeTutorial = useTutorialStore((state) => state.setMakeTutorial);
+    const setMemberTutorial = useTutorialStore((state) => state.setMemberTutorial);
+    const setRequestTutorial = useTutorialStore((state) => state.setRequestTutorial);
 
     return {
-        initTutorial: initState,
-        setMakeTutorial,
-        setMemberTutorial,
-        setRequestTutorial,
+        initTutorial: useCallback(() => initTutorial(), [initTutorial]),
+        setMakeTutorial: useCallback((showMakeTutorial: boolean) => setMakeTutorial(showMakeTutorial), [setMakeTutorial]),
+        setMemberTutorial: useCallback((showMemberTutorial: boolean) => setMemberTutorial(showMemberTutorial), [setMemberTutorial]),
+        setRequestTutorial: useCallback((showRequestTutorial: boolean) => setRequestTutorial(showRequestTutorial), [setRequestTutorial]),
     };
 };
 

--- a/apps/app/src/features/tutorial/index.ts
+++ b/apps/app/src/features/tutorial/index.ts
@@ -1,4 +1,3 @@
-import {useCallback} from 'react';
 import {useTutorialStore} from './model/store';
 
 const useTutorialUseCase = () => {
@@ -8,10 +7,10 @@ const useTutorialUseCase = () => {
     const setRequestTutorial = useTutorialStore((state) => state.setRequestTutorial);
 
     return {
-        initTutorial: useCallback(() => initTutorial(), [initTutorial]),
-        setMakeTutorial: useCallback((showMakeTutorial: boolean) => setMakeTutorial(showMakeTutorial), [setMakeTutorial]),
-        setMemberTutorial: useCallback((showMemberTutorial: boolean) => setMemberTutorial(showMemberTutorial), [setMemberTutorial]),
-        setRequestTutorial: useCallback((showRequestTutorial: boolean) => setRequestTutorial(showRequestTutorial), [setRequestTutorial]),
+        initTutorial,
+        setMakeTutorial,
+        setMemberTutorial,
+        setRequestTutorial,
     };
 };
 

--- a/apps/app/src/features/tutorial/model/store.ts
+++ b/apps/app/src/features/tutorial/model/store.ts
@@ -8,4 +8,10 @@ const initialState = {
 
 export const useTutorialStore = createStore(initialState, {
     name: 'useTutorialStore',
+    actions: ({set, reset}) => ({
+        resetTutorial: reset,
+        setMakeTutorial: (showMakeTutorial: boolean) => set('showMakeTutorial', showMakeTutorial),
+        setRequestTutorial: (showRequestTutorial: boolean) => set('showRequestTutorial', showRequestTutorial),
+        setMemberTutorial: (showMemberTutorial: boolean) => set('showMemberTutorial', showMemberTutorial),
+    }),
 });

--- a/apps/app/src/shared/util/__tests__/create-store.test.ts
+++ b/apps/app/src/shared/util/__tests__/create-store.test.ts
@@ -36,6 +36,8 @@ describe('createStore', () => {
             count: 1,
             label: 'updated',
         });
+        expect('unsafePatch' in useCounterStore.getState()).toBe(false);
+        expect('unsafeSetState' in useCounterStore.getState()).toBe(false);
     });
 
     it('supports narrowed persist payloads through custom partialize typing', () => {

--- a/apps/app/src/shared/util/__tests__/create-store.test.ts
+++ b/apps/app/src/shared/util/__tests__/create-store.test.ts
@@ -1,0 +1,59 @@
+import {afterEach, describe, expect, it} from 'vitest';
+import {createStore} from '../create-store';
+
+describe('createStore', () => {
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    it('exposes explicit actions while keeping persisted payload limited to state keys', () => {
+        const useCounterStore = createStore(
+            {
+                count: 0,
+                label: 'idle',
+            },
+            {
+                name: 'useCounterStore',
+                persist: true,
+                actions: ({patch, reset}) => ({
+                    increase: () => patch((prev) => ({count: prev.count + 1, label: 'updated'})),
+                    resetCounter: reset,
+                }),
+            },
+        );
+
+        useCounterStore.getState().increase();
+
+        expect(useCounterStore.getState()).toMatchObject({
+            count: 1,
+            label: 'updated',
+        });
+        expect(useCounterStore.getState().resetCounter).toBeTypeOf('function');
+
+        const persisted = JSON.parse(localStorage.getItem('useCounterStore') ?? '{}');
+
+        expect(persisted.state).toEqual({
+            count: 1,
+            label: 'updated',
+        });
+    });
+
+    it('only exposes unsafe mutators when a store opts into the migration escape hatch', () => {
+        const useDraftStore = createStore(
+            {
+                value: 1,
+            },
+            {
+                name: 'useDraftStore',
+                unsafeMutators: true,
+            },
+        );
+
+        useDraftStore.getState().unsafePatch({
+            value: 3,
+        });
+
+        expect(useDraftStore.getState().value).toBe(3);
+        expect('unsafePatch' in useDraftStore.getState()).toBe(true);
+    });
+});

--- a/apps/app/src/shared/util/__tests__/create-store.test.ts
+++ b/apps/app/src/shared/util/__tests__/create-store.test.ts
@@ -38,6 +38,48 @@ describe('createStore', () => {
         });
     });
 
+    it('supports narrowed persist payloads through custom partialize typing', () => {
+        const useSessionStore = createStore<
+            {token: string | null; profileId: number | null; transientError: string | null},
+            {setSession: (token: string, profileId: number) => void},
+            false,
+            {token: string | null; profileId: number | null}
+        >(
+            {
+                token: null,
+                profileId: null,
+                transientError: null,
+            },
+            {
+                name: 'useSessionStore',
+                persist: true,
+                actions: ({patch}) => ({
+                    setSession: (token, profileId) =>
+                        patch({
+                            token,
+                            profileId,
+                        }),
+                }),
+                persistOptions: {
+                    partialize: ({token, profileId}) => ({
+                        token,
+                        profileId,
+                    }),
+                },
+            },
+        );
+
+        useSessionStore.getState().setSession('token', 7);
+
+        const persisted = JSON.parse(localStorage.getItem('useSessionStore') ?? '{}');
+
+        expect(persisted.state).toEqual({
+            token: 'token',
+            profileId: 7,
+        });
+        expect(persisted.state.transientError).toBeUndefined();
+    });
+
     it('only exposes unsafe mutators when a store opts into the migration escape hatch', () => {
         const useDraftStore = createStore(
             {

--- a/apps/app/src/shared/util/create-store.ts
+++ b/apps/app/src/shared/util/create-store.ts
@@ -3,37 +3,116 @@ import {devtools, persist, type PersistOptions} from 'zustand/middleware';
 import {shallow} from 'zustand/shallow';
 import {createWithEqualityFn} from 'zustand/traditional';
 
-export type TStoreActions<S extends object> = {
-    setState: <K extends keyof S>(key: K, value: S[K]) => void;
-    patch: (partial: Partial<S> | ((prev: S) => Partial<S>)) => void;
+export type TStorePatch<S extends object> = Partial<S> | ((prev: S) => Partial<S>);
+
+export type TStoreWriteHelpers<S extends object> = {
+    set: <K extends keyof S>(key: K, value: S[K]) => void;
+    patch: (partial: TStorePatch<S>) => void;
     reset: () => void;
+    getState: () => S;
 };
 
-export type TStoreOf<S extends object> = S & TStoreActions<S>;
+export type TUnsafeStoreMutators<S extends object> = {
+    unsafeSetState: <K extends keyof S>(key: K, value: S[K]) => void;
+    unsafePatch: (partial: TStorePatch<S>) => void;
+};
 
-type TOptions<S extends object> = {
+export type TStoreOf<S extends object, A extends object = {}, TUnsafe extends boolean = false> = S &
+    A & {
+        reset: () => void;
+    } & (TUnsafe extends true ? TUnsafeStoreMutators<S> : object);
+
+type TOptions<S extends object, A extends object, TUnsafe extends boolean> = {
     name: string;
+    actions?: (helpers: TStoreWriteHelpers<S>) => A;
     persist?: boolean;
     devtools?: boolean;
-    persistOptions?: Omit<PersistOptions<TStoreOf<S>>, 'name'>;
+    unsafeMutators?: TUnsafe;
+    persistOptions?: Omit<PersistOptions<TStoreOf<S, A, TUnsafe>, S>, 'name'>;
     equalityFn?: typeof shallow;
 };
 
-export function createStore<S extends object>(initialState: S, opts: TOptions<S>): UseBoundStore<StoreApi<TStoreOf<S>>> {
-    const {name, persist: usePersist = false, devtools: useDevtools = true, persistOptions, equalityFn = shallow} = opts;
-    const baseCreator: StateCreator<TStoreOf<S>> = (set) => ({
-        ...initialState,
-        setState: (key, value) => set((prev) => ({...prev, [key]: value})),
-        patch: (partial) => set((prev) => ({...prev, ...(typeof partial === 'function' ? partial(prev) : partial)})),
-        reset: () => set(() => ({...initialState})),
-    });
+function pickState<S extends object, TStore extends Record<keyof S, unknown>>(store: TStore, stateKeys: Array<keyof S>): S {
+    return stateKeys.reduce<S>((acc, key) => {
+        acc[key] = store[key] as unknown as S[typeof key];
+
+        return acc;
+    }, {} as S);
+}
+
+export function createStoreWriteHelpers<S extends object, TStore extends Record<keyof S, unknown>>({
+    set,
+    get,
+    initialState,
+}: {
+    set: StoreApi<TStore>['setState'];
+    get: StoreApi<TStore>['getState'];
+    initialState: S;
+}): TStoreWriteHelpers<S> {
+    const stateKeys = Object.keys(initialState) as Array<keyof S>;
+    const toState = (store: TStore) => pickState<S, TStore>(store, stateKeys);
+
+    return {
+        set: (key, value) => set((prev) => ({...prev, [key]: value})),
+        patch: (partial) =>
+            set((prev) => {
+                const prevState = toState(prev);
+                const nextPartial = typeof partial === 'function' ? partial(prevState) : partial;
+
+                return {...prev, ...nextPartial};
+            }),
+        reset: () => set((prev) => ({...prev, ...initialState})),
+        getState: () => toState(get()),
+    };
+}
+
+// Store standard:
+// - keep generic set/patch private to the store factory
+// - expose explicit actions from the public store API
+// - reserve unsafe mutators for temporary migration paths only
+export function createStore<S extends object, A extends object = {}, TUnsafe extends boolean = false>(
+    initialState: S,
+    opts: TOptions<S, A, TUnsafe>,
+): UseBoundStore<StoreApi<TStoreOf<S, A, TUnsafe>>> {
+    const {
+        name,
+        actions: createActions,
+        persist: usePersist = false,
+        devtools: useDevtools = true,
+        unsafeMutators = false as TUnsafe,
+        persistOptions,
+        equalityFn = shallow,
+    } = opts;
+    const stateKeys = Object.keys(initialState) as Array<keyof S>;
+    const baseCreator: StateCreator<TStoreOf<S, A, TUnsafe>> = (set, get) => {
+        const helpers = createStoreWriteHelpers<S, TStoreOf<S, A, TUnsafe>>({
+            set,
+            get,
+            initialState,
+        });
+        const actions = (createActions?.(helpers) ?? {}) as A;
+        const unsafe = unsafeMutators
+            ? ({
+                  unsafeSetState: helpers.set,
+                  unsafePatch: helpers.patch,
+              } as TUnsafeStoreMutators<S>)
+            : {};
+
+        return {
+            ...initialState,
+            ...actions,
+            ...unsafe,
+            reset: helpers.reset,
+        } as TStoreOf<S, A, TUnsafe>;
+    };
     const withPersist = usePersist
         ? (persist(baseCreator, {
               name,
+              partialize: (state) => pickState<S, TStoreOf<S, A, TUnsafe>>(state, stateKeys),
               ...persistOptions,
-          }) as StateCreator<TStoreOf<S>>)
+          }) as StateCreator<TStoreOf<S, A, TUnsafe>>)
         : baseCreator;
-    const withDevtools = useDevtools ? devtools(withPersist) : withPersist;
+    const withDevtools = useDevtools ? devtools(withPersist, {name}) : withPersist;
 
-    return createWithEqualityFn<TStoreOf<S>>(withDevtools as StateCreator<TStoreOf<S>>, equalityFn);
+    return createWithEqualityFn<TStoreOf<S, A, TUnsafe>>(withDevtools as StateCreator<TStoreOf<S, A, TUnsafe>>, equalityFn);
 }

--- a/apps/app/src/shared/util/create-store.ts
+++ b/apps/app/src/shared/util/create-store.ts
@@ -22,13 +22,13 @@ export type TStoreOf<S extends object, A extends object = {}, TUnsafe extends bo
         reset: () => void;
     } & (TUnsafe extends true ? TUnsafeStoreMutators<S> : object);
 
-type TOptions<S extends object, A extends object, TUnsafe extends boolean> = {
+type TOptions<S extends object, A extends object, TUnsafe extends boolean, TPersistedState extends object> = {
     name: string;
     actions?: (helpers: TStoreWriteHelpers<S>) => A;
     persist?: boolean;
     devtools?: boolean;
     unsafeMutators?: TUnsafe;
-    persistOptions?: Omit<PersistOptions<TStoreOf<S, A, TUnsafe>, S>, 'name'>;
+    persistOptions?: Omit<PersistOptions<TStoreOf<S, A, TUnsafe>, TPersistedState>, 'name'>;
     equalityFn?: typeof shallow;
 };
 
@@ -70,9 +70,10 @@ export function createStoreWriteHelpers<S extends object, TStore extends Record<
 // - keep generic set/patch private to the store factory
 // - expose explicit actions from the public store API
 // - reserve unsafe mutators for temporary migration paths only
-export function createStore<S extends object, A extends object = {}, TUnsafe extends boolean = false>(
+// - allow persist partialize to narrow the stored shape when needed
+export function createStore<S extends object, A extends object = {}, TUnsafe extends boolean = false, TPersistedState extends object = S>(
     initialState: S,
-    opts: TOptions<S, A, TUnsafe>,
+    opts: TOptions<S, A, TUnsafe, TPersistedState>,
 ): UseBoundStore<StoreApi<TStoreOf<S, A, TUnsafe>>> {
     const {
         name,
@@ -106,11 +107,19 @@ export function createStore<S extends object, A extends object = {}, TUnsafe ext
         } as TStoreOf<S, A, TUnsafe>;
     };
     const withPersist = usePersist
-        ? (persist(baseCreator, {
-              name,
-              partialize: (state) => pickState<S, TStoreOf<S, A, TUnsafe>>(state, stateKeys),
-              ...persistOptions,
-          }) as StateCreator<TStoreOf<S, A, TUnsafe>>)
+        ? (() => {
+              const resolvedPersistOptions = {
+                  name,
+                  ...persistOptions,
+              } as PersistOptions<TStoreOf<S, A, TUnsafe>, TPersistedState>;
+
+              if (!resolvedPersistOptions.partialize) {
+                  resolvedPersistOptions.partialize = (state) =>
+                      pickState<S, TStoreOf<S, A, TUnsafe>>(state, stateKeys) as unknown as TPersistedState;
+              }
+
+              return persist(baseCreator, resolvedPersistOptions) as StateCreator<TStoreOf<S, A, TUnsafe>>;
+          })()
         : baseCreator;
     const withDevtools = useDevtools ? devtools(withPersist, {name}) : withPersist;
 

--- a/apps/app/src/shared/util/create-store.ts
+++ b/apps/app/src/shared/util/create-store.ts
@@ -33,11 +33,11 @@ type TOptions<S extends object, A extends object, TUnsafe extends boolean, TPers
 };
 
 function pickState<S extends object, TStore extends Record<keyof S, unknown>>(store: TStore, stateKeys: Array<keyof S>): S {
-    return stateKeys.reduce<S>((acc, key) => {
+    return stateKeys.reduce<Partial<S>>((acc, key) => {
         acc[key] = store[key] as unknown as S[typeof key];
 
         return acc;
-    }, {} as S);
+    }, {}) as S;
 }
 
 export function createStoreWriteHelpers<S extends object, TStore extends Record<keyof S, unknown>>({


### PR DESCRIPTION
## Motivation

shared store 생성 방식이 섞여 있어 generic mutation 사용 범위가 넓었습니다.
이번 변경은 외부 공개 API를 explicit action 중심으로 정리하고, 이후 `auth`/`request-shift`/`make-shift`/`duty` 리팩토링이 같은 기준으로 이어질 수 있는 최소 기반을 만드는 데 목적이 있습니다.

- 티켓: [DUT-975](https://gom3.atlassian.net/browse/DUT-975)
- 배경: `setState`/`patch`가 외부 useCase까지 노출되어 상태 전이 의도가 흐려지고 있었습니다.
- 목표: 공통 store 표준 API를 정하고, 필요한 범위에 explicit action 패턴을 실제 적용합니다.

<br>

## Key Changes

- `create-store.ts`를 `internal write helpers(set/patch/reset/getState) + explicit public actions + reset` 구조로 재정의했습니다.
- persist 사용 시 action 함수들이 저장되지 않도록 기본 `partialize`를 state key 기준으로 정리했고, 과도기 예외는 `unsafePatch`/`unsafeSetState` opt-in으로만 열었습니다.
- `auth` store는 shared helper를 써서 `beginLogin`, `applyDemoSession`, `setAccountMeSuccess` 같은 명시적 action으로 바꿨고, `ui-config`/`loading`/`tutorial`도 같은 패턴으로 정리했습니다.
- 아직 대량 리팩토링이 부담되는 `edit-shift-team`은 과도기 escape hatch를 사용하도록 이름을 명확히 바꾸고 테스트를 맞췄습니다.
- `create-store` 표준 동작과 auth/edit-shift-team 회귀를 검증하는 테스트를 추가했습니다.

<br>

## To Reviewers

- 봐야 할 파일: `apps/app/src/shared/util/create-store.ts`, `apps/app/src/features/auth/model/store.ts`, `apps/app/src/features/auth/index.ts`
- 중점적으로 봐야 할 로직: public store API에서 generic mutation이 빠지고 explicit action만 남는 기준, 그리고 persist 시 action 함수가 저장되지 않는 처리
- 고려하는 지점 / 확인 필요한 부분: `edit-shift-team`은 아직 `unsafePatch`를 쓰는 과도기 상태입니다. 이후 `request-shift`, `make-shift`, `duty`도 같은 helper와 action naming 기준으로 옮길 수 있게 이번 변경을 최소 기반으로 잡았습니다.


[DUT-975]: https://gom3.atlassian.net/browse/DUT-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ