### PR TITLE
[DUT-976]: auth/request-shift store 전이 명시화

### DIFF
--- a/apps/app/src/features/auth/__tests__/index.test.tsx
+++ b/apps/app/src/features/auth/__tests__/index.test.tsx
@@ -40,9 +40,9 @@ vi.mock('@/analytics', () => ({
 }));
 
 vi.mock('@/features/request-shift/model/store', () => ({
-    useRequestShiftStore: (selector: (state: {resetState: () => void}) => unknown) =>
+    useRequestShiftStore: (selector: (state: {reset: () => void}) => unknown) =>
         selector({
-            resetState: mockResetRequestShiftState,
+            reset: mockResetRequestShiftState,
         }),
 }));
 

--- a/apps/app/src/features/auth/index.ts
+++ b/apps/app/src/features/auth/index.ts
@@ -27,22 +27,22 @@ const useAuth = (activeEffect = false) => {
         wardId,
         demoStartDate,
         _loaded,
-        beginLogin,
+        startLogin,
         applyDemoSession,
-        setAccountMeLoading,
-        setAccountMeSuccess,
-        setAccountMeError,
+        beginAccountBootstrap,
+        completeAccountBootstrap,
+        failAccountBootstrap,
         setDemoExpired: setAuthDemoExpired,
-        resetState,
+        resetSession,
     } = useAuthStore();
-    const resetRequestShiftState = useRequestShiftStore((state) => state.resetState);
+    const resetRequestShiftState = useRequestShiftStore((state) => state.reset);
     const {pathname} = useLocation();
     const {setLoading} = useLoadingUseCase();
     const {initTutorial} = useTutorialUseCase();
     const navigate = useNavigate();
     const resetSessionState = () => {
         resetRequestShiftState();
-        resetState();
+        resetSession();
         setAccessToken('');
     };
     const handleLogout = async (fallBackPath?: string) => {
@@ -52,7 +52,7 @@ const useAuth = (activeEffect = false) => {
         if (fallBackPath && pathname !== fallBackPath) navigate(fallBackPath);
     };
     const handleLogin = (accessToken: string, nextPageUrl?: string | null, options?: THandleLoginOptions) => {
-        beginLogin(accessToken, {preserveDemoStartDate: options?.preserveDemoStartDate});
+        startLogin(accessToken, {preserveDemoStartDate: options?.preserveDemoStartDate});
         setAccessToken(accessToken);
 
         const redirectDecision = getLoginRedirectDecision(nextPageUrl);
@@ -72,6 +72,7 @@ const useAuth = (activeEffect = false) => {
 
         try {
             initTutorial();
+
             const data = await AuthAPI.demoStart();
 
             applyDemoSession({
@@ -88,14 +89,14 @@ const useAuth = (activeEffect = false) => {
         }
     };
     const handleGetAccountMe = async () => {
-        setAccountMeLoading();
+        beginAccountBootstrap();
 
         try {
             const account = await AccountAPI.getAccountMe();
 
-            setAccountMeSuccess(account);
+            completeAccountBootstrap(account);
         } catch (error) {
-            setAccountMeError();
+            failAccountBootstrap();
             throw error;
         }
     };

--- a/apps/app/src/features/auth/model/store.ts
+++ b/apps/app/src/features/auth/model/store.ts
@@ -1,8 +1,7 @@
-import {create} from 'zustand';
-import {devtools, persist, type PersistStorage, type StorageValue} from 'zustand/middleware';
+import {type PersistStorage, type StorageValue} from 'zustand/middleware';
 import {type TAccount} from '@/entities/account';
 import {setAccessToken} from '@/shared/api/client';
-import {createStoreWriteHelpers} from '@/shared/util/create-store';
+import {createStore} from '@/shared/util/create-store';
 
 interface IState {
     accountMe: TAccount | null;
@@ -15,23 +14,6 @@ interface IState {
     wardId: number | null;
     demoStartDate: string | null;
     _loaded: boolean;
-}
-
-interface IStore extends IState {
-    beginLogin: (accessToken: string, options?: {preserveDemoStartDate?: boolean}) => void;
-    applyDemoSession: (payload: {
-        accessToken: string;
-        accountId: number | null;
-        nurseId: number | null;
-        wardId: number | null;
-        demoStartDate: string;
-    }) => void;
-    setAccountMeLoading: () => void;
-    setAccountMeSuccess: (account: TAccount) => void;
-    setAccountMeError: () => void;
-    setDemoExpired: (expired: boolean) => void;
-    markHydrated: () => void;
-    resetState: () => void;
 }
 
 type TPersistedAuthState = Pick<IState, 'isAuth' | 'accessToken' | 'accountId' | 'nurseId' | 'wardId' | 'demoStartDate'>;
@@ -65,83 +47,103 @@ const authStoreStorage: PersistStorage<TPersistedAuthState> = {
     setItem: (name, value) => localStorage.setItem(name, JSON.stringify(value)),
     removeItem: (name) => localStorage.removeItem(name),
 };
-const useAuthStore = create<IStore>()(
-    devtools(
-        persist(
-            (set, get) => {
-                const {set: setField, patch} = createStoreWriteHelpers<IState, IStore>({
-                    set,
-                    get,
-                    initialState,
-                });
+const useAuthStore = createStore<
+    IState,
+    {
+        startLogin: (accessToken: string, options?: {preserveDemoStartDate?: boolean}) => void;
+        applyDemoSession: (payload: {
+            accessToken: string;
+            accountId: number | null;
+            nurseId: number | null;
+            wardId: number | null;
+            demoStartDate: string;
+        }) => void;
+        beginAccountBootstrap: () => void;
+        completeAccountBootstrap: (account: TAccount) => void;
+        failAccountBootstrap: () => void;
+        setDemoExpired: (expired: boolean) => void;
+        completeHydration: () => void;
+        resetSession: () => void;
+    },
+    false,
+    TPersistedAuthState
+>(initialState, {
+    name: 'useAuthStore',
+    persist: true,
+    actions: ({patch}) => ({
+        startLogin: (accessToken, options) =>
+            patch((prev) => ({
+                accountMe: null,
+                accountMeStatus: 'loading',
+                isAuth: true,
+                isDemoExpired: false,
+                accessToken,
+                accountId: null,
+                nurseId: null,
+                wardId: null,
+                demoStartDate: options?.preserveDemoStartDate ? prev.demoStartDate : null,
+            })),
+        applyDemoSession: ({accessToken, accountId, nurseId, wardId, demoStartDate}) =>
+            patch({
+                accountMe: null,
+                accessToken,
+                accountId,
+                nurseId,
+                wardId,
+                isAuth: true,
+                isDemoExpired: false,
+                accountMeStatus: 'success',
+                demoStartDate,
+            }),
+        beginAccountBootstrap: () =>
+            patch({
+                accountMeStatus: 'loading',
+            }),
+        completeAccountBootstrap: (account) =>
+            patch({
+                accountMe: account,
+                wardId: account.wardId,
+                accountId: account.accountId,
+                nurseId: account.nurseId,
+                isAuth: true,
+                accountMeStatus: 'success',
+            }),
+        failAccountBootstrap: () =>
+            patch({
+                accountMeStatus: 'error',
+            }),
+        setDemoExpired: (expired) =>
+            patch({
+                isDemoExpired: expired,
+            }),
+        completeHydration: () =>
+            patch({
+                _loaded: true,
+            }),
+        resetSession: () =>
+            patch({
+                ...initialState,
+                _loaded: true,
+            }),
+    }),
+    persistOptions: {
+        storage: authStoreStorage,
+        partialize: ({isAuth, accessToken, accountId, nurseId, wardId, demoStartDate}): TPersistedAuthState => {
+            if (accessToken) setAccessToken(accessToken);
 
-                return {
-                    ...initialState,
-                    beginLogin: (accessToken, options) =>
-                        patch((prev) => ({
-                            accountMe: null,
-                            accountMeStatus: 'loading',
-                            isAuth: true,
-                            isDemoExpired: false,
-                            accessToken,
-                            accountId: null,
-                            nurseId: null,
-                            wardId: null,
-                            demoStartDate: options?.preserveDemoStartDate ? prev.demoStartDate : null,
-                        })),
-                    applyDemoSession: ({accessToken, accountId, nurseId, wardId, demoStartDate}) =>
-                        patch({
-                            accountMe: null,
-                            accessToken,
-                            accountId,
-                            nurseId,
-                            wardId,
-                            isAuth: true,
-                            isDemoExpired: false,
-                            accountMeStatus: 'success',
-                            demoStartDate,
-                        }),
-                    setAccountMeLoading: () => setField('accountMeStatus', 'loading'),
-                    setAccountMeSuccess: (account) =>
-                        patch({
-                            accountMe: account,
-                            wardId: account.wardId,
-                            accountId: account.accountId,
-                            nurseId: account.nurseId,
-                            isAuth: true,
-                            accountMeStatus: 'success',
-                        }),
-                    setAccountMeError: () => setField('accountMeStatus', 'error'),
-                    setDemoExpired: (expired) => setField('isDemoExpired', expired),
-                    markHydrated: () => setField('_loaded', true),
-                    resetState: () =>
-                        patch({
-                            ...initialState,
-                            _loaded: true,
-                        }),
-                };
-            },
-            {
-                name: 'useAuthStore',
-                storage: authStoreStorage,
-                partialize: ({isAuth, accessToken, accountId, nurseId, wardId, demoStartDate}: IStore): TPersistedAuthState => {
-                    if (accessToken) setAccessToken(accessToken);
-
-                    return {
-                        isAuth,
-                        accessToken,
-                        accountId,
-                        nurseId,
-                        wardId,
-                        demoStartDate,
-                    };
-                },
-                onRehydrateStorage: (state) => (rehydratedState) => {
-                    (rehydratedState ?? state).markHydrated();
-                },
-            },
-        ),
-    ),
-);
+            return {
+                isAuth,
+                accessToken,
+                accountId,
+                nurseId,
+                wardId,
+                demoStartDate,
+            };
+        },
+        onRehydrateStorage: (state) => (rehydratedState) => {
+            (rehydratedState ?? state).completeHydration();
+        },
+    },
+});
 
 export default useAuthStore;

--- a/apps/app/src/features/request-shift/index.ts
+++ b/apps/app/src/features/request-shift/index.ts
@@ -7,15 +7,11 @@ import useAuth from '@/features/auth';
 import {WardAPI} from '@/shared/api';
 import {showActionErrorFeedback, showValidationFeedback} from '@/shared/util/feedback';
 import {
-    createInitialFoldedLevels,
-    createWardShiftTypeMap,
     findDutyRequestByFocus,
     getAdjacentRequestShiftDate,
     getRequestShiftBootstrapStatus,
     getRequestShiftMonthChangeDecision,
     getRequestShiftTypeIdAtFocus,
-    shouldResetFoldedLevelsOnRequestLoad,
-    shouldSyncFoldedLevelsLength,
 } from './model/request-shift';
 import {useRequestShiftStore} from './model/store';
 import {type TFocus} from './model/types';
@@ -30,12 +26,23 @@ const useRequestShift = (activeEffect = false) => {
         focus,
         foldedLevels,
         currentShiftTeamId,
-        oldCurrentShiftTeamId,
         wardShiftTypeMap,
         readonly,
         changeStatus,
         updatingRequestId,
-        setState,
+        syncShiftTeams,
+        loadRequestShift,
+        setCalendarDate,
+        selectFocus,
+        toggleFoldedLevel,
+        enterEditMode,
+        enterReadonlyMode,
+        selectShiftTeam,
+        startRequestChange,
+        completeRequestChange,
+        resetRequestChangeStatus,
+        startRequestDecision,
+        finishRequestDecision,
     } = useRequestShiftStore();
     const {
         state: {wardId, isAuth, _loaded, accountMeStatus},
@@ -61,19 +68,7 @@ const useRequestShift = (activeEffect = false) => {
         queryFn: async () => {
             const res = await WardAPI.getShiftTeams(wardId!);
 
-            if (res.length === 0) {
-                setState('currentShiftTeamId', null);
-
-                return res;
-            }
-
-            if (currentShiftTeamId) {
-                if (res.every((shiftTeam) => shiftTeam.shiftTeamId !== currentShiftTeamId)) {
-                    setState('currentShiftTeamId', res[0].shiftTeamId);
-                }
-            } else {
-                setState('currentShiftTeamId', res[0].shiftTeamId);
-            }
+            syncShiftTeams(res);
 
             return res;
         },
@@ -98,16 +93,7 @@ const useRequestShift = (activeEffect = false) => {
 
             if (res === null) return null as unknown as TRequestShift;
 
-            if (
-                shouldResetFoldedLevelsOnRequestLoad({
-                    foldedLevels,
-                    previousShiftTeamId: oldCurrentShiftTeamId,
-                    currentShiftTeamId,
-                })
-            ) {
-                setState('foldedLevels', createInitialFoldedLevels(res));
-                setState('oldCurrentShiftTeamId', currentShiftTeamId);
-            }
+            loadRequestShift(res);
 
             return res;
         },
@@ -120,7 +106,9 @@ const useRequestShift = (activeEffect = false) => {
         requestShiftQueryKey,
         wardShiftTypeMap,
         queryClient,
-        setChangeStatus: (status) => setState('changeStatus', status),
+        startRequestChange,
+        completeRequestChange,
+        resetRequestChangeStatus,
     });
     const acceptRequests = useCallback(
         async (reqShiftIds: number[], isAccepted: boolean | null) => {
@@ -128,7 +116,7 @@ const useRequestShift = (activeEffect = false) => {
 
             if (reqShiftIds.length === 0 || useRequestShiftStore.getState().updatingRequestId !== null) return false;
 
-            setState('updatingRequestId', reqShiftIds.length === 1 ? reqShiftIds[0] : -1);
+            startRequestDecision(reqShiftIds.length === 1 ? reqShiftIds[0] : -1);
 
             try {
                 const results = await Promise.allSettled(
@@ -147,10 +135,10 @@ const useRequestShift = (activeEffect = false) => {
 
                 return rejectedResults.length === 0;
             } finally {
-                setState('updatingRequestId', null);
+                finishRequestDecision();
             }
         },
-        [dutyRequestQueryKey, queryClient, requestShiftQueryKey, setState, wardId],
+        [dutyRequestQueryKey, finishRequestDecision, queryClient, requestShiftQueryKey, startRequestDecision, wardId],
     );
     const acceptRequest = useCallback(
         async (reqShiftId: number, isAccepted: boolean | null) => {
@@ -173,13 +161,12 @@ const useRequestShift = (activeEffect = false) => {
         }
 
         if (decision.shouldEnableReadonly) {
-            setState('readonly', true);
+            enterReadonlyMode();
         }
 
         if (decision.shouldBlock) return false;
 
-        setState('year', decision.year);
-        setState('month', decision.month);
+        setCalendarDate(decision.year, decision.month);
 
         return true;
     };
@@ -207,10 +194,7 @@ const useRequestShift = (activeEffect = false) => {
     const foldLevel = (level: number) => {
         if (!requestShift || !foldedLevels) return;
 
-        setState(
-            'foldedLevels',
-            foldedLevels.map((isFolded, index) => (index === level ? !isFolded : isFolded)),
-        );
+        toggleFoldedLevel(level);
     };
 
     useRequestShiftKeyboard({
@@ -218,7 +202,7 @@ const useRequestShift = (activeEffect = false) => {
         focus,
         requestShift,
         changeFocusedShift,
-        setFocus: (nextFocus) => setState('focus', nextFocus),
+        setFocus: selectFocus,
     });
 
     const handleToggleEditMode = (targetDate?: {year: number; month: number}) => {
@@ -231,17 +215,12 @@ const useRequestShift = (activeEffect = false) => {
                 return false;
             }
 
-            setState('readonly', false);
+            enterEditMode();
 
             return true;
         }
 
-        setState('readonly', true);
-        setState('focus', null);
-
-        if (requestShift) {
-            setState('foldedLevels', createInitialFoldedLevels(requestShift));
-        }
+        enterReadonlyMode(requestShift);
 
         return true;
     };
@@ -258,12 +237,7 @@ const useRequestShift = (activeEffect = false) => {
                       month: nextMonth,
                   };
 
-        if (nextMonth > 12) {
-            setState('year', year + 1);
-            setState('month', 1);
-        } else {
-            setState('month', nextMonth);
-        }
+        setCalendarDate(nextDate.year, nextDate.month);
 
         handleToggleEditMode(nextDate);
     };
@@ -287,18 +261,7 @@ const useRequestShift = (activeEffect = false) => {
         if (!activeEffect || !requestShift) return;
 
         window.dispatchEvent(new Event('resize'));
-
-        if (
-            shouldSyncFoldedLevelsLength({
-                foldedLevels,
-                requestShift,
-            })
-        ) {
-            setState('foldedLevels', createInitialFoldedLevels(requestShift));
-        }
-
-        setState('wardShiftTypeMap', createWardShiftTypeMap(requestShift));
-    }, [activeEffect, foldedLevels, requestShift, setState]);
+    }, [activeEffect, requestShift]);
 
     return {
         queryKey: {
@@ -334,11 +297,11 @@ const useRequestShift = (activeEffect = false) => {
             foldLevel,
             changeMonth,
             retry,
-            changeFocus: (nextFocus: TFocus | null) => setState('focus', nextFocus),
+            changeFocus: selectFocus,
             changeShiftTeam: (shiftTeam: TShiftTeam) => {
                 if (shiftTeam.shiftTeamId === currentShiftTeamId) return false;
 
-                setState('currentShiftTeamId', shiftTeam.shiftTeamId);
+                selectShiftTeam(shiftTeam.shiftTeamId);
 
                 return true;
             },

--- a/apps/app/src/features/request-shift/index.ts
+++ b/apps/app/src/features/request-shift/index.ts
@@ -4,6 +4,7 @@ import {type TRequestShift} from '@/entities/shift';
 import {type TShiftTeam} from '@/entities/ward';
 import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth';
+import useAuthStore from '@/features/auth/model/store';
 import {WardAPI} from '@/shared/api';
 import {showActionErrorFeedback, showValidationFeedback} from '@/shared/util/feedback';
 import {
@@ -12,6 +13,8 @@ import {
     getRequestShiftBootstrapStatus,
     getRequestShiftMonthChangeDecision,
     getRequestShiftTypeIdAtFocus,
+    shouldApplyRequestShiftResponseToStore,
+    shouldApplyShiftTeamsResponseToStore,
 } from './model/request-shift';
 import {useRequestShiftStore} from './model/store';
 import {type TFocus} from './model/types';
@@ -66,9 +69,17 @@ const useRequestShift = (activeEffect = false) => {
     } = useQuery({
         ...shiftTeamsQueryOptions,
         queryFn: async () => {
-            const res = await WardAPI.getShiftTeams(wardId!);
+            const requestedWardId = wardId!;
+            const res = await WardAPI.getShiftTeams(requestedWardId);
 
-            syncShiftTeams(res);
+            if (
+                shouldApplyShiftTeamsResponseToStore({
+                    requestedWardId,
+                    currentWardId: useAuthStore.getState().wardId,
+                })
+            ) {
+                syncShiftTeams(res);
+            }
 
             return res;
         },
@@ -89,11 +100,30 @@ const useRequestShift = (activeEffect = false) => {
     } = useQuery({
         ...requestShiftQueryOptions,
         queryFn: async (): Promise<TRequestShift> => {
-            const res = await WardAPI.getReqShift(wardId!, currentShiftTeamId!, year, month);
+            const requestedWardId = wardId!;
+            const requestedShiftTeamId = currentShiftTeamId!;
+            const requestedYear = year;
+            const requestedMonth = month;
+            const res = await WardAPI.getReqShift(requestedWardId, requestedShiftTeamId, requestedYear, requestedMonth);
 
             if (res === null) return null as unknown as TRequestShift;
 
-            loadRequestShift(res);
+            const currentRequestShiftState = useRequestShiftStore.getState();
+
+            if (
+                shouldApplyRequestShiftResponseToStore({
+                    requestedWardId,
+                    requestedShiftTeamId,
+                    requestedYear,
+                    requestedMonth,
+                    currentWardId: useAuthStore.getState().wardId,
+                    currentShiftTeamId: currentRequestShiftState.currentShiftTeamId,
+                    currentYear: currentRequestShiftState.year,
+                    currentMonth: currentRequestShiftState.month,
+                })
+            ) {
+                loadRequestShift(res);
+            }
 
             return res;
         },

--- a/apps/app/src/features/request-shift/model/__tests__/request-shift.test.ts
+++ b/apps/app/src/features/request-shift/model/__tests__/request-shift.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from 'vitest';
 import type {TDutyRequest, TRequestShift} from '@/entities/shift';
+import type {TShiftTeam} from '@/entities/ward';
 import {
     createInitialFoldedLevels,
     createWardShiftTypeMap,
@@ -9,6 +10,7 @@ import {
     getRequestShiftChangeEventMessage,
     getRequestShiftMonthChangeDecision,
     getRequestShiftTypeIdAtFocus,
+    resolveCurrentRequestShiftTeamId,
     shouldResetFoldedLevelsOnRequestLoad,
     shouldSyncFoldedLevelsLength,
 } from '../request-shift';
@@ -89,6 +91,7 @@ const dutyRequestFixture: TDutyRequest[] = [
         isAccepted: null,
     },
 ];
+const shiftTeamsFixture: TShiftTeam[] = [{shiftTeamId: 1, name: 'A팀'} as TShiftTeam, {shiftTeamId: 2, name: 'B팀'} as TShiftTeam];
 
 describe('useRequestShift model', () => {
     const now = new Date('2026-03-21T09:00:00+09:00');
@@ -124,6 +127,18 @@ describe('useRequestShift model', () => {
 
     it('folded level 초기화와 동기화 조건을 계산한다', () => {
         expect(createInitialFoldedLevels(requestShiftFixture)).toEqual([false, false]);
+        expect(
+            resolveCurrentRequestShiftTeamId({
+                shiftTeams: shiftTeamsFixture,
+                currentShiftTeamId: 2,
+            }),
+        ).toBe(2);
+        expect(
+            resolveCurrentRequestShiftTeamId({
+                shiftTeams: shiftTeamsFixture,
+                currentShiftTeamId: 9,
+            }),
+        ).toBe(1);
         expect(
             shouldResetFoldedLevelsOnRequestLoad({
                 foldedLevels: [false],

--- a/apps/app/src/features/request-shift/model/__tests__/request-shift.test.ts
+++ b/apps/app/src/features/request-shift/model/__tests__/request-shift.test.ts
@@ -11,6 +11,8 @@ import {
     getRequestShiftMonthChangeDecision,
     getRequestShiftTypeIdAtFocus,
     resolveCurrentRequestShiftTeamId,
+    shouldApplyRequestShiftResponseToStore,
+    shouldApplyShiftTeamsResponseToStore,
     shouldResetFoldedLevelsOnRequestLoad,
     shouldSyncFoldedLevelsLength,
 } from '../request-shift';
@@ -152,6 +154,46 @@ describe('useRequestShift model', () => {
                 requestShift: requestShiftFixture,
             }),
         ).toBe(true);
+    });
+
+    it('stale query response가 최신 selection을 덮어쓰지 않도록 guard를 계산한다', () => {
+        expect(
+            shouldApplyShiftTeamsResponseToStore({
+                requestedWardId: 10,
+                currentWardId: 10,
+            }),
+        ).toBe(true);
+        expect(
+            shouldApplyShiftTeamsResponseToStore({
+                requestedWardId: 10,
+                currentWardId: 11,
+            }),
+        ).toBe(false);
+
+        expect(
+            shouldApplyRequestShiftResponseToStore({
+                requestedWardId: 10,
+                requestedShiftTeamId: 2,
+                requestedYear: 2026,
+                requestedMonth: 4,
+                currentWardId: 10,
+                currentShiftTeamId: 2,
+                currentYear: 2026,
+                currentMonth: 4,
+            }),
+        ).toBe(true);
+        expect(
+            shouldApplyRequestShiftResponseToStore({
+                requestedWardId: 10,
+                requestedShiftTeamId: 2,
+                requestedYear: 2026,
+                requestedMonth: 4,
+                currentWardId: 10,
+                currentShiftTeamId: 3,
+                currentYear: 2026,
+                currentMonth: 4,
+            }),
+        ).toBe(false);
     });
 
     it('월 이동 정책을 순수 계산으로 분리한다', () => {

--- a/apps/app/src/features/request-shift/model/__tests__/store.test.ts
+++ b/apps/app/src/features/request-shift/model/__tests__/store.test.ts
@@ -1,0 +1,119 @@
+import {afterEach, describe, expect, it} from 'vitest';
+import {type TRequestShift} from '@/entities/shift';
+import {type TShiftTeam} from '@/entities/ward';
+import {useRequestShiftStore} from '../store';
+
+const shiftTeamsFixture: TShiftTeam[] = [{shiftTeamId: 1, name: 'A팀'} as TShiftTeam, {shiftTeamId: 2, name: 'B팀'} as TShiftTeam];
+const requestShiftFixture: TRequestShift = {
+    days: [{day: 1, dayType: 'workday'}],
+    wardShiftTypes: [
+        {
+            wardShiftTypeId: 11,
+            name: 'Day',
+            shortName: 'D',
+            startTime: '07:00',
+            endTime: '15:00',
+            color: '#111111',
+            isDefault: true,
+            isOff: false,
+            isCounted: true,
+            classification: 'DAY',
+        },
+    ],
+    divisionShiftNurses: [
+        [
+            {
+                shiftNurse: {
+                    shiftNurseId: 101,
+                    nurseId: 1001,
+                    name: '황인서',
+                    carried: 0,
+                    divisionNum: 1,
+                    priority: 1,
+                    isWorker: true,
+                },
+                carry: 0,
+                wardReqShiftList: [11],
+            },
+        ],
+        [
+            {
+                shiftNurse: {
+                    shiftNurseId: 102,
+                    nurseId: 1002,
+                    name: '김간호',
+                    carried: 0,
+                    divisionNum: 2,
+                    priority: 2,
+                    isWorker: true,
+                },
+                carry: 0,
+                wardReqShiftList: [null],
+            },
+        ],
+    ],
+};
+
+describe('useRequestShiftStore', () => {
+    afterEach(() => {
+        localStorage.clear();
+        useRequestShiftStore.getState().reset();
+    });
+
+    it('keeps the current shift team when still available and falls back when it is removed', () => {
+        useRequestShiftStore.getState().selectShiftTeam(2);
+        useRequestShiftStore.getState().syncShiftTeams(shiftTeamsFixture);
+
+        expect(useRequestShiftStore.getState().currentShiftTeamId).toBe(2);
+
+        useRequestShiftStore.getState().syncShiftTeams([{shiftTeamId: 1, name: 'A팀'} as TShiftTeam]);
+
+        expect(useRequestShiftStore.getState().currentShiftTeamId).toBe(1);
+
+        useRequestShiftStore.getState().syncShiftTeams([]);
+
+        expect(useRequestShiftStore.getState().currentShiftTeamId).toBeNull();
+    });
+
+    it('loads request shift data into folded levels and derived ward shift type state', () => {
+        useRequestShiftStore.getState().selectShiftTeam(2);
+        useRequestShiftStore.getState().loadRequestShift(requestShiftFixture);
+
+        expect(useRequestShiftStore.getState()).toMatchObject({
+            foldedLevels: [false, false],
+            oldCurrentShiftTeamId: 2,
+        });
+        expect(useRequestShiftStore.getState().wardShiftTypeMap?.get(11)?.shortName).toBe('D');
+    });
+
+    it('expresses edit mode and request processing transitions through explicit actions', () => {
+        useRequestShiftStore.getState().selectFocus({
+            shiftNurseId: 101,
+            shiftNurseName: '황인서',
+            day: 0,
+        });
+
+        useRequestShiftStore.getState().enterEditMode();
+        useRequestShiftStore.getState().startRequestChange();
+        useRequestShiftStore.getState().startRequestDecision(301);
+
+        expect(useRequestShiftStore.getState()).toMatchObject({
+            readonly: false,
+            changeStatus: 'loading',
+            updatingRequestId: 301,
+        });
+
+        useRequestShiftStore.getState().enterReadonlyMode(requestShiftFixture);
+        useRequestShiftStore.getState().completeRequestChange('success');
+        useRequestShiftStore.getState().finishRequestDecision();
+        useRequestShiftStore.getState().resetRequestChangeStatus();
+
+        expect(useRequestShiftStore.getState()).toMatchObject({
+            readonly: true,
+            focus: null,
+            foldedLevels: [false, false],
+            changeStatus: 'idle',
+            updatingRequestId: null,
+        });
+    });
+});

--- a/apps/app/src/features/request-shift/model/request-shift.ts
+++ b/apps/app/src/features/request-shift/model/request-shift.ts
@@ -28,6 +28,20 @@ type TMonthChangeDecision = {
     shouldEnableReadonly: boolean;
     feedbackMessage: string | null;
 };
+type TShiftTeamsResponseGuardParams = {
+    requestedWardId: number;
+    currentWardId: number | null;
+};
+type TRequestShiftResponseGuardParams = {
+    requestedWardId: number;
+    requestedShiftTeamId: number;
+    requestedYear: number;
+    requestedMonth: number;
+    currentWardId: number | null;
+    currentShiftTeamId: number | null;
+    currentYear: number;
+    currentMonth: number;
+};
 
 const flattenRequestShiftRows = (requestShift: TRequestShift) => requestShift.divisionShiftNurses.flatMap((division) => division);
 
@@ -87,6 +101,28 @@ export const resolveCurrentRequestShiftTeamId = ({
     }
 
     return shiftTeams[0].shiftTeamId;
+};
+
+export const shouldApplyShiftTeamsResponseToStore = ({requestedWardId, currentWardId}: TShiftTeamsResponseGuardParams) => {
+    return requestedWardId === currentWardId;
+};
+
+export const shouldApplyRequestShiftResponseToStore = ({
+    requestedWardId,
+    requestedShiftTeamId,
+    requestedYear,
+    requestedMonth,
+    currentWardId,
+    currentShiftTeamId,
+    currentYear,
+    currentMonth,
+}: TRequestShiftResponseGuardParams) => {
+    return (
+        requestedWardId === currentWardId &&
+        requestedShiftTeamId === currentShiftTeamId &&
+        requestedYear === currentYear &&
+        requestedMonth === currentMonth
+    );
 };
 
 export const getAdjacentRequestShiftDate = (year: number, month: number, type: TMonthChangeType) => {

--- a/apps/app/src/features/request-shift/model/request-shift.ts
+++ b/apps/app/src/features/request-shift/model/request-shift.ts
@@ -1,5 +1,5 @@
 import {type TDutyRequest, type TRequestShift} from '@/entities/shift';
-import {type TWardShiftType} from '@/entities/ward';
+import {type TShiftTeam, type TWardShiftType} from '@/entities/ward';
 import {type TFocus, type TRequestShiftEditAvailability} from './types';
 
 type TBootstrapStatus = 'pending' | 'error' | 'success';
@@ -71,6 +71,22 @@ export const createWardShiftTypeMap = (requestShift: TRequestShift) => {
     return new Map<number, TWardShiftType>(
         requestShift.wardShiftTypes.map((wardShiftType) => [wardShiftType.wardShiftTypeId, wardShiftType]),
     );
+};
+
+export const resolveCurrentRequestShiftTeamId = ({
+    shiftTeams,
+    currentShiftTeamId,
+}: {
+    shiftTeams: TShiftTeam[];
+    currentShiftTeamId: number | null;
+}) => {
+    if (shiftTeams.length === 0) return null;
+
+    if (currentShiftTeamId !== null && shiftTeams.some((shiftTeam) => shiftTeam.shiftTeamId === currentShiftTeamId)) {
+        return currentShiftTeamId;
+    }
+
+    return shiftTeams[0].shiftTeamId;
 };
 
 export const getAdjacentRequestShiftDate = (year: number, month: number, type: TMonthChangeType) => {

--- a/apps/app/src/features/request-shift/model/store.ts
+++ b/apps/app/src/features/request-shift/model/store.ts
@@ -1,8 +1,16 @@
-import {type TValues} from '@dutying/utils';
-import {create} from 'zustand';
-import {devtools, persist} from 'zustand/middleware';
-import {type TWardShiftType} from '@/entities/ward';
+import {type TRequestShift} from '@/entities/shift';
+import {type TShiftTeam, type TWardShiftType} from '@/entities/ward';
+import {createStore} from '@/shared/util/create-store';
+import {
+    createInitialFoldedLevels,
+    createWardShiftTypeMap,
+    resolveCurrentRequestShiftTeamId,
+    shouldResetFoldedLevelsOnRequestLoad,
+    shouldSyncFoldedLevelsLength,
+} from './request-shift';
 import {type TFocus} from './types';
+
+type TChangeStatus = 'idle' | 'loading' | 'success' | 'error';
 
 interface IState {
     year: number;
@@ -13,18 +21,16 @@ interface IState {
     oldCurrentShiftTeamId: number | null;
     wardShiftTypeMap: Map<number, TWardShiftType> | null;
     readonly: boolean;
-    changeStatus: 'idle' | 'loading' | 'success' | 'error';
+    changeStatus: TChangeStatus;
     updatingRequestId: number | null;
 }
 
-interface IStore extends IState {
-    setState: (key: keyof IState, value: TValues<IState>) => void;
-    resetState: () => void;
-}
+type TPersistedRequestShiftState = Pick<IState, 'year' | 'month' | 'currentShiftTeamId' | 'oldCurrentShiftTeamId'>;
 
+const now = new Date();
 const initialState: IState = {
-    year: new Date().getMonth() + 1 === 12 ? new Date().getFullYear() + 1 : new Date().getFullYear(),
-    month: new Date().getMonth() + 1 === 12 ? 1 : new Date().getMonth() + 2,
+    year: now.getMonth() + 1 === 12 ? now.getFullYear() + 1 : now.getFullYear(),
+    month: now.getMonth() + 1 === 12 ? 1 : now.getMonth() + 2,
     focus: null,
     currentShiftTeamId: null,
     oldCurrentShiftTeamId: null,
@@ -35,23 +41,108 @@ const initialState: IState = {
     updatingRequestId: null,
 };
 
-export const useRequestShiftStore = create<IStore>()(
-    devtools(
-        persist(
-            (set) => ({
-                ...initialState,
-                setState: (state, value) => set((prev) => ({...prev, [state]: value})),
-                resetState: () => set(initialState),
-            }),
-            {
-                name: 'useRequestShiftStore',
-                partialize: ({year, month, currentShiftTeamId, oldCurrentShiftTeamId}: IStore) => ({
-                    year,
-                    month,
-                    currentShiftTeamId,
-                    oldCurrentShiftTeamId,
+export const useRequestShiftStore = createStore<
+    IState,
+    {
+        syncShiftTeams: (shiftTeams: TShiftTeam[]) => void;
+        loadRequestShift: (requestShift: TRequestShift) => void;
+        setCalendarDate: (year: number, month: number) => void;
+        selectFocus: (focus: TFocus | null) => void;
+        toggleFoldedLevel: (level: number) => void;
+        enterEditMode: () => void;
+        enterReadonlyMode: (requestShift?: TRequestShift) => void;
+        selectShiftTeam: (shiftTeamId: number | null) => void;
+        startRequestChange: () => void;
+        completeRequestChange: (status: Exclude<TChangeStatus, 'idle' | 'loading'>) => void;
+        resetRequestChangeStatus: () => void;
+        startRequestDecision: (requestId: number) => void;
+        finishRequestDecision: () => void;
+    },
+    false,
+    TPersistedRequestShiftState
+>(initialState, {
+    name: 'useRequestShiftStore',
+    persist: true,
+    actions: ({patch}) => ({
+        syncShiftTeams: (shiftTeams) =>
+            patch((prev) => ({
+                currentShiftTeamId: resolveCurrentRequestShiftTeamId({
+                    shiftTeams,
+                    currentShiftTeamId: prev.currentShiftTeamId,
                 }),
-            },
-        ),
-    ),
-);
+            })),
+        loadRequestShift: (requestShift) =>
+            patch((prev) => {
+                const shouldResetFoldedLevels = shouldResetFoldedLevelsOnRequestLoad({
+                    foldedLevels: prev.foldedLevels,
+                    previousShiftTeamId: prev.oldCurrentShiftTeamId,
+                    currentShiftTeamId: prev.currentShiftTeamId,
+                });
+                const nextFoldedLevels =
+                    shouldResetFoldedLevels || shouldSyncFoldedLevelsLength({foldedLevels: prev.foldedLevels, requestShift})
+                        ? createInitialFoldedLevels(requestShift)
+                        : prev.foldedLevels;
+
+                return {
+                    foldedLevels: nextFoldedLevels,
+                    oldCurrentShiftTeamId: shouldResetFoldedLevels ? prev.currentShiftTeamId : prev.oldCurrentShiftTeamId,
+                    wardShiftTypeMap: createWardShiftTypeMap(requestShift),
+                };
+            }),
+        setCalendarDate: (year, month) =>
+            patch({
+                year,
+                month,
+            }),
+        selectFocus: (focus) =>
+            patch({
+                focus,
+            }),
+        toggleFoldedLevel: (level) =>
+            patch((prev) => ({
+                foldedLevels: prev.foldedLevels?.map((isFolded, index) => (index === level ? !isFolded : isFolded)) ?? prev.foldedLevels,
+            })),
+        enterEditMode: () =>
+            patch({
+                readonly: false,
+            }),
+        enterReadonlyMode: (requestShift) =>
+            patch((prev) => ({
+                readonly: true,
+                focus: null,
+                foldedLevels: requestShift ? createInitialFoldedLevels(requestShift) : prev.foldedLevels,
+            })),
+        selectShiftTeam: (shiftTeamId) =>
+            patch({
+                currentShiftTeamId: shiftTeamId,
+            }),
+        startRequestChange: () =>
+            patch({
+                changeStatus: 'loading',
+            }),
+        completeRequestChange: (status) =>
+            patch({
+                changeStatus: status,
+            }),
+        resetRequestChangeStatus: () =>
+            patch({
+                changeStatus: 'idle',
+            }),
+        startRequestDecision: (requestId) =>
+            patch({
+                updatingRequestId: requestId,
+            }),
+        finishRequestDecision: () =>
+            patch({
+                updatingRequestId: null,
+            }),
+    }),
+    persistOptions: {
+        partialize: ({year, month, currentShiftTeamId, oldCurrentShiftTeamId}): TPersistedRequestShiftState => ({
+            year,
+            month,
+            currentShiftTeamId,
+            oldCurrentShiftTeamId,
+        }),
+    },
+});

--- a/apps/app/src/features/request-shift/model/use-request-shift-change-queue.ts
+++ b/apps/app/src/features/request-shift/model/use-request-shift-change-queue.ts
@@ -17,7 +17,9 @@ type TUseRequestShiftChangeQueueParams = {
     requestShiftQueryKey: readonly unknown[];
     wardShiftTypeMap: Map<number, TWardShiftType> | null;
     queryClient: QueryClient;
-    setChangeStatus: (status: TChangeStatus) => void;
+    startRequestChange: () => void;
+    completeRequestChange: (status: Exclude<TChangeStatus, 'idle' | 'loading'>) => void;
+    resetRequestChangeStatus: () => void;
 };
 
 const CHANGE_STATUS_RESET_DELAY = 2400;
@@ -29,7 +31,9 @@ export const useRequestShiftChangeQueue = ({
     requestShiftQueryKey,
     wardShiftTypeMap,
     queryClient,
-    setChangeStatus,
+    startRequestChange,
+    completeRequestChange,
+    resetRequestChangeStatus,
 }: TUseRequestShiftChangeQueueParams) => {
     const changeStatusResetTimerRef = useRef<number | null>(null);
     const requestShiftChangeQueueRef = useRef<Array<{focus: TFocus; shiftTypeId: number | null}>>([]);
@@ -43,16 +47,23 @@ export const useRequestShiftChangeQueue = ({
     const setChangeStatusWithAutoReset = useCallback(
         (status: TChangeStatus) => {
             clearChangeStatusResetTimer();
-            setChangeStatus(status);
+
+            if (status === 'loading') {
+                startRequestChange();
+            } else if (status === 'idle') {
+                resetRequestChangeStatus();
+            } else {
+                completeRequestChange(status);
+            }
 
             if (status === 'loading' || status === 'idle') return;
 
             changeStatusResetTimerRef.current = window.setTimeout(() => {
-                setChangeStatus('idle');
+                resetRequestChangeStatus();
                 changeStatusResetTimerRef.current = null;
             }, CHANGE_STATUS_RESET_DELAY);
         },
-        [clearChangeStatusResetTimer, setChangeStatus],
+        [clearChangeStatusResetTimer, completeRequestChange, resetRequestChangeStatus, startRequestChange],
     );
     const applyRequestShiftChangeToCache = useCallback(
         (focus: TFocus, shiftTypeId: number | null) => {

--- a/apps/app/src/widgets/tutorial/RequestTutorial.tsx
+++ b/apps/app/src/widgets/tutorial/RequestTutorial.tsx
@@ -13,7 +13,7 @@ const RequestTutorial = () => {
     const {
         actions: {toggleEditMode},
     } = useRequestShift();
-    const {setState} = useRequestShiftStore();
+    const enterReadonlyMode = useRequestShiftStore((state) => state.enterReadonlyMode);
     const config = useMemo<ITutorialConfig>(
         () => ({
             steps: [
@@ -61,9 +61,9 @@ const RequestTutorial = () => {
 
     useEffect(() => {
         if (showRequestTutorial) {
-            setState('readonly', true);
+            enterReadonlyMode();
         }
-    }, [showRequestTutorial]);
+    }, [enterReadonlyMode, showRequestTutorial]);
 
     return <TutorialPortal open={showRequestTutorial} config={config} closeCallback={() => setRequestTutorial(false)} />;
 };


### PR DESCRIPTION
## Motivation

auth/request-shift store가 generic setter와 분산된 상태 변경에 의존해서 전이 규칙을 읽기 어려운 상태였습니다.

- 티켓: [DUT-976](https://gom3.atlassian.net/browse/DUT-976)
- 배경: 로그인 시작, 계정 조회, 팀 변경, request-shift 편집/저장 전이가 store 밖의 임의 key mutation으로 흩어져 있었습니다.
- 목표: public store API를 explicit action 중심으로 정리하고, 상태 전이 규칙과 reset 기준을 코드에서 바로 읽히게 만듭니다.

<br>

## Key Changes

- `auth` store를 `shared/util/create-store.ts` 표준으로 맞추고 `startLogin`, `beginAccountBootstrap`, `completeAccountBootstrap`, `failAccountBootstrap`, `resetSession` 같은 전이 중심 액션으로 재구성했습니다.
- `request-shift` store의 public `setState`를 제거하고 `syncShiftTeams`, `loadRequestShift`, `setCalendarDate`, `selectFocus`, `enterEditMode`, `enterReadonlyMode`, `startRequestChange`, `completeRequestChange`, `startRequestDecision` 등 의미가 드러나는 액션으로 교체했습니다.
- 팀 선택 해석과 request load 전이를 pure helper/store 테스트로 보강하고, `useRequestShift`, `RequestTutorial`, `useAuth` 호출부를 새 액션에 맞게 정리했습니다.

<br>

## To Reviewers

- 특히 봐야 할 파일: `apps/app/src/features/request-shift/model/store.ts`, `apps/app/src/features/request-shift/index.ts`, `apps/app/src/features/auth/model/store.ts`
- 중점적으로 봐야 할 로직: shift team 목록 로드 시 선택 유지/초기화 규칙, request-shift 로드 시 `foldedLevels`/`oldCurrentShiftTeamId`/`wardShiftTypeMap` 동기화, 편집 모드 및 요청 처리 상태 전이
- 우려되는 지점 / 확인이 필요한 부분: `queryFn` 부수효과 제거/useCase 분리는 DUT-980 범위라 이번 PR에서는 건드리지 않았습니다.
- 검증: `pnpm exec vitest run src/features/auth/model/__tests__/store.test.ts src/features/auth/__tests__/index.test.tsx src/features/request-shift/model/__tests__/request-shift.test.ts src/features/request-shift/model/__tests__/store.test.ts`, `pnpm exec eslint src/features/auth/model/store.ts src/features/auth/index.ts src/features/auth/__tests__/index.test.tsx src/features/request-shift/model/store.ts src/features/request-shift/index.ts src/features/request-shift/model/use-request-shift-change-queue.ts src/features/request-shift/model/request-shift.ts src/features/request-shift/model/__tests__/request-shift.test.ts src/features/request-shift/model/__tests__/store.test.ts src/widgets/tutorial/RequestTutorial.tsx`, `pnpm type-check`는 `develop`에서도 재현되는 `src/features/shift-editor/model/shift-to-image.ts`의 `html-to-image` 해석 오류로 실패했습니다.


[DUT-976]: https://gom3.atlassian.net/browse/DUT-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ