### PR TITLE
feat(make-shift): 근무 만들기 UI·캘린더·제약 정리

### DIFF
--- a/apps/app/src/features/shift-editor/model/__tests__/shift-adapter.test.ts
+++ b/apps/app/src/features/shift-editor/model/__tests__/shift-adapter.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 import type {TShift} from '@/entities';
-import {buildWorkKeyMap, docToShift, docToWardShiftsDTO, isDutyShiftWithoutAssignments, shiftToDoc} from '../shift-adapter';
+import {buildWorkKeyMap, docToShift, docToWardShiftsDTO, isDutyShiftFullyAssigned, isDutyShiftWithoutAssignments, shiftToDoc} from '../shift-adapter';
 
 function createShift(): TShift {
     return {
@@ -108,6 +108,31 @@ describe('shift-adapter', () => {
         };
 
         expect(isDutyShiftWithoutAssignments(onlyNullCells)).toBe(true);
+    });
+
+    it('detects fully assigned worker grids', () => {
+        expect(isDutyShiftFullyAssigned(createShift())).toBe(false);
+
+        const full: TShift = {
+            ...createShift(),
+            divisionShiftNurses: [
+                [
+                    {
+                        ...createShift().divisionShiftNurses[0]![0]!,
+                        wardShiftList: [10, 20],
+                    },
+                ],
+            ],
+        };
+
+        expect(isDutyShiftFullyAssigned(full)).toBe(true);
+
+        const noWorkers: TShift = {
+            ...createShift(),
+            divisionShiftNurses: [[]],
+        };
+
+        expect(isDutyShiftFullyAssigned(noWorkers)).toBe(false);
     });
 
     it('converts only worker rows into editor doc', () => {

--- a/apps/app/src/features/shift-editor/model/__tests__/use-shift-editor-key-bindings.test.tsx
+++ b/apps/app/src/features/shift-editor/model/__tests__/use-shift-editor-key-bindings.test.tsx
@@ -18,15 +18,20 @@ vi.mock('../use-shift-editor-commands', () => ({
     useShiftEditorCommands: () => commands,
 }));
 
-vi.mock('../store', () => ({
-    useShiftEditorStore: (selector: (state: {doc: {columns: string[]; rows: unknown[]}}) => unknown) =>
-        selector({
-            doc: {
-                columns: ['2026-03-01'],
-                rows: [{workerId: '1', cells: [null]}],
-            },
-        }),
-}));
+vi.mock('../store', () => {
+    const state = {
+        doc: {
+            columns: ['2026-03-01'],
+            rows: [{workerId: '1', cells: [null]}],
+        },
+        selection: {type: 'single' as const, anchor: {row: 0, col: 0}},
+    };
+    const useShiftEditorStore = (selector: (s: typeof state) => unknown) => selector(state);
+
+    return {
+        useShiftEditorStore: Object.assign(useShiftEditorStore, {getState: () => state}),
+    };
+});
 
 function createKeyboardEvent(
     key: string,
@@ -98,6 +103,16 @@ describe('useShiftEditorKeyBindings', () => {
         expect(commands.clearSelectionCells).toHaveBeenCalledTimes(1);
     });
 
+    it('moves the selection with Tab / Shift+Tab like spreadsheet column navigation', async () => {
+        const {result} = renderHook(() => useShiftEditorKeyBindings());
+
+        await result.current.onKeyDown(createKeyboardEvent('Tab'));
+        await result.current.onKeyDown(createKeyboardEvent('Tab', {shiftKey: true}));
+
+        expect(commands.moveSelection).toHaveBeenNthCalledWith(1, 'right', false, false);
+        expect(commands.moveSelection).toHaveBeenNthCalledWith(2, 'left', false, false);
+    });
+
     it('interprets Korean IME keys through the work key map', async () => {
         const {result} = renderHook(() =>
             useShiftEditorKeyBindings({
@@ -108,6 +123,7 @@ describe('useShiftEditorKeyBindings', () => {
         await result.current.onKeyDown(createKeyboardEvent('ㅇ'));
 
         expect(commands.setSelectionValue).toHaveBeenCalledWith('D');
+        expect(commands.moveSelection).toHaveBeenCalledWith('right', false, false);
     });
 
     it('copies and cuts selected cells through the clipboard API', async () => {
@@ -130,21 +146,18 @@ describe('useShiftEditorKeyBindings', () => {
         expect(commands.clearSelectionCells).toHaveBeenCalledTimes(1);
     });
 
-    it('pastes normalized TSV from both keydown and onPaste handlers', async () => {
+    it('pastes normalized TSV from onPasteCapture only (Ctrl+V does not use readText)', async () => {
         const {result} = renderHook(() => useShiftEditorKeyBindings());
 
         await result.current.onKeyDown(createKeyboardEvent('v', {ctrlKey: true}));
-        result.current.onPaste(createPasteEvent('A\tB\r\nC'));
 
-        expect(commands.paste).toHaveBeenNthCalledWith(1, {
-            width: 2,
-            height: 2,
-            cells: [
-                ['O', 'N'],
-                ['E', null],
-            ],
-        });
-        expect(commands.paste).toHaveBeenNthCalledWith(2, {
+        expect(commands.paste).not.toHaveBeenCalled();
+        expect(navigator.clipboard.readText).not.toHaveBeenCalled();
+
+        result.current.onPasteCapture(createPasteEvent('A\tB\r\nC'));
+
+        expect(commands.paste).toHaveBeenCalledTimes(1);
+        expect(commands.paste).toHaveBeenCalledWith({
             width: 2,
             height: 2,
             cells: [

--- a/apps/app/src/features/shift-editor/model/shift-adapter.ts
+++ b/apps/app/src/features/shift-editor/model/shift-adapter.ts
@@ -49,6 +49,30 @@ export function isDutyShiftWithoutAssignments(shift: TShift): boolean {
     return true;
 }
 
+/** 모든 근무자(worker) 행의 날짜별 칸이 비어 있지 않을 때 true (골격만 있는 응답 / 미배정 칸이 하나라도 있으면 false). */
+export function isDutyShiftFullyAssigned(shift: TShift): boolean {
+    if (!shift.days?.length) return false;
+
+    const dayCount = shift.days.length;
+    const divisions = shift.divisionShiftNurses ?? [];
+    let seenWorker = false;
+
+    for (const division of divisions) {
+        for (const row of division) {
+            if (!row.shiftNurse.isWorker) continue;
+
+            seenWorker = true;
+            const list = row.wardShiftList ?? [];
+
+            for (let j = 0; j < dayCount; j += 1) {
+                if (list[j] == null) return false;
+            }
+        }
+    }
+
+    return seenWorker;
+}
+
 export function shiftToDoc(shift: TShift, year: number, month: number): TDutyDoc {
     const {idToType} = buildWardShiftTypeMaps(shift);
     const columns = shift.days.map((d) => formatDateKey(year, month, d.day));

--- a/apps/app/src/features/shift-editor/model/use-shift-editor-key-bindings.ts
+++ b/apps/app/src/features/shift-editor/model/use-shift-editor-key-bindings.ts
@@ -57,13 +57,16 @@ function tsvToPayload(text: string): TClipboardPayload {
         .replace(/\r/g, '')
         .split('\n')
         .filter((x) => x.length > 0)
-        .map((x) => x.split('\t'));
+        .map((line) => line.split('\t').map((cell) => cell.trim()));
     const height = rows.length;
     const width = Math.max(0, ...rows.map((r) => r.length));
     const cells = rows.map((r) => {
         const row: (string | null)[] = [];
 
-        for (let i = 0; i < width; i++) row.push(r[i] ? r[i]! : null);
+        for (let i = 0; i < width; i++) {
+            const raw = r[i];
+            row.push(raw !== undefined && raw !== '' ? raw : null);
+        }
 
         return row;
     });
@@ -101,6 +104,14 @@ export function useShiftEditorKeyBindings(opts: TShiftEditorKeyBindingsOptions =
             const key = normalizeKey(native.key);
             const dir = toDirection(native.key);
             const mod = isMetaOrCtrl(native);
+
+            // Tab: 엑셀처럼 오른쪽 셀(Shift+Tab은 왼쪽)
+            if (native.key === 'Tab') {
+                e.preventDefault();
+                commands.moveSelection(native.shiftKey ? 'left' : 'right', false, false);
+
+                return;
+            }
 
             // 방향키 이동 / Shift+방향키 범위 / Ctrl(Cmd)+방향키 끝까지
             if (dir) {
@@ -143,11 +154,13 @@ export function useShiftEditorKeyBindings(opts: TShiftEditorKeyBindingsOptions =
                 return;
             }
 
-            // clipboard (기본: Ctrl/Cmd + X/C/V)
-            const isClipboardKey = key === 'c' || key === 'x' || key === 'v';
+            // clipboard: 복사/잘라내기만 키다운에서 처리. 붙여넣기는 onPaste(clipboardData)만 사용한다.
+            // (readText는 권한/HTTP 컨텍스트에 따라 실패해 일부 칸만 반영되는 증상이 난다.)
             const allowPlain = allowUnmodifiedClipboardShortcuts && !native.altKey && !native.shiftKey && !mod;
+            const usePlainCopyCut = allowPlain && (key === 'c' || key === 'x');
+            const useModCopyCut = mod && (key === 'c' || key === 'x');
 
-            if ((mod && isClipboardKey) || allowPlain) {
+            if (useModCopyCut || usePlainCopyCut) {
                 if (key === 'c') {
                     e.preventDefault();
 
@@ -185,21 +198,11 @@ export function useShiftEditorKeyBindings(opts: TShiftEditorKeyBindingsOptions =
 
                     return;
                 }
+            }
 
-                if (key === 'v') {
-                    e.preventDefault();
-
-                    try {
-                        const text = await navigator.clipboard.readText();
-                        const payload = tsvToPayload(text);
-
-                        commands.paste(payload);
-                    } catch {
-                        // ignore
-                    }
-
-                    return;
-                }
+            if (allowPlain && key === 'v') {
+                // 수정 없이 v만 허용할 때는 붙여넣기를 onPaste에 맡김
+                return;
             }
 
             // 사용자 근무 키 입력 (modifier 없이)
@@ -208,7 +211,14 @@ export function useShiftEditorKeyBindings(opts: TShiftEditorKeyBindingsOptions =
 
                 if (value !== undefined) {
                     e.preventDefault();
+                    const selBefore = useShiftEditorStore.getState().selection;
+
                     commands.setSelectionValue(value);
+
+                    // 단일 셀: 엑셀처럼 입력 후 오른쪽 칸으로 이동
+                    if (selBefore?.type === 'single') {
+                        commands.moveSelection('right', false, false);
+                    }
                 }
             }
 
@@ -229,5 +239,8 @@ export function useShiftEditorKeyBindings(opts: TShiftEditorKeyBindingsOptions =
         [commands],
     );
 
-    return {onKeyDown, onPaste};
+    /** 포커스가 에디터 자식(일자 셀 버튼 등)에 있어도 먼저 가로채기 위해 컨테이너에 연결한다. */
+    const onPasteCapture = onPaste;
+
+    return {onKeyDown, onPaste, onPasteCapture};
 }

--- a/apps/app/src/features/shift-editor/ui/complex-view/toolbar.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/toolbar.tsx
@@ -114,7 +114,7 @@ function Toolbar({
             />
 
             <InfoIcon
-                className="h-6.5 w-6.5 cursor-pointer"
+                className="h-6.5 w-6.5 cursor-pointer text-sub-2.5"
                 onClick={() => {
                     setOpenInfo((prev) => !prev);
                     sendEvent(events.makePage.toolbar.openShiftInfoModal);

--- a/apps/app/src/features/shift-editor/ui/shift-editor-grid.tsx
+++ b/apps/app/src/features/shift-editor/ui/shift-editor-grid.tsx
@@ -7,7 +7,7 @@ export function ShiftEditorGrid() {
     const selection = useShiftEditorStore((s) => s.selection);
     const violations = useShiftEditorStore((s) => s.violations);
     const commands = useShiftEditorCommands();
-    const {onKeyDown, onPaste} = useShiftEditorKeyBindings({
+    const {onKeyDown, onPasteCapture} = useShiftEditorKeyBindings({
         // TODO: 사용자별 주입 지점 (예: settings)
         workKeyMap: {d: 'D', e: 'E', n: 'N', o: 'O'},
     });
@@ -27,7 +27,7 @@ export function ShiftEditorGrid() {
     }, [selection]);
 
     return (
-        <div className="flex w-full flex-col gap-2 overflow-auto outline-none" tabIndex={0} onKeyDown={onKeyDown} onPaste={onPaste}>
+        <div className="flex w-full flex-col gap-2 overflow-auto outline-none" tabIndex={0} onKeyDown={onKeyDown} onPasteCapture={onPasteCapture}>
             <div className="flex items-center gap-2">
                 <button
                     className="h-9 rounded-lg bg-sub-5 px-3 font-apple text-sm text-sub-2.5"

--- a/apps/app/src/pages/duty/model/__tests__/duty-hook.integration.test.tsx
+++ b/apps/app/src/pages/duty/model/__tests__/duty-hook.integration.test.tsx
@@ -34,7 +34,7 @@ vi.mock('@/features/shift-editor', async () => {
         ...actual,
         useShiftEditorKeyBindings: () => ({
             onKeyDown: vi.fn(),
-            onPaste: vi.fn(),
+            onPasteCapture: vi.fn(),
         }),
     };
 });

--- a/apps/app/src/pages/duty/model/__tests__/duty-hook.test.tsx
+++ b/apps/app/src/pages/duty/model/__tests__/duty-hook.test.tsx
@@ -122,7 +122,7 @@ vi.mock('@/features/shift-editor', async (importOriginal) => {
                 }
             },
         }),
-        useShiftEditorKeyBindings: () => ({onKeyDown: vi.fn(), onPaste: vi.fn()}),
+        useShiftEditorKeyBindings: () => ({onKeyDown: vi.fn(), onPasteCapture: vi.fn()}),
         useShiftEditorStore: (selector: (state: typeof mockEditorState) => unknown) => selector(mockEditorState),
     };
 });

--- a/apps/app/src/pages/duty/model/__tests__/duty-navigation.test.ts
+++ b/apps/app/src/pages/duty/model/__tests__/duty-navigation.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {buildMakeShiftPath, getNextYearMonth} from '../duty-navigation';
+import {buildDutyPath, buildMakeShiftPath, getNextYearMonth} from '../duty-navigation';
 
 describe('dutyNavigation', () => {
     it('builds the make page path with the selected shift team', () => {
@@ -8,6 +8,14 @@ describe('dutyNavigation', () => {
 
     it('omits shiftTeamId when no team is selected', () => {
         expect(buildMakeShiftPath({year: 2026, month: 3, shiftTeamId: null})).toBe('/make?year=2026&month=3');
+    });
+
+    it('builds the duty page path with the selected shift team', () => {
+        expect(buildDutyPath({year: 2026, month: 3, shiftTeamId: 20})).toBe('/duty?year=2026&month=3&shiftTeamId=20');
+    });
+
+    it('omits shiftTeamId on duty path when no team is selected', () => {
+        expect(buildDutyPath({year: 2026, month: 3, shiftTeamId: null})).toBe('/duty?year=2026&month=3');
     });
 
     it('rolls over to january of the next year', () => {

--- a/apps/app/src/pages/duty/model/duty-hook.ts
+++ b/apps/app/src/pages/duty/model/duty-hook.ts
@@ -89,6 +89,12 @@ export function useDutyHook() {
     const queryYear = useMemo(() => parsePositiveInt(searchParams.get('year')), [searchParams]);
     const queryMonth = useMemo(() => parsePositiveInt(searchParams.get('month')), [searchParams]);
     const queryShiftTeamId = useMemo(() => parsePositiveInt(searchParams.get('shiftTeamId')), [searchParams]);
+
+    // URL 맥락(연·월·팀)으로 들어올 때마다 보기 전용. (다른 화면에서 수정 모드로 나갔다 와도 편집 모드가 유지되지 않게)
+    useEffect(() => {
+        setReadonly(true);
+    }, [wardId, queryYear, queryMonth, queryShiftTeamId, setReadonly]);
+
     const bootstrapStatus =
         !_loaded || (isAuth && wardId === null && (accountMeStatus === 'idle' || accountMeStatus === 'loading'))
             ? 'pending'

--- a/apps/app/src/pages/duty/model/duty-hook.ts
+++ b/apps/app/src/pages/duty/model/duty-hook.ts
@@ -106,7 +106,7 @@ export function useDutyHook() {
         refetchOnWindowFocus: false,
     });
     const workKeyMap = useMemo(() => buildWorkKeyMap(shift ?? undefined), [shift]);
-    const {onKeyDown, onPaste} = useShiftEditorKeyBindings({workKeyMap});
+    const {onKeyDown, onPasteCapture} = useShiftEditorKeyBindings({workKeyMap});
     const {isExporting: isExportingExcel, exportExcel} = useShiftExcelExport({
         month,
         shift,
@@ -307,7 +307,7 @@ export function useDutyHook() {
             exportExcel: handleExportExcel,
             retry: handleRetry,
             onKeyDown,
-            onPaste,
+            onPasteCapture,
         },
     };
 }

--- a/apps/app/src/pages/duty/model/duty-navigation.ts
+++ b/apps/app/src/pages/duty/model/duty-navigation.ts
@@ -7,13 +7,13 @@ export function getNextYearMonth(year: number, month: number) {
     };
 }
 
-type TBuildMakeShiftPathParams = {
+type TYearMonthShiftTeamParams = {
     year: number;
     month: number;
     shiftTeamId: number | null;
 };
 
-export function buildMakeShiftPath({year, month, shiftTeamId}: TBuildMakeShiftPathParams) {
+export function buildMakeShiftPath({year, month, shiftTeamId}: TYearMonthShiftTeamParams) {
     const params = new URLSearchParams({
         year: String(year),
         month: String(month),
@@ -24,4 +24,18 @@ export function buildMakeShiftPath({year, month, shiftTeamId}: TBuildMakeShiftPa
     }
 
     return `${ROUTE.MAKE}?${params.toString()}`;
+}
+
+/** 확정 근무표 보기(/duty) — 쿼리는 duty 훅과 동일하게 year, month, shiftTeamId(선택). */
+export function buildDutyPath({year, month, shiftTeamId}: TYearMonthShiftTeamParams) {
+    const params = new URLSearchParams({
+        year: String(year),
+        month: String(month),
+    });
+
+    if (shiftTeamId !== null) {
+        params.set('shiftTeamId', String(shiftTeamId));
+    }
+
+    return `${ROUTE.DUTY}?${params.toString()}`;
 }

--- a/apps/app/src/pages/duty/ui/index.tsx
+++ b/apps/app/src/pages/duty/ui/index.tsx
@@ -174,7 +174,7 @@ export const DutyPageView = ({duty}: TDutyPageViewProps) => {
                                 className="mt-6 w-full min-w-0 flex-1 outline-none"
                                 tabIndex={0}
                                 onKeyDown={state.readonly ? undefined : handlers.onKeyDown}
-                                onPaste={state.readonly ? undefined : handlers.onPaste}
+                                onPasteCapture={state.readonly ? undefined : handlers.onPasteCapture}
                             >
                                 <MakeShiftCalendar
                                     shift={state.shift}

--- a/apps/app/src/pages/make-shift/model/__tests__/ai-autofill-state.test.ts
+++ b/apps/app/src/pages/make-shift/model/__tests__/ai-autofill-state.test.ts
@@ -15,10 +15,12 @@ describe('ai-autofill-state', () => {
     });
 
     it('에러 상태에서는 재시도 액션을 노출해야 한다', () => {
-        expect(getAiAutofillActionLabel('idle')).toBe('action');
-        expect(getAiAutofillActionLabel('loading')).toBe('generating');
-        expect(getAiAutofillActionLabel('error')).toBe('retry');
-        expect(getAiAutofillActionLabel('success')).toBe('action');
+        expect(getAiAutofillActionLabel('idle', false)).toBe('firstFill');
+        expect(getAiAutofillActionLabel('idle', true)).toBe('action');
+        expect(getAiAutofillActionLabel('success', false)).toBe('firstFill');
+        expect(getAiAutofillActionLabel('success', true)).toBe('action');
+        expect(getAiAutofillActionLabel('loading', false)).toBe('generating');
+        expect(getAiAutofillActionLabel('error', false)).toBe('retry');
     });
 
     it('상태별 톤을 구분해야 한다', () => {

--- a/apps/app/src/pages/make-shift/model/ai-autofill-state.ts
+++ b/apps/app/src/pages/make-shift/model/ai-autofill-state.ts
@@ -27,14 +27,17 @@ export function getAiAutofillStatusTone(status: TAiAutofillStatus): 'neutral' | 
     }
 }
 
-export function getAiAutofillActionLabel(status: TAiAutofillStatus): 'action' | 'retry' | 'generating' {
+export function getAiAutofillActionLabel(
+    status: TAiAutofillStatus,
+    hasCompletedAiFill: boolean,
+): 'action' | 'retry' | 'generating' | 'firstFill' {
     switch (status) {
         case 'loading':
             return 'generating';
         case 'error':
             return 'retry';
         default:
-            return 'action';
+            return hasCompletedAiFill ? 'action' : 'firstFill';
     }
 }
 

--- a/apps/app/src/pages/make-shift/model/make-shift-store.ts
+++ b/apps/app/src/pages/make-shift/model/make-shift-store.ts
@@ -105,6 +105,13 @@ function readMaxReached(wardId: number | null, shiftTeamId: number | null, year:
     return loadMaxReachedStep(wardId, shiftTeamId, year, month);
 }
 
+/** 헤더로 연·월이 바뀌면 만들기 단계(stepping)를 끊고 개요로 보낸다(다른 달 플로우가 그대로 이어지지 않게). */
+function exitingSteppingIfNeeded(phase: TFlowPhase): Partial<Pick<TMakeShiftStore, 'phase' | 'currentStep' | 'restoreDraftModalOpen'>> {
+    if (phase !== 'stepping') return {};
+
+    return {phase: 'overview', currentStep: 1, restoreDraftModalOpen: false};
+}
+
 export const useMakeShiftStore = create<TMakeShiftStore>()(
     devtools((set, get) => ({
         phase: 'overview',
@@ -209,17 +216,18 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
 
         setYearMonth: ({year, month}) => {
             const nextMonth = Math.min(12, Math.max(1, month));
-            const {wardId, currentShiftTeamId} = get();
+            const {wardId, currentShiftTeamId, phase} = get();
 
             set(() => ({
                 year,
                 month: nextMonth,
                 maxReachedStep: readMaxReached(wardId, currentShiftTeamId, year, nextMonth),
+                ...exitingSteppingIfNeeded(phase),
             }));
             persistYearMonth(year, nextMonth);
         },
         goPrevMonth: () => {
-            const {year, month, wardId, currentShiftTeamId} = get();
+            const {year, month, wardId, currentShiftTeamId, phase} = get();
 
             if (month <= 1) {
                 const ny = year - 1;
@@ -229,6 +237,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
                     year: ny,
                     month: nm,
                     maxReachedStep: readMaxReached(wardId, currentShiftTeamId, ny, nm),
+                    ...exitingSteppingIfNeeded(phase),
                 }));
                 persistYearMonth(ny, nm);
 
@@ -240,11 +249,12 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
             set(() => ({
                 month: nm,
                 maxReachedStep: readMaxReached(wardId, currentShiftTeamId, year, nm),
+                ...exitingSteppingIfNeeded(phase),
             }));
             persistYearMonth(year, nm);
         },
         goNextMonth: () => {
-            const {year, month, wardId, currentShiftTeamId} = get();
+            const {year, month, wardId, currentShiftTeamId, phase} = get();
 
             if (month >= 12) {
                 const ny = year + 1;
@@ -254,6 +264,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
                     year: ny,
                     month: nm,
                     maxReachedStep: readMaxReached(wardId, currentShiftTeamId, ny, nm),
+                    ...exitingSteppingIfNeeded(phase),
                 }));
                 persistYearMonth(ny, nm);
 
@@ -265,6 +276,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
             set(() => ({
                 month: nm,
                 maxReachedStep: readMaxReached(wardId, currentShiftTeamId, year, nm),
+                ...exitingSteppingIfNeeded(phase),
             }));
             persistYearMonth(year, nm);
         },

--- a/apps/app/src/pages/make-shift/model/make-shift-store.ts
+++ b/apps/app/src/pages/make-shift/model/make-shift-store.ts
@@ -74,6 +74,8 @@ export type TMakeShiftStore = {
     // overview status (MVP)
     shiftStatus: TShiftStatus;
     shiftExists: boolean;
+    /** 근무자 칸이 모두 채워진 상태(만들기 플로 진입 불가). */
+    shiftFullyAssigned: boolean;
     reloadToken: number;
 
     // actions (no business logic beyond state transitions)
@@ -95,6 +97,7 @@ export type TMakeShiftStore = {
 
     setShiftStatus: (status: TShiftStatus) => void;
     setShiftExists: (exists: boolean) => void;
+    setShiftFullyAssigned: (fully: boolean) => void;
     requestReload: () => void;
     setHydrated: () => void;
 };
@@ -129,6 +132,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
 
         shiftStatus: 'idle',
         shiftExists: false,
+        shiftFullyAssigned: false,
         reloadToken: 0,
 
         setWardId: (wardId) => {
@@ -141,7 +145,9 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
         },
 
         startFromStep: ({step, openRestoreDraftModal}) => {
-            const {wardId, currentShiftTeamId, year, month} = get();
+            const {wardId, currentShiftTeamId, year, month, shiftFullyAssigned, shiftStatus} = get();
+
+            if (shiftStatus === 'success' && shiftFullyAssigned) return;
 
             set(() => ({
                 phase: 'stepping',
@@ -222,6 +228,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
                 year,
                 month: nextMonth,
                 maxReachedStep: readMaxReached(wardId, currentShiftTeamId, year, nextMonth),
+                shiftFullyAssigned: false,
                 ...exitingSteppingIfNeeded(phase),
             }));
             persistYearMonth(year, nextMonth);
@@ -237,6 +244,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
                     year: ny,
                     month: nm,
                     maxReachedStep: readMaxReached(wardId, currentShiftTeamId, ny, nm),
+                    shiftFullyAssigned: false,
                     ...exitingSteppingIfNeeded(phase),
                 }));
                 persistYearMonth(ny, nm);
@@ -249,6 +257,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
             set(() => ({
                 month: nm,
                 maxReachedStep: readMaxReached(wardId, currentShiftTeamId, year, nm),
+                shiftFullyAssigned: false,
                 ...exitingSteppingIfNeeded(phase),
             }));
             persistYearMonth(year, nm);
@@ -264,6 +273,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
                     year: ny,
                     month: nm,
                     maxReachedStep: readMaxReached(wardId, currentShiftTeamId, ny, nm),
+                    shiftFullyAssigned: false,
                     ...exitingSteppingIfNeeded(phase),
                 }));
                 persistYearMonth(ny, nm);
@@ -276,6 +286,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
             set(() => ({
                 month: nm,
                 maxReachedStep: readMaxReached(wardId, currentShiftTeamId, year, nm),
+                shiftFullyAssigned: false,
                 ...exitingSteppingIfNeeded(phase),
             }));
             persistYearMonth(year, nm);
@@ -289,6 +300,7 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
                 set(() => ({
                     currentShiftTeamId,
                     maxReachedStep: 1,
+                    shiftFullyAssigned: false,
                 }));
 
                 return;
@@ -306,11 +318,13 @@ export const useMakeShiftStore = create<TMakeShiftStore>()(
                 currentShiftTeamId,
                 maxReachedStep: maxReached,
                 currentStep,
+                shiftFullyAssigned: false,
             }));
         },
 
         setShiftStatus: (shiftStatus) => set(() => ({shiftStatus})),
         setShiftExists: (shiftExists) => set(() => ({shiftExists})),
+        setShiftFullyAssigned: (shiftFullyAssigned) => set(() => ({shiftFullyAssigned})),
         requestReload: () => set((state) => ({reloadToken: state.reloadToken + 1})),
         setHydrated: () => set(() => ({isHydrated: true})),
     })),

--- a/apps/app/src/pages/make-shift/model/make-shift-use-case.ts
+++ b/apps/app/src/pages/make-shift/model/make-shift-use-case.ts
@@ -26,8 +26,15 @@ export function useMakeShiftUseCase() {
     }, []);
 
     const start = useCallback(() => {
-        const persisted = editor.getPersisted();
         const s = useMakeShiftStore.getState();
+
+        if (s.shiftStatus === 'success' && s.shiftFullyAssigned) {
+            showValidationFeedback(t('page.makeShift.overview.fullyAssignedCantStart'));
+
+            return;
+        }
+
+        const persisted = editor.getPersisted();
         const saved =
             s.wardId && s.currentShiftTeamId
                 ? loadDraftStep(s.wardId, s.currentShiftTeamId, s.year, s.month) ?? loadPersistedStep()
@@ -35,7 +42,7 @@ export function useMakeShiftUseCase() {
         const step = saved ?? 1;
 
         startFromStep({step, openRestoreDraftModal: persisted !== null});
-    }, [editor, startFromStep]);
+    }, [editor, startFromStep, t]);
     const confirmRestoreDraft = useCallback(() => {
         const persisted = editor.getPersisted();
 

--- a/apps/app/src/pages/make-shift/model/use-bootstrap.ts
+++ b/apps/app/src/pages/make-shift/model/use-bootstrap.ts
@@ -1,6 +1,6 @@
 import {useEffect, useRef} from 'react';
 import {useSearchParams} from 'react-router';
-import {useShiftEditorCommands} from '@/features/shift-editor';
+import {isDutyShiftWithoutAssignments, useShiftEditorCommands} from '@/features/shift-editor';
 import WardAPI from '@/shared/api/ward';
 import {
     bumpMaxReachedStep,
@@ -186,7 +186,8 @@ export function useMakeShiftBootstrap(wardId: number | null) {
                 if (cancelled) return;
 
                 setShiftStatus('success');
-                setShiftExists(Boolean(shift));
+                // 근무표 존재: 최소 1칸 이상 배정이 있을 때만 true (`/duty`와 동일 — `isDutyShiftWithoutAssignments` 역).
+                setShiftExists(!isDutyShiftWithoutAssignments(shift));
             } catch {
                 if (!cancelled) setShiftStatus('error');
             }

--- a/apps/app/src/pages/make-shift/model/use-bootstrap.ts
+++ b/apps/app/src/pages/make-shift/model/use-bootstrap.ts
@@ -1,6 +1,10 @@
 import {useEffect, useRef} from 'react';
 import {useSearchParams} from 'react-router';
-import {isDutyShiftWithoutAssignments, useShiftEditorCommands} from '@/features/shift-editor';
+import {
+    isDutyShiftFullyAssigned,
+    isDutyShiftWithoutAssignments,
+    useShiftEditorCommands,
+} from '@/features/shift-editor';
 import WardAPI from '@/shared/api/ward';
 import {
     bumpMaxReachedStep,
@@ -28,6 +32,7 @@ export function useMakeShiftBootstrap(wardId: number | null) {
 
     const setShiftStatus = useMakeShiftStore((s) => s.setShiftStatus);
     const setShiftExists = useMakeShiftStore((s) => s.setShiftExists);
+    const setShiftFullyAssigned = useMakeShiftStore((s) => s.setShiftFullyAssigned);
     const setShiftTeams = useMakeShiftStore((s) => s.setShiftTeams);
     const setShiftTeamsStatus = useMakeShiftStore((s) => s.setShiftTeamsStatus);
     const setCurrentShiftTeamId = useMakeShiftStore((s) => s.setCurrentShiftTeamId);
@@ -41,7 +46,10 @@ export function useMakeShiftBootstrap(wardId: number | null) {
     const isHydrated = useMakeShiftStore((s) => s.isHydrated);
     const setHydrated = useMakeShiftStore((s) => s.setHydrated);
     const startFromStep = useMakeShiftStore((s) => s.startFromStep);
+    const resetToOverview = useMakeShiftStore((s) => s.resetToOverview);
     const setWardId = useMakeShiftStore((s) => s.setWardId);
+    const phase = useMakeShiftStore((s) => s.phase);
+    const shiftFullyAssigned = useMakeShiftStore((s) => s.shiftFullyAssigned);
     const autoRestoreAttemptedRef = useRef(false);
 
     useEffect(() => {
@@ -123,6 +131,7 @@ export function useMakeShiftBootstrap(wardId: number | null) {
                 setShiftTeamsStatus('idle');
                 setShiftStatus('idle');
                 setShiftExists(false);
+                setShiftFullyAssigned(false);
                 setShiftTeams([]);
                 setCurrentShiftTeamId(null);
 
@@ -151,7 +160,16 @@ export function useMakeShiftBootstrap(wardId: number | null) {
         return () => {
             cancelled = true;
         };
-    }, [reloadToken, setCurrentShiftTeamId, setShiftExists, setShiftStatus, setShiftTeams, setShiftTeamsStatus, wardId]);
+    }, [
+        reloadToken,
+        setCurrentShiftTeamId,
+        setShiftExists,
+        setShiftFullyAssigned,
+        setShiftStatus,
+        setShiftTeams,
+        setShiftTeamsStatus,
+        wardId,
+    ]);
 
     useEffect(() => {
         if (!wardId) return;
@@ -173,12 +191,14 @@ export function useMakeShiftBootstrap(wardId: number | null) {
             if (!wardId || !currentShiftTeamId) {
                 setShiftStatus('idle');
                 setShiftExists(false);
+                setShiftFullyAssigned(false);
 
                 return;
             }
 
             setShiftStatus('pending');
             setShiftExists(false);
+            setShiftFullyAssigned(false);
 
             try {
                 const shift = await WardAPI.getShift(wardId, currentShiftTeamId, year, month);
@@ -188,8 +208,12 @@ export function useMakeShiftBootstrap(wardId: number | null) {
                 setShiftStatus('success');
                 // 근무표 존재: 최소 1칸 이상 배정이 있을 때만 true (`/duty`와 동일 — `isDutyShiftWithoutAssignments` 역).
                 setShiftExists(!isDutyShiftWithoutAssignments(shift));
+                setShiftFullyAssigned(isDutyShiftFullyAssigned(shift));
             } catch {
-                if (!cancelled) setShiftStatus('error');
+                if (!cancelled) {
+                    setShiftStatus('error');
+                    setShiftFullyAssigned(false);
+                }
             }
         };
 
@@ -198,7 +222,22 @@ export function useMakeShiftBootstrap(wardId: number | null) {
         return () => {
             cancelled = true;
         };
-    }, [currentShiftTeamId, month, reloadToken, setShiftExists, setShiftStatus, wardId, year]);
+    }, [
+        currentShiftTeamId,
+        month,
+        reloadToken,
+        setShiftExists,
+        setShiftFullyAssigned,
+        setShiftStatus,
+        wardId,
+        year,
+    ]);
+
+    useEffect(() => {
+        if (shiftStatus !== 'success' || !shiftFullyAssigned || phase !== 'stepping') return;
+
+        resetToOverview();
+    }, [phase, resetToOverview, shiftFullyAssigned, shiftStatus]);
 
     useEffect(() => {
         let cancelled = false;

--- a/apps/app/src/pages/make-shift/ui/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/index.tsx
@@ -149,13 +149,6 @@ export const MakeShiftPageView = () => {
                         </div>
                     ) : (
                         <>
-                            {hasAssignedCells && (
-                                <div className="flex flex-wrap items-center justify-end gap-3 border-b border-gray-6 px-6 py-3 2xl:px-10">
-                                    <ManagementActionButton variant="secondary" size="md" onClick={handleGoDuty}>
-                                        {t('page.makeShift.overview.viewShift', {month})}
-                                    </ManagementActionButton>
-                                </div>
-                            )}
                             {/*
                              * Stepper는 흰 카드 폭 전체에 직접 배치한다 (분리선이 카드 좌우 가장자리까지 닿게).
                              * 좌우 콘텐츠 패딩은 stepper 내부의 step list(`px-[clamp(...)]`)와 아래 step content에만 적용한다.

--- a/apps/app/src/pages/make-shift/ui/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/index.tsx
@@ -20,6 +20,7 @@ export const MakeShiftPageView = () => {
     const year = useMakeShiftStore((s) => s.year);
     const shiftStatus = useMakeShiftStore((s) => s.shiftStatus);
     const shiftExists = useMakeShiftStore((s) => s.shiftExists);
+    const shiftFullyAssigned = useMakeShiftStore((s) => s.shiftFullyAssigned);
     const month = useMakeShiftStore((s) => s.month);
     const shiftTeams = useMakeShiftStore((s) => s.shiftTeams);
     const shiftTeamsStatus = useMakeShiftStore((s) => s.shiftTeamsStatus);
@@ -32,8 +33,9 @@ export const MakeShiftPageView = () => {
     const canOfferCreateFollowingMonth = isDutyViewingThisCalendarMonth(year, month);
     const showNoTeamsState = shiftTeamsStatus === 'success' && shiftTeams.length === 0;
     const currentShiftTeamName = shiftTeams.find((t) => t.shiftTeamId === currentShiftTeamId)?.name ?? '선택한 팀';
-    /** `useMakeShiftBootstrap`: 실제 배정 1칸 이상일 때만 true (`isDutyShiftWithoutAssignments`와 동일 기준). */
-    const hasCurrentMonthShift = shiftStatus === 'success' && shiftExists;
+    /** 배정 1칸 이상 (`isDutyShiftWithoutAssignments` 역). 전부 채움은 `shiftFullyAssigned`. */
+    const hasAssignedCells = shiftStatus === 'success' && shiftExists;
+    const isMakeFlowBlocked = shiftStatus === 'success' && shiftFullyAssigned;
     const nextMonth = month === 12 ? 1 : month + 1;
     const nextYear = month === 12 ? year + 1 : year;
     const handleGoDuty = () => {
@@ -90,11 +92,10 @@ export const MakeShiftPageView = () => {
                                     action={{label: t('page.state.retry'), onClick: useCase.retryOverview}}
                                     className="py-0"
                                 />
-                            ) : hasCurrentMonthShift ? (
+                            ) : isMakeFlowBlocked ? (
                                 <PageState
                                     tone="empty"
                                     title={t('page.makeShift.overview.shiftExists', {teamName: currentShiftTeamName, month})}
-                                    description={t('page.state.emptyDescription')}
                                     className="py-0"
                                 >
                                     <div className="mt-1 flex flex-wrap justify-center gap-4">
@@ -108,11 +109,29 @@ export const MakeShiftPageView = () => {
                                         )}
                                     </div>
                                 </PageState>
+                            ) : hasAssignedCells ? (
+                                <PageState
+                                    tone="empty"
+                                    title={t('page.makeShift.overview.shiftPartialFill', {teamName: currentShiftTeamName, month})}
+                                    className="py-0"
+                                >
+                                    <div className="mt-1 flex flex-wrap justify-center gap-4">
+                                        <ManagementActionButton variant="secondary" size="lg" onClick={handleGoDuty}>
+                                            {t('page.makeShift.overview.viewShift', {month})}
+                                        </ManagementActionButton>
+                                        <ManagementActionButton
+                                            size="lg"
+                                            onClick={handleCreateCurrentMonth}
+                                            disabled={currentShiftTeamId === null}
+                                        >
+                                            {t('page.makeShift.overview.createShift', {month})}
+                                        </ManagementActionButton>
+                                    </div>
+                                </PageState>
                             ) : (
                                 <PageState
                                     tone="empty"
                                     title={t('page.makeShift.overview.shiftEmpty', {teamName: currentShiftTeamName, month})}
-                                    description={t('page.state.emptyDescription')}
                                     className="py-0"
                                 >
                                     <div className="mt-1 flex justify-center">
@@ -130,7 +149,7 @@ export const MakeShiftPageView = () => {
                         </div>
                     ) : (
                         <>
-                            {hasCurrentMonthShift && (
+                            {hasAssignedCells && (
                                 <div className="flex flex-wrap items-center justify-end gap-3 border-b border-gray-6 px-6 py-3 2xl:px-10">
                                     <ManagementActionButton variant="secondary" size="md" onClick={handleGoDuty}>
                                         {t('page.makeShift.overview.viewShift', {month})}

--- a/apps/app/src/pages/make-shift/ui/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/index.tsx
@@ -55,7 +55,7 @@ export const MakeShiftPageView = () => {
     return (
         <div className="min-h-screen w-full overflow-x-auto">
             {/* 최소 지원 폭 이하로 내려가면 "페이지 전체" 가로 스크롤 */}
-            <div className="flex min-h-screen min-w-[1280px] flex-col px-10 py-10">
+            <div className="flex min-h-screen min-w-[1280px] flex-col px-10 py-4">
                 <MakeShiftHeader />
 
                 <div className="mt-[14px] flex flex-1 flex-col rounded-[20px] bg-white">
@@ -69,67 +69,69 @@ export const MakeShiftPageView = () => {
                         </div>
                     ) : isOverview ? (
                         <div className="flex flex-1 items-center justify-center px-10 py-16">
-                        {showNoTeamsState ? (
-                            <PageState
-                                tone="empty"
-                                title={t('page.makeShift.overview.noTeamsTitle')}
-                                description={t('page.makeShift.overview.noTeamsDescription')}
-                                className="py-0"
-                            />
-                        ) : shiftStatus === 'pending' || shiftStatus === 'idle' ? (
-                            <PageState
-                                tone="loading"
-                                title={
-                                    shiftStatus === 'pending' ? t('page.makeShift.overview.loading') : t('page.makeShift.overview.checking')
-                                }
-                                description={t('page.state.loadingDescription')}
-                                className="py-0"
-                            />
-                        ) : shiftStatus === 'error' ? (
-                            <PageState
-                                tone="error"
-                                title={t('page.makeShift.overview.error')}
-                                description={t('page.state.errorDescription')}
-                                action={{label: t('page.state.retry'), onClick: useCase.retryOverview}}
-                                className="py-0"
-                            />
-                        ) : hasCurrentMonthShift ? (
-                            <PageState
-                                tone="empty"
-                                title={t('page.makeShift.overview.shiftExists', {teamName: currentShiftTeamName, month})}
-                                description={t('page.state.emptyDescription')}
-                                className="py-0"
-                            >
-                                <div className="mt-1 flex flex-wrap justify-center gap-4">
-                                    <ManagementActionButton variant="secondary" size="lg" onClick={handleGoDuty}>
-                                        {t('page.makeShift.overview.viewShift', {month})}
-                                    </ManagementActionButton>
-                                    {canOfferCreateFollowingMonth && (
-                                        <ManagementActionButton size="lg" onClick={handleCreateNextMonth}>
-                                            {t('page.makeShift.overview.createShift', {month: nextMonth})}
+                            {showNoTeamsState ? (
+                                <PageState
+                                    tone="empty"
+                                    title={t('page.makeShift.overview.noTeamsTitle')}
+                                    description={t('page.makeShift.overview.noTeamsDescription')}
+                                    className="py-0"
+                                />
+                            ) : shiftStatus === 'pending' || shiftStatus === 'idle' ? (
+                                <PageState
+                                    tone="loading"
+                                    title={
+                                        shiftStatus === 'pending'
+                                            ? t('page.makeShift.overview.loading')
+                                            : t('page.makeShift.overview.checking')
+                                    }
+                                    description={t('page.state.loadingDescription')}
+                                    className="py-0"
+                                />
+                            ) : shiftStatus === 'error' ? (
+                                <PageState
+                                    tone="error"
+                                    title={t('page.makeShift.overview.error')}
+                                    description={t('page.state.errorDescription')}
+                                    action={{label: t('page.state.retry'), onClick: useCase.retryOverview}}
+                                    className="py-0"
+                                />
+                            ) : hasCurrentMonthShift ? (
+                                <PageState
+                                    tone="empty"
+                                    title={t('page.makeShift.overview.shiftExists', {teamName: currentShiftTeamName, month})}
+                                    description={t('page.state.emptyDescription')}
+                                    className="py-0"
+                                >
+                                    <div className="mt-1 flex flex-wrap justify-center gap-4">
+                                        <ManagementActionButton variant="secondary" size="lg" onClick={handleGoDuty}>
+                                            {t('page.makeShift.overview.viewShift', {month})}
                                         </ManagementActionButton>
-                                    )}
-                                </div>
-                            </PageState>
-                        ) : (
-                            <PageState
-                                tone="empty"
-                                title={t('page.makeShift.overview.shiftEmpty', {teamName: currentShiftTeamName, month})}
-                                description={t('page.state.emptyDescription')}
-                                className="py-0"
-                            >
-                                <div className="mt-1 flex justify-center">
-                                    <ManagementActionButton
-                                        variant="secondary"
-                                        size="lg"
-                                        onClick={handleCreateCurrentMonth}
-                                        disabled={currentShiftTeamId === null}
-                                    >
-                                        {t('page.makeShift.overview.createShift', {month})}
-                                    </ManagementActionButton>
-                                </div>
-                            </PageState>
-                        )}
+                                        {canOfferCreateFollowingMonth && (
+                                            <ManagementActionButton size="lg" onClick={handleCreateNextMonth}>
+                                                {t('page.makeShift.overview.createShift', {month: nextMonth})}
+                                            </ManagementActionButton>
+                                        )}
+                                    </div>
+                                </PageState>
+                            ) : (
+                                <PageState
+                                    tone="empty"
+                                    title={t('page.makeShift.overview.shiftEmpty', {teamName: currentShiftTeamName, month})}
+                                    description={t('page.state.emptyDescription')}
+                                    className="py-0"
+                                >
+                                    <div className="mt-1 flex justify-center">
+                                        <ManagementActionButton
+                                            variant="secondary"
+                                            size="lg"
+                                            onClick={handleCreateCurrentMonth}
+                                            disabled={currentShiftTeamId === null}
+                                        >
+                                            {t('page.makeShift.overview.createShift', {month})}
+                                        </ManagementActionButton>
+                                    </div>
+                                </PageState>
+                            )}
                         </div>
                     ) : (
                         <>
@@ -137,11 +139,7 @@ export const MakeShiftPageView = () => {
                              * Stepper는 흰 카드 폭 전체에 직접 배치한다 (분리선이 카드 좌우 가장자리까지 닿게).
                              * 좌우 콘텐츠 패딩은 stepper 내부의 step list(`px-[clamp(...)]`)와 아래 step content에만 적용한다.
                              */}
-                            <MakeShiftStepper
-                                currentStep={currentStep}
-                                maxReachedStep={maxReachedStep}
-                                onClickStep={useCase.goToStep}
-                            />
+                            <MakeShiftStepper currentStep={currentStep} maxReachedStep={maxReachedStep} onClickStep={useCase.goToStep} />
 
                             <div className="w-full min-w-0 px-6 2xl:px-10">
                                 <MakeShiftStepContent

--- a/apps/app/src/pages/make-shift/ui/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/index.tsx
@@ -1,9 +1,9 @@
 import {useNavigate} from 'react-router';
-import ROUTE from '@/shared/constant/path';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import {isDutyViewingThisCalendarMonth, isMakeShiftMonthAllowed} from '@/shared/lib/shift-calendar-month-policy';
 import PageState from '@/shared/ui/PageState';
 import {DutyManagementStatusCard, ManagementActionButton} from '@/widgets/duty-management/ui';
+import {buildDutyPath} from '@/pages/duty/model/duty-navigation';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../model/make-shift-store';
 import {useMakeShiftUseCase} from '../model/make-shift-use-case';
 import {MakeShiftHeader} from './make-shift-header';
@@ -32,17 +32,12 @@ export const MakeShiftPageView = () => {
     const canOfferCreateFollowingMonth = isDutyViewingThisCalendarMonth(year, month);
     const showNoTeamsState = shiftTeamsStatus === 'success' && shiftTeams.length === 0;
     const currentShiftTeamName = shiftTeams.find((t) => t.shiftTeamId === currentShiftTeamId)?.name ?? '선택한 팀';
+    /** `useMakeShiftBootstrap`: 실제 배정 1칸 이상일 때만 true (`isDutyShiftWithoutAssignments`와 동일 기준). */
     const hasCurrentMonthShift = shiftStatus === 'success' && shiftExists;
     const nextMonth = month === 12 ? 1 : month + 1;
     const nextYear = month === 12 ? year + 1 : year;
     const handleGoDuty = () => {
-        const params = new URLSearchParams({
-            year: String(year),
-            month: String(month),
-            shiftTeamId: String(currentShiftTeamId ?? ''),
-        });
-
-        navigate(`${ROUTE.DUTY}?${params.toString()}`);
+        navigate(buildDutyPath({year, month, shiftTeamId: currentShiftTeamId}));
     };
     const handleCreateCurrentMonth = () => {
         useCase.start();
@@ -135,6 +130,13 @@ export const MakeShiftPageView = () => {
                         </div>
                     ) : (
                         <>
+                            {hasCurrentMonthShift && (
+                                <div className="flex flex-wrap items-center justify-end gap-3 border-b border-gray-6 px-6 py-3 2xl:px-10">
+                                    <ManagementActionButton variant="secondary" size="md" onClick={handleGoDuty}>
+                                        {t('page.makeShift.overview.viewShift', {month})}
+                                    </ManagementActionButton>
+                                </div>
+                            )}
                             {/*
                              * Stepper는 흰 카드 폭 전체에 직접 배치한다 (분리선이 카드 좌우 가장자리까지 닿게).
                              * 좌우 콘텐츠 패딩은 stepper 내부의 step list(`px-[clamp(...)]`)와 아래 step content에만 적용한다.

--- a/apps/app/src/pages/make-shift/ui/make-shift-step-content.tsx
+++ b/apps/app/src/pages/make-shift/ui/make-shift-step-content.tsx
@@ -1,8 +1,9 @@
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import {renderMultilineText} from '@/shared/util/string';
-import {ManagementActionButton} from '@/widgets/duty-management/ui';
+import Button from '@/shared/ui/form-controls/Button';
 import {type TMakeShiftStep} from '../model/make-shift-store';
 import {MAKE_SHIFT_STEP_CONFIG} from './make-shift-step-config';
+import {MAKE_SHIFT_STEP_NAV_BUTTON_CLASS} from './make-shift-step-nav';
 
 type TMakeShiftStepContentProps = {
     currentStep: TMakeShiftStep;
@@ -16,16 +17,14 @@ export function MakeShiftStepContent({currentStep, canPrev, canNext, onPrev, onN
     const {t} = useTypedTranslation();
     const stepConfig = MAKE_SHIFT_STEP_CONFIG[currentStep];
     const StepComponent = stepConfig.Component;
-    /** 스텝 1·2·3: wide 래퍼에서도 상단 여백을 narrow와 맞추기 위해 pt를 한 단계 키움(스텝 4·5는 기존 유지). */
-    const roomierTopForEarlySteps = currentStep <= 3;
-    const wideTopPadding = roomierTopForEarlySteps ? 'pt-[clamp(16px,1.6vw,32px)]' : 'pt-[clamp(8px,0.8vw,16px)]';
 
     if (stepConfig.layout === 'wide') {
+        // 3탭(신청 근무): 헤더만 있고 자식 루트에 pt가 없어 스텝퍼와의 간격을 래퍼에서 준다. 4·5탭은 자식이 이미 상단 여백을 둔다.
+        const widePtClass = currentStep === 3 ? 'pt-[clamp(12px,1.25vw,28px)]' : '';
+
         return (
-            // wide layout(신청 근무 확정 / 고정 근무 / AI 자동 채우기 등): 자식이 자체적으로 상단 패딩(pt)을 가질 수 있어
-            // 여기서는 stepper와 사이의 최소 여백, 페이지 하단의 최소 여백만 화면 폭에 비례해 둔다.
             <div
-                className={`make-shift-step-content make-shift-step-content--wide flex w-full min-w-0 flex-1 flex-col ${wideTopPadding} pb-[clamp(12px,1.2vw,24px)]`}
+                className={`make-shift-step-content make-shift-step-content--wide flex w-full min-w-0 flex-1 flex-col pb-[clamp(12px,1.2vw,24px)] ${widePtClass}`}
             >
                 <p className="sr-only">{t(stepConfig.labelKey)}</p>
                 <StepComponent />
@@ -36,9 +35,8 @@ export function MakeShiftStepContent({currentStep, canPrev, canNext, onPrev, onN
     const intro = stepConfig.intro;
 
     return (
-        // narrow layout(근무자 확인 / 제약 조건 / 신청 근무 확정 등): 좌측 intro + 우측 step 본문.
-        // 상단은 wide와 동일한 pt 한 번 + intro 타이틀 기준 같은 간격을 한 번 더 (pt 합 ≈ clamp(16px,1.6vw,32px)).
-        <div className="make-shift-step-content make-shift-step-content--narrow flex w-full min-w-0 flex-1 gap-[clamp(20px,2.0vw,40px)] pt-[clamp(16px,1.6vw,32px)] pb-[clamp(12px,1.2vw,24px)]">
+        // narrow layout(근무자 확인 / 제약 조건 등): 좌측 intro + 우측 step 본문.
+        <div className="make-shift-step-content make-shift-step-content--narrow flex w-full min-w-0 flex-1 gap-[clamp(20px,2.0vw,40px)] pt-[clamp(12px,1.25vw,28px)] pb-[clamp(12px,1.2vw,24px)]">
             <div className="make-shift-step-content__intro w-[clamp(280px,30vw,440px)] shrink-0">
                 <p className="make-shift-step-content__intro-title font-apple text-[clamp(20px,1.7vw,30px)] font-semibold text-sub-1">
                     {intro ? t(intro.titleKey) : ''}
@@ -47,13 +45,28 @@ export function MakeShiftStepContent({currentStep, canPrev, canNext, onPrev, onN
                     {intro ? renderMultilineText(t(intro.descriptionKey)) : null}
                 </div>
 
-                <div className="make-shift-step-content__intro-actions mt-[clamp(28px,4.2vw,82px)] flex items-center gap-[clamp(12px,1.6vw,32px)]">
-                    <ManagementActionButton variant="neutral" size="sm" onClick={onPrev} disabled={!canPrev}>
-                        {t('page.makeShift.navigation.previous')}
-                    </ManagementActionButton>
-                    <ManagementActionButton size="sm" onClick={onNext} disabled={!canNext}>
+                <div className="make-shift-step-content__intro-actions mt-[clamp(28px,4.2vw,82px)] flex items-center gap-[clamp(12px,1.1vw,24px)]">
+                    {currentStep > 1 && (
+                        <Button
+                            variant="secondary"
+                            size="md"
+                            type="button"
+                            onClick={onPrev}
+                            disabled={!canPrev}
+                            className={`cursor-pointer disabled:cursor-not-allowed ${MAKE_SHIFT_STEP_NAV_BUTTON_CLASS}`}
+                        >
+                            {t('page.makeShift.navigation.previous')}
+                        </Button>
+                    )}
+                    <Button
+                        size="md"
+                        type="button"
+                        onClick={onNext}
+                        disabled={!canNext}
+                        className={`cursor-pointer border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed ${MAKE_SHIFT_STEP_NAV_BUTTON_CLASS}`}
+                    >
                         {t('page.makeShift.navigation.next')}
-                    </ManagementActionButton>
+                    </Button>
                 </div>
             </div>
 

--- a/apps/app/src/pages/make-shift/ui/make-shift-step-nav.ts
+++ b/apps/app/src/pages/make-shift/ui/make-shift-step-nav.ts
@@ -1,0 +1,5 @@
+/**
+ * 근무표 만들기 — 이전/다음 공통 높이·패딩·타이포 (narrow intro, 신청 탭 헤더, 고정 근무 툴바).
+ */
+export const MAKE_SHIFT_STEP_NAV_BUTTON_CLASS =
+    'h-[clamp(30px,2.5vw,42px)] rounded-[clamp(8px,0.7vw,10px)] px-[clamp(12px,1.0vw,20px)] text-[clamp(11px,0.95vw,16px)] font-semibold';

--- a/apps/app/src/pages/make-shift/ui/make-shift-stepper.tsx
+++ b/apps/app/src/pages/make-shift/ui/make-shift-stepper.tsx
@@ -6,19 +6,18 @@ type TStepState = 'prev' | 'current' | 'next';
 
 const STEP_CIRCLE_BASE =
     'flex shrink-0 items-center justify-center rounded-full font-poppins font-medium leading-none size-[clamp(20px,1.6vw,26px)] text-[clamp(11px,0.85vw,14px)]';
-const STEP_LABEL_BASE =
-    'whitespace-nowrap font-apple leading-none text-[clamp(13px,1.05vw,18px)]';
+const STEP_LABEL_BASE = 'whitespace-nowrap font-apple text-[clamp(13px,1.05vw,18px)] leading-[1.05]';
 
 function StepCircle({state, step}: {state: TStepState; step: number}) {
     if (state === 'current') {
         return <div className={`${STEP_CIRCLE_BASE} bg-main-1 text-white`}>{step}</div>;
     }
 
-    /*
-     * 사진 기준: prev / next 모두 동일한 옅은 회색 배경 + 흰 숫자.
-     * 현재 단계(current)만 보라색으로 강조해서 시각적 위계를 단순화한다.
-     */
-    return <div className={`${STEP_CIRCLE_BASE} bg-gray-4 text-white`}>{step}</div>;
+    if (state === 'prev') {
+        return <div className={`${STEP_CIRCLE_BASE} bg-gray-4 text-white`}>{step}</div>;
+    }
+
+    return <div className={`${STEP_CIRCLE_BASE} border-[1.5px] border-current bg-transparent text-gray-3`}>{step}</div>;
 }
 
 export function MakeShiftStepper({
@@ -46,11 +45,10 @@ export function MakeShiftStepper({
              * - 컨테이너의 padding-y는 0으로 두고 각 step button이 직접 py-... 를 가져 button의 bottom = 분리선 위치가 되도록 한다.
              *   (그래야 button 내부의 absolute indicator를 -bottom-px 로 두는 것만으로 회색 분리선과 정확히 같은 줄에 겹쳐 그려진다.)
              */}
-            <div className="make-shift-stepper__list flex w-full flex-wrap items-stretch justify-around">
+            <div className="make-shift-stepper__list flex w-full flex-wrap items-center justify-around">
                 {([1, 2, 3, 4, 5] as const).map((step) => {
                     const clickable = step !== currentStep && step <= maxReachedStep;
-                    const state: TStepState =
-                        step < currentStep ? 'prev' : step === currentStep ? 'current' : 'next';
+                    const state: TStepState = step < currentStep ? 'prev' : step === currentStep ? 'current' : 'next';
 
                     return (
                         <button
@@ -59,13 +57,13 @@ export function MakeShiftStepper({
                             onClick={() => clickable && onClickStep(step)}
                             data-step={step}
                             data-step-state={state}
-                            className={`make-shift-stepper__step relative flex items-center gap-[clamp(6px,0.55vw,10px)] py-[clamp(12px,1.1vw,20px)] ${
+                            className={`make-shift-stepper__step relative flex items-center gap-[clamp(6px,0.55vw,10px)] py-[clamp(10px,0.95vw,18px)] ${
                                 clickable ? 'cursor-pointer' : 'cursor-default'
                             }`}
                         >
                             <StepCircle state={state} step={step} />
                             <span
-                                className={`make-shift-stepper__label ${STEP_LABEL_BASE} ${
+                                className={`make-shift-stepper__label flex items-center ${STEP_LABEL_BASE} ${
                                     state === 'current' ? 'font-semibold text-main-1' : 'font-medium text-gray-3'
                                 }`}
                             >

--- a/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/ai-autofill-toolbar.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/ai-autofill-toolbar.tsx
@@ -15,18 +15,13 @@ type TAiAutofillToolbarProps = {
     onAiFill: () => void;
     isAiGenerating: boolean;
     aiStatus: TAiAutofillStatus;
+    hasCompletedAiFill: boolean;
     onConfirm: () => void;
     canConfirm: boolean;
 };
 
 /**
- * 사진 레퍼런스에 맞춘 상단 툴바.
- *
- * 좌: 제목 1개
- * 우: [자동 채우기 토글] [잘못된 근무 토글] | [undo/redo] | [AI 다시 채우기] [확정하기]
- *
- * 자동 채우기 토글: ON이면 AI·수동 등 전체 근무가 보이고, OFF이면 고정 근무(fixedCells)만 캘린더에 표시된다.
- * 모든 글자 크기는 clamp() 기반. 가로 폭이 줄어들면 함께 줄어든다.
+ * 상단 툴바: 신청 근무 확정 탭과 같이 제목 + 보조 문구(좌), 컨트롤(우).
  */
 export function AiAutofillToolbar({
     autoFillEnabled,
@@ -40,17 +35,23 @@ export function AiAutofillToolbar({
     onAiFill,
     isAiGenerating,
     aiStatus,
+    hasCompletedAiFill,
     onConfirm,
     canConfirm,
 }: TAiAutofillToolbarProps) {
     const {t} = useTypedTranslation();
-    const aiActionLabel = getAiAutofillActionLabel(aiStatus);
+    const aiActionKey = getAiAutofillActionLabel(aiStatus, hasCompletedAiFill);
 
     return (
-        <div className="ai-autofill-toolbar flex w-full min-w-0 items-center justify-between gap-[clamp(8px,0.8vw,16px)]">
-            <h1 className="ai-autofill-toolbar__title font-apple text-[clamp(20px,1.7vw,30px)] font-semibold whitespace-nowrap text-sub-1">
-                AI가 채운 근무표를 수정해 보세요
-            </h1>
+        <div className="ai-autofill-toolbar flex w-full min-w-0 flex-wrap items-center justify-between gap-[clamp(10px,0.9vw,16px)]">
+            <div className="ai-autofill-toolbar__titles flex min-w-0 flex-1 flex-wrap items-baseline gap-x-[clamp(12px,1.2vw,24px)] gap-y-[clamp(4px,0.4vw,8px)]">
+                <h1 className="ai-autofill-toolbar__title shrink-0 font-apple text-[clamp(20px,1.7vw,30px)] font-semibold text-sub-1">
+                    {t('page.makeShift.aiRefill.toolbarTitle')}
+                </h1>
+                <p className="ai-autofill-toolbar__hint max-w-full min-w-0 font-apple text-[clamp(13px,1.1vw,20px)] leading-snug font-medium text-gray-3">
+                    {t('page.makeShift.aiRefill.toolbarHint')}
+                </p>
+            </div>
 
             <div className="ai-autofill-toolbar__actions flex shrink-0 items-center gap-[clamp(6px,0.55vw,10px)]">
                 <ToggleChip
@@ -86,20 +87,10 @@ export function AiAutofillToolbar({
                 />
 
                 <span className="ai-autofill-toolbar__history flex items-center gap-[2px]">
-                    <IconButton
-                        className="ai-autofill-toolbar__history-undo"
-                        onClick={onUndo}
-                        disabled={!canUndo}
-                        ariaLabel="undo"
-                    >
+                    <IconButton className="ai-autofill-toolbar__history-undo" onClick={onUndo} disabled={!canUndo} ariaLabel="undo">
                         <HistoryBackIcon className="size-full" />
                     </IconButton>
-                    <IconButton
-                        className="ai-autofill-toolbar__history-redo"
-                        onClick={onRedo}
-                        disabled={!canRedo}
-                        ariaLabel="redo"
-                    >
+                    <IconButton className="ai-autofill-toolbar__history-redo" onClick={onRedo} disabled={!canRedo} ariaLabel="redo">
                         <HistoryNextIcon className="size-full" />
                     </IconButton>
                 </span>
@@ -117,12 +108,12 @@ export function AiAutofillToolbar({
                         'ai-autofill-toolbar__cta ai-autofill-toolbar__cta--ai-fill',
                         'flex shrink-0 items-center gap-[clamp(4px,0.4vw,8px)] rounded-[12px] px-[clamp(12px,1vw,18px)]',
                         'h-[clamp(30px,2.5vw,40px)] font-apple text-[clamp(12px,0.95vw,16px)] font-semibold whitespace-nowrap text-white',
-                        'shadow-[0_2px_10px_0_rgba(102,61,250,0.25)] disabled:opacity-60',
+                        'disabled:opacity-60',
                     )}
                     style={{backgroundImage: 'linear-gradient(105deg, #B53DFA 0%, #663DFA 100%)'}}
                 >
                     <SparkleIcon className="size-[clamp(13px,1.1vw,17px)]" />
-                    {t(`page.makeShift.aiRefill.${aiActionLabel}`)}
+                    {t(`page.makeShift.aiRefill.${aiActionKey}`)}
                 </button>
 
                 <button
@@ -159,7 +150,7 @@ function ToggleChip({
             type="button"
             onClick={onClick}
             className={cn(
-                'flex shrink-0 items-center gap-[clamp(3px,0.35vw,6px)] rounded-[6px] border whitespace-nowrap',
+                'flex shrink-0 cursor-pointer items-center gap-[clamp(3px,0.35vw,6px)] rounded-[6px] border whitespace-nowrap',
                 'h-[clamp(20px,1.7vw,26px)] px-[clamp(6px,0.55vw,10px)] font-apple text-[clamp(9px,0.72vw,12px)]',
                 active ? 'border-gray-5 bg-white text-sub-2' : 'border-gray-5 bg-gray-6 text-sub-2.5 opacity-90',
                 className,
@@ -190,7 +181,7 @@ function IconButton({
             disabled={disabled}
             aria-label={ariaLabel}
             className={cn(
-                'grid size-[clamp(18px,1.5vw,24px)] shrink-0 place-items-center rounded-[6px] text-sub-2.5 hover:bg-gray-7 disabled:opacity-40 disabled:hover:bg-transparent',
+                'grid size-[clamp(18px,1.5vw,24px)] shrink-0 cursor-pointer place-items-center rounded-[6px] text-sub-2.5 hover:bg-gray-7 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent',
                 className,
             )}
         >

--- a/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
@@ -1,11 +1,7 @@
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import toast from 'react-hot-toast';
 import useAuth from '@/features/auth';
-import {
-    docToWardShiftsDTO,
-    useShiftEditorCommands,
-    useShiftEditorStore,
-} from '@/features/shift-editor';
+import {docToWardShiftsDTO, useShiftEditorCommands, useShiftEditorStore} from '@/features/shift-editor';
 import WardAPI from '@/shared/api/ward';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import PageState from '@/shared/ui/PageState';
@@ -39,6 +35,7 @@ export function AiAutofill() {
     const [isWorking, setIsWorking] = useState(false);
     const [isAiGenerating, setIsAiGenerating] = useState(false);
     const [aiStatus, setAiStatus] = useState<TAiAutofillStatus>('idle');
+    const [hasCompletedAiFill, setHasCompletedAiFill] = useState(false);
     const resetAiStatus = useCallback(() => setAiStatus('idle'), []);
     const {
         dutyQuery,
@@ -54,11 +51,14 @@ export function AiAutofill() {
 
     currentAiContextRef.current = {wardId, shiftTeamId: currentShiftTeamId, year, month};
 
+    useEffect(() => {
+        setHasCompletedAiFill(false);
+    }, [wardId, currentShiftTeamId, year, month]);
+
     const calendarDoc = useMemo(
         () => (autoFillEnabled ? hydratedDoc : maskDutyDocNonFixedCells(hydratedDoc)),
         [autoFillEnabled, hydratedDoc],
     );
-
     const canConfirm =
         !isWorking &&
         !isAiGenerating &&
@@ -123,6 +123,7 @@ export function AiAutofill() {
 
             commands.applySchedule(result.response.schedule, 'ai');
             setAiStatus('success');
+            setHasCompletedAiFill(true);
         } finally {
             if (aiRequestSeqRef.current === requestSeq) {
                 setIsAiGenerating(false);
@@ -133,7 +134,7 @@ export function AiAutofill() {
     return (
         <div
             id="make_ai_autofill_step"
-            className="ai-autofill-root flex w-full min-w-0 flex-col gap-[clamp(16px,1.4vw,28px)] pt-[clamp(16px,1.6vw,28px)] outline-none"
+            className="ai-autofill-root flex w-full min-w-0 flex-col gap-[clamp(16px,1.4vw,28px)] pt-[clamp(12px,1.25vw,28px)] outline-none"
             ref={editorRef}
             onKeyDown={onKeyDown}
             onPaste={onPaste}
@@ -151,16 +152,13 @@ export function AiAutofill() {
                 onAiFill={handleAiFill}
                 isAiGenerating={isAiGenerating}
                 aiStatus={aiStatus}
+                hasCompletedAiFill={hasCompletedAiFill}
                 onConfirm={handleConfirm}
                 canConfirm={canConfirm}
             />
 
             {dutyQuery.isLoading && (
-                <PageState
-                    tone="loading"
-                    title={t('page.makeShift.aiRefill.loading')}
-                    description={t('page.state.loadingDescription')}
-                />
+                <PageState tone="loading" title={t('page.makeShift.aiRefill.loading')} description={t('page.state.loadingDescription')} />
             )}
             {dutyQuery.isError && (
                 <PageState

--- a/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
@@ -42,7 +42,7 @@ export function AiAutofill() {
         editorRef,
         editorDoc: hydratedDoc,
         onKeyDown,
-        onPaste,
+        onPasteCapture,
         violationMap,
         focusEditor,
     } = useDutyEditorStep({onContextChanged: resetAiStatus});
@@ -137,7 +137,7 @@ export function AiAutofill() {
             className="ai-autofill-root flex w-full min-w-0 flex-col gap-[clamp(16px,1.4vw,28px)] pt-[clamp(12px,1.25vw,28px)] outline-none focus-visible:ring-2 focus-visible:ring-main-4 focus-visible:ring-offset-2"
             ref={editorRef}
             onKeyDown={onKeyDown}
-            onPaste={onPaste}
+            onPasteCapture={onPasteCapture}
             tabIndex={0}
         >
             <AiAutofillToolbar

--- a/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
@@ -134,7 +134,7 @@ export function AiAutofill() {
     return (
         <div
             id="make_ai_autofill_step"
-            className="ai-autofill-root flex w-full min-w-0 flex-col gap-[clamp(16px,1.4vw,28px)] pt-[clamp(12px,1.25vw,28px)] outline-none"
+            className="ai-autofill-root flex w-full min-w-0 flex-col gap-[clamp(16px,1.4vw,28px)] pt-[clamp(12px,1.25vw,28px)] outline-none focus-visible:ring-2 focus-visible:ring-main-4 focus-visible:ring-offset-2"
             ref={editorRef}
             onKeyDown={onKeyDown}
             onPaste={onPaste}

--- a/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
@@ -1,7 +1,9 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useNavigate} from 'react-router';
 import toast from 'react-hot-toast';
 import useAuth from '@/features/auth';
 import {docToWardShiftsDTO, useShiftEditorCommands, useShiftEditorStore} from '@/features/shift-editor';
+import {buildDutyPath} from '@/pages/duty/model/duty-navigation';
 import WardAPI from '@/shared/api/ward';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import PageState from '@/shared/ui/PageState';
@@ -19,6 +21,7 @@ import {AiAutofillToolbar} from './ai-autofill-toolbar';
  */
 export function AiAutofill() {
     const {t} = useTypedTranslation();
+    const navigate = useNavigate();
     const {
         state: {wardId},
     } = useAuth();
@@ -76,6 +79,7 @@ export function AiAutofill() {
 
             await WardAPI.updateShifts(wardId, dto);
             useCase.complete();
+            navigate(buildDutyPath({year, month, shiftTeamId: currentShiftTeamId}));
         } catch {
             toast.error(t('page.makeShift.aiRefill.saveFailed'));
         } finally {

--- a/apps/app/src/pages/make-shift/ui/steps/constraints-sections.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/constraints-sections.tsx
@@ -7,6 +7,7 @@ import {type TDutyRuleKey} from '@/features/shift-editor/model/types';
 import {InfoIcon, SixDotsIcon} from '@/shared/assets/svg';
 import {type useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import Select from '@/shared/ui/form-controls/Select';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@/shared/ui/primitives/tooltip';
 
 type TActiveBucket = 'error' | 'warning';
 type TTypedT = ReturnType<typeof useTypedTranslation>['t'];
@@ -18,43 +19,85 @@ type TConstraintSectionProps = {
     onToggle?: () => void;
     disabled?: boolean;
     infoLabel?: string;
+    infoTooltipAria: string;
     children: ReactNode;
 };
 
-export function ConstraintSection({title, countLabel, isOpen, onToggle, disabled = false, infoLabel, children}: TConstraintSectionProps) {
+export function ConstraintSection({
+    title,
+    countLabel,
+    isOpen,
+    onToggle,
+    disabled = false,
+    infoLabel,
+    infoTooltipAria,
+    children,
+}: TConstraintSectionProps) {
     const collapsible = typeof isOpen === 'boolean' && onToggle;
 
     return (
         <>
-            <div className="make-shift-constraints__section-header flex items-center justify-between">
+            <div className="make-shift-constraints__section-header flex min-h-[clamp(36px,3.0vw,46px)] items-center justify-between gap-[clamp(8px,0.7vw,14px)]">
                 {collapsible ? (
                     <button
                         type="button"
-                        className="make-shift-constraints__section-title flex items-center gap-[clamp(4px,0.5vw,8px)] font-apple text-[clamp(16px,1.4vw,24px)] font-bold text-sub-2 disabled:opacity-50"
+                        className="make-shift-constraints__section-title flex min-w-0 items-center gap-[clamp(4px,0.5vw,8px)] font-apple text-[clamp(13px,1.2vw,21px)] font-bold text-sub-2 disabled:opacity-50"
                         onClick={onToggle}
                         disabled={disabled}
                     >
                         {title}
                         <ChevronDown
-                            className={cn('size-[clamp(16px,1.4vw,24px)] transition-transform', isOpen ? 'rotate-180' : 'rotate-0')}
+                            className={cn(
+                                'size-[clamp(15px,1.25vw,21px)] shrink-0 transition-transform',
+                                isOpen ? 'rotate-180' : 'rotate-0',
+                            )}
                         />
                     </button>
                 ) : (
-                    <p className="make-shift-constraints__section-title font-apple text-[clamp(16px,1.4vw,24px)] font-bold text-gray-4">
+                    <p className="make-shift-constraints__section-title font-apple text-[clamp(13px,1.2vw,21px)] font-bold text-gray-4">
                         {title}
                     </p>
                 )}
-                <p className="make-shift-constraints__section-count font-apple text-[clamp(13px,1.2vw,20px)] font-medium text-gray-4">
-                    {countLabel}
-                </p>
+                <div className="make-shift-constraints__section-meta flex shrink-0 items-center gap-[clamp(8px,0.65vw,12px)]">
+                    <p className="make-shift-constraints__section-count font-apple text-[clamp(12px,1.05vw,17px)] font-semibold text-sub-2">
+                        {countLabel}
+                    </p>
+                </div>
             </div>
 
             {collapsible && !isOpen ? null : (
-                <div className="make-shift-constraints__section-body mt-[clamp(10px,1.0vw,16px)] rounded-[clamp(10px,1.0vw,15px)] bg-gray-7 p-[clamp(14px,2.0vw,30px)]">
+                <div
+                    className={cn(
+                        'make-shift-constraints__section-body mt-[clamp(4px,0.45vw,8px)] rounded-[clamp(10px,1.0vw,15px)] bg-gray-7 px-[clamp(12px,1.8vw,26px)]',
+                        infoLabel ? 'pt-[clamp(4px,0.35vw,7px)] pb-[clamp(8px,1.05vw,16px)]' : 'py-[clamp(8px,1.1vw,18px)]',
+                    )}
+                >
                     {infoLabel ? (
-                        <div className="make-shift-constraints__section-info mb-[clamp(10px,1.2vw,18px)] flex items-center gap-[clamp(4px,0.5vw,8px)]">
-                            <InfoIcon className="size-[clamp(16px,1.4vw,24px)]" />
-                            <p className="font-apple text-[clamp(11px,0.95vw,16px)] font-semibold text-main-1">{infoLabel}</p>
+                        <div
+                            className="make-shift-constraints__section-body-info grid grid-cols-[clamp(22px,2.4vw,36px)_minmax(0,1fr)] items-center gap-x-[clamp(10px,1.1vw,20px)] pt-[clamp(5px,0.45vw,9px)] pb-[clamp(5px,0.45vw,9px)]"
+                        >
+                            <div aria-hidden className="w-full" />
+                            <div className="flex min-w-0 justify-end">
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <button
+                                            type="button"
+                                            className="make-shift-constraints__section-info-trigger text-sub-3 outline-none transition-colors hover:text-gray-4 focus-visible:ring-2 focus-visible:ring-main-4 focus-visible:ring-offset-2"
+                                            aria-label={infoTooltipAria}
+                                        >
+                                            <InfoIcon className="size-[clamp(13px,1.12vw,19px)] shrink-0" />
+                                        </button>
+                                    </TooltipTrigger>
+                                    <TooltipContent
+                                        side="top"
+                                        align="start"
+                                        sideOffset={6}
+                                        className="max-w-none whitespace-nowrap border border-gray-5 bg-white px-[clamp(10px,0.9vw,14px)] py-[clamp(6px,0.55vw,10px)] font-apple text-[clamp(11px,0.95vw,14px)] leading-none font-medium text-sub-1 shadow-md"
+                                    >
+                                        {infoLabel}
+                                    </TooltipContent>
+                                </Tooltip>
+                            </div>
                         </div>
                     ) : null}
                     {children}
@@ -73,8 +116,8 @@ export function renderRuleEditor(t: TTypedT, meta: TDutyRuleMeta, value: number 
             value={value ?? ''}
             onChange={(e) => onChange(parseInt(e.target.value, 10))}
             options={options}
-            className="make-shift-constraints__rule-editor-select mx-[clamp(3px,0.3vw,5px)] h-[clamp(28px,2.4vw,44px)] w-[clamp(48px,4.6vw,67px)]"
-            selectClassName="rounded-[5px] px-[clamp(8px,0.85vw,15px)] py-[clamp(4px,0.45vw,7px)] outline-[0.5px] outline-main-4 text-main-1 text-[clamp(11px,0.95vw,16px)]"
+            className="make-shift-constraints__rule-editor-select mx-[clamp(3px,0.3vw,5px)] h-[clamp(22px,1.85vw,30px)] w-[clamp(44px,4.2vw,60px)]"
+            selectClassName="rounded-[5px] px-[clamp(6px,0.65vw,12px)] py-[clamp(2px,0.25vw,5px)] outline-[0.5px] outline-main-4 text-main-1 text-[clamp(10px,0.85vw,14px)]"
         />
     );
     const editorClass =
@@ -135,15 +178,11 @@ export function ConstraintBucketList({
 }: TConstraintBucketListProps) {
     return (
         <Droppable droppableId={bucket}>
-            {(provided, snapshot) => (
+            {(provided) => (
                 <div
                     ref={provided.innerRef}
                     {...provided.droppableProps}
-                    className={cn(
-                        'make-shift-constraints__bucket',
-                        `make-shift-constraints__bucket--${bucket}`,
-                        snapshot.isDraggingOver && 'bg-[#f0ecff]',
-                    )}
+                    className={cn('make-shift-constraints__bucket', `make-shift-constraints__bucket--${bucket}`)}
                 >
                     {ruleKeys.length === 0 ? (
                         <div className="make-shift-constraints__empty rounded-[clamp(8px,0.7vw,10px)] bg-white px-[clamp(14px,1.5vw,24px)] py-[clamp(12px,1.25vw,20px)] text-center font-apple text-[clamp(10px,0.85vw,14px)] text-gray-4">
@@ -164,14 +203,14 @@ export function ConstraintBucketList({
                                                 ref={dragProvided.innerRef}
                                                 {...dragProvided.draggableProps}
                                                 className={cn(
-                                                    'make-shift-constraints__rule flex items-center gap-[clamp(10px,1.1vw,20px)]',
+                                                    'make-shift-constraints__rule flex h-[clamp(28px,2.75vw,42px)] items-center gap-[clamp(10px,1.1vw,20px)]',
                                                     dragSnapshot.isDragging && 'opacity-95',
                                                 )}
                                             >
-                                                <div className="make-shift-constraints__rule-index w-[clamp(24px,2.6vw,40px)] text-center font-apple text-[clamp(16px,1.6vw,28px)] text-gray-3">
+                                                <div className="make-shift-constraints__rule-index w-[clamp(22px,2.4vw,36px)] text-center font-apple text-[clamp(14px,1.45vw,26px)] text-gray-4">
                                                     {index + 1}
                                                 </div>
-                                                <div className="make-shift-constraints__rule-card flex h-[clamp(44px,4.0vw,62px)] flex-1 items-center rounded-[clamp(8px,0.7vw,10px)] bg-white px-[clamp(12px,1.3vw,20px)]">
+                                                <div className="make-shift-constraints__rule-card flex h-full min-h-0 flex-1 items-center rounded-[clamp(8px,0.7vw,10px)] bg-white px-[clamp(12px,1.3vw,20px)]">
                                                     <button
                                                         type="button"
                                                         aria-label={t('page.makeShift.constraints.dragHandleAria')}
@@ -202,11 +241,14 @@ export function ConstraintBucketList({
                                                     <button
                                                         type="button"
                                                         aria-label={t('page.makeShift.constraints.excludeRuleAria')}
-                                                        className="make-shift-constraints__rule-exclude ml-[clamp(6px,0.6vw,10px)] flex size-[clamp(28px,2.5vw,40px)] shrink-0 items-center justify-center rounded-[clamp(6px,0.55vw,8px)] border border-gray-5 text-gray-3 hover:border-main-4 hover:bg-gray-7 hover:text-main-1 disabled:opacity-40"
+                                                        className="make-shift-constraints__rule-exclude ml-[clamp(6px,0.6vw,10px)] grid size-[clamp(18px,1.55vw,26px)] shrink-0 place-items-center rounded-full border border-gray-5 bg-white text-gray-4 transition-colors hover:border-gray-4 hover:bg-gray-7 hover:text-gray-3 disabled:opacity-40"
                                                         disabled={disabled}
                                                         onClick={() => onExcludeRule(key)}
                                                     >
-                                                        <Minus className="size-[clamp(14px,1.2vw,20px)]" strokeWidth={2.2} />
+                                                        <Minus
+                                                            className="size-[clamp(10px,0.82vw,14px)] shrink-0 stroke-[1.85]"
+                                                            aria-hidden
+                                                        />
                                                     </button>
                                                 </div>
                                             </div>

--- a/apps/app/src/pages/make-shift/ui/steps/constraints.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/constraints.tsx
@@ -4,6 +4,7 @@ import {useShiftEditorCommands, useShiftEditorStore} from '@/features/shift-edit
 import {type TDutyRuleMeta} from '@/features/shift-editor/model/duty-constraints';
 import {type TDutyRuleKey} from '@/features/shift-editor/model/types';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
+import {TooltipProvider} from '@/shared/ui/primitives/tooltip';
 import {ConstraintBucketList, ConstraintSection} from './constraints-sections';
 
 type TDragBucket = 'error' | 'warning';
@@ -78,50 +79,54 @@ export function Constraints() {
     const disabled = dutyValidationInput === null || board === null;
 
     return (
-        <DragDropContext onDragEnd={onDragEnd}>
-            <div id="make_constraints_step" className="make-shift-constraints w-full">
-                <ConstraintSection
-                    title={t('page.makeShift.constraints.section.strong')}
-                    countLabel={t('page.makeShift.constraints.count', {count: strongCount})}
-                    isOpen={open.error}
-                    onToggle={() => setOpen((state) => ({...state, error: !state.error}))}
-                    disabled={disabled}
-                    infoLabel={t('page.makeShift.constraints.info')}
-                >
-                    <ConstraintBucketList
-                        t={t}
-                        bucket="error"
-                        ruleKeys={board?.error ?? []}
-                        ruleViolationCount={ruleViolationCount}
-                        wardConstraint={wardConstraint}
-                        onUpdateRuleValue={updateRuleValue}
-                        onExcludeRule={(key) => excludeRule('error', key)}
-                        disabled={disabled}
-                    />
-                </ConstraintSection>
-
-                <div className="make-shift-constraints__section-spacer mt-[clamp(14px,1.6vw,24px)]">
+        <TooltipProvider delayDuration={200}>
+            <DragDropContext onDragEnd={onDragEnd}>
+                <div id="make_constraints_step" className="make-shift-constraints w-full">
                     <ConstraintSection
-                        title={t('page.makeShift.constraints.section.weak')}
-                        countLabel={t('page.makeShift.constraints.count', {count: weakCount})}
-                        isOpen={open.warning}
-                        onToggle={() => setOpen((state) => ({...state, warning: !state.warning}))}
+                        title={t('page.makeShift.constraints.section.strong')}
+                        countLabel={t('page.makeShift.constraints.count', {count: strongCount})}
+                        isOpen={open.error}
+                        onToggle={() => setOpen((state) => ({...state, error: !state.error}))}
                         disabled={disabled}
                         infoLabel={t('page.makeShift.constraints.info')}
+                        infoTooltipAria={t('page.makeShift.constraints.infoTooltipAria')}
                     >
                         <ConstraintBucketList
                             t={t}
-                            bucket="warning"
-                            ruleKeys={board?.warning ?? []}
+                            bucket="error"
+                            ruleKeys={board?.error ?? []}
                             ruleViolationCount={ruleViolationCount}
                             wardConstraint={wardConstraint}
                             onUpdateRuleValue={updateRuleValue}
-                            onExcludeRule={(key) => excludeRule('warning', key)}
+                            onExcludeRule={(key) => excludeRule('error', key)}
                             disabled={disabled}
                         />
                     </ConstraintSection>
+
+                    <div className="make-shift-constraints__section-spacer mt-[clamp(14px,1.6vw,24px)]">
+                        <ConstraintSection
+                            title={t('page.makeShift.constraints.section.weak')}
+                            countLabel={t('page.makeShift.constraints.count', {count: weakCount})}
+                            isOpen={open.warning}
+                            onToggle={() => setOpen((state) => ({...state, warning: !state.warning}))}
+                            disabled={disabled}
+                            infoLabel={t('page.makeShift.constraints.info')}
+                            infoTooltipAria={t('page.makeShift.constraints.infoTooltipAria')}
+                        >
+                            <ConstraintBucketList
+                                t={t}
+                                bucket="warning"
+                                ruleKeys={board?.warning ?? []}
+                                ruleViolationCount={ruleViolationCount}
+                                wardConstraint={wardConstraint}
+                                onUpdateRuleValue={updateRuleValue}
+                                onExcludeRule={(key) => excludeRule('warning', key)}
+                                disabled={disabled}
+                            />
+                        </ConstraintSection>
+                    </div>
                 </div>
-            </div>
-        </DragDropContext>
+            </DragDropContext>
+        </TooltipProvider>
     );
 }

--- a/apps/app/src/pages/make-shift/ui/steps/fixed-shifts.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/fixed-shifts.tsx
@@ -8,9 +8,10 @@ import {type TViolation} from '@/features/shift-editor/model';
 import WardAPI from '@/shared/api/ward';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import PageState from '@/shared/ui/PageState';
-import {ManagementActionButton} from '@/widgets/duty-management/ui';
+import Button from '@/shared/ui/form-controls/Button';
 import {canGoNext, canGoPrev, useMakeShiftStore} from '../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../model/make-shift-use-case';
+import {MAKE_SHIFT_STEP_NAV_BUTTON_CLASS} from '../make-shift-step-nav';
 import {MakeShiftCalendar} from './shared/make-shift-calendar';
 import {useDutyEditorStep} from './shared/use-duty-editor-step';
 
@@ -47,7 +48,6 @@ export function FixedShifts() {
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
     const canNext = useMakeShiftStore((s) => canGoNext(s));
     const {dutyQuery, editorDoc, editorRef, onKeyDown, onPaste, focusEditor} = useDutyEditorStep();
-
     const handleNext = useCallback(async () => {
         if (!wardId || !dutyQuery.data || !canNext || isSaving) return;
 
@@ -66,28 +66,9 @@ export function FixedShifts() {
         } finally {
             setIsSaving(false);
         }
-    }, [
-        wardId,
-        dutyQuery.data,
-        canNext,
-        isSaving,
-        editorDoc,
-        queryClient,
-        currentShiftTeamId,
-        year,
-        month,
-        useCase,
-        t,
-    ]);
-
+    }, [wardId, dutyQuery.data, canNext, isSaving, editorDoc, queryClient, currentShiftTeamId, year, month, useCase, t]);
     const nextDisabled =
-        wardId === null ||
-        !canNext ||
-        isSaving ||
-        dutyQuery.isLoading ||
-        dutyQuery.isError ||
-        dutyQuery.data === undefined;
-
+        wardId === null || !canNext || isSaving || dutyQuery.isLoading || dutyQuery.isError || dutyQuery.data === undefined;
     /**
      * 고정 근무 화면에서는 fixedCells / requestCells 로 마킹된 셀만 보여준다.
      * (그 외 셀은 비워서 사용자가 "고정해야 할 부분"에만 집중하도록.)
@@ -114,7 +95,7 @@ export function FixedShifts() {
     return (
         <div
             id="make_fixed_shifts_step"
-            className="fixed-shifts-root flex w-full min-w-0 flex-col gap-[clamp(16px,1.4vw,28px)] pt-[clamp(16px,1.6vw,28px)] outline-none"
+            className="fixed-shifts-root flex w-full min-w-0 flex-col gap-[clamp(16px,1.4vw,28px)] pt-[clamp(12px,1.25vw,28px)] outline-none"
             ref={editorRef}
             onKeyDown={onKeyDown}
             onPaste={onPaste}
@@ -126,18 +107,26 @@ export function FixedShifts() {
                     고정할 근무를 선택해 주세요
                 </h1>
 
-                <div className="fixed-shifts-toolbar__actions flex shrink-0 items-center gap-[clamp(6px,0.55vw,12px)]">
-                    <ManagementActionButton
-                        variant="neutral"
-                        size="sm"
+                <div className="fixed-shifts-toolbar__actions flex shrink-0 items-center gap-[clamp(12px,1.1vw,24px)]">
+                    <Button
+                        variant="secondary"
+                        size="md"
+                        type="button"
+                        className={`cursor-pointer disabled:cursor-not-allowed ${MAKE_SHIFT_STEP_NAV_BUTTON_CLASS}`}
                         onClick={() => useCase.prev()}
                         disabled={!canPrev}
                     >
                         {t('page.makeShift.navigation.previous')}
-                    </ManagementActionButton>
-                    <ManagementActionButton size="sm" onClick={() => void handleNext()} disabled={nextDisabled}>
+                    </Button>
+                    <Button
+                        size="md"
+                        type="button"
+                        className={`cursor-pointer border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed ${MAKE_SHIFT_STEP_NAV_BUTTON_CLASS}`}
+                        onClick={() => void handleNext()}
+                        disabled={nextDisabled}
+                    >
                         {isSaving ? t('page.makeShift.navigation.saving') : t('page.makeShift.navigation.next')}
-                    </ManagementActionButton>
+                    </Button>
                 </div>
             </div>
 

--- a/apps/app/src/pages/make-shift/ui/steps/fixed-shifts.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/fixed-shifts.tsx
@@ -47,7 +47,7 @@ export function FixedShifts() {
 
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
     const canNext = useMakeShiftStore((s) => canGoNext(s));
-    const {dutyQuery, editorDoc, editorRef, onKeyDown, onPaste, focusEditor} = useDutyEditorStep();
+    const {dutyQuery, editorDoc, editorRef, onKeyDown, onPasteCapture, focusEditor} = useDutyEditorStep();
     const handleNext = useCallback(async () => {
         if (!wardId || !dutyQuery.data || !canNext || isSaving) return;
 
@@ -98,7 +98,7 @@ export function FixedShifts() {
             className="fixed-shifts-root flex w-full min-w-0 flex-col gap-[clamp(16px,1.4vw,28px)] pt-[clamp(12px,1.25vw,28px)] outline-none"
             ref={editorRef}
             onKeyDown={onKeyDown}
-            onPaste={onPaste}
+            onPasteCapture={onPasteCapture}
             tabIndex={0}
         >
             {/* 상단 툴바: 제목 + 액션 버튼 */}

--- a/apps/app/src/pages/make-shift/ui/steps/requests-shifts-sections.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/requests-shifts-sections.tsx
@@ -1,7 +1,8 @@
 import {cn} from '@dutying/utils/style';
+import {Check, Clock, X} from 'lucide-react';
 import {type TDutyRequest, type TWardShiftType} from '@/entities';
 import ShiftBadge from '@/entities/shift/ui/shift-badge';
-import {Check, Clock, X} from 'lucide-react';
+import {MAKE_SHIFT_STEP_NAV_BUTTON_CLASS} from '../make-shift-step-nav';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import Button from '@/shared/ui/form-controls/Button';
 
@@ -14,35 +15,25 @@ type TRequestsShiftsHeaderProps = {
     onNext: () => void;
 };
 
-const REQUESTS_NAV_BUTTON_CLASS =
-    'h-[clamp(30px,2.5vw,42px)] rounded-[clamp(8px,0.7vw,10px)] px-[clamp(12px,1.0vw,20px)] text-[clamp(11px,0.95vw,16px)] font-semibold';
-
-export function RequestsShiftsHeader({
-    canPrev,
-    canNext,
-    onPrev,
-    onNext,
-}: TRequestsShiftsHeaderProps) {
+export function RequestsShiftsHeader({canPrev, canNext, onPrev, onNext}: TRequestsShiftsHeaderProps) {
     const {t} = useTypedTranslation();
 
     return (
-        <div className="make-shift-requests-header flex flex-wrap items-start justify-between gap-[clamp(14px,1.5vw,24px)]">
+        <div className="make-shift-requests-header flex flex-wrap items-center justify-between gap-[clamp(14px,1.5vw,24px)]">
             <div className="make-shift-requests-header__intro flex min-w-0 flex-1 flex-wrap items-baseline gap-x-[clamp(12px,1.2vw,24px)] gap-y-[clamp(6px,0.55vw,10px)]">
                 <p className="make-shift-requests-header__title shrink-0 font-apple text-[clamp(20px,1.7vw,30px)] font-semibold text-sub-1">
                     {t('page.makeShift.requests.title')}
                 </p>
-                <p className="make-shift-requests-header__description min-w-0 max-w-full font-apple text-[clamp(13px,1.1vw,20px)] font-medium leading-snug text-gray-3">
-                    {t('page.makeShift.requests.descriptionPrefix')}{' '}
-                    <span className="text-main-1">{t('page.makeShift.requests.descriptionHighlight')}</span>
-                    {t('page.makeShift.requests.descriptionSuffix')}
+                <p className="make-shift-requests-header__description max-w-full min-w-0 font-apple text-[clamp(13px,1.1vw,20px)] leading-snug font-medium text-gray-3">
+                    {t('page.makeShift.requests.descriptionLine')}
                 </p>
             </div>
 
-            <div className="make-shift-requests-header__actions flex items-center gap-[clamp(6px,0.55vw,12px)]">
+            <div className="make-shift-requests-header__actions flex shrink-0 items-center gap-[clamp(12px,1.1vw,24px)]">
                 <Button
                     variant="secondary"
                     size="md"
-                    className={`make-shift-requests-header__nav-button ${REQUESTS_NAV_BUTTON_CLASS}`}
+                    className={`make-shift-requests-header__nav-button cursor-pointer disabled:cursor-not-allowed ${MAKE_SHIFT_STEP_NAV_BUTTON_CLASS}`}
                     onClick={onPrev}
                     disabled={!canPrev}
                     type="button"
@@ -51,7 +42,7 @@ export function RequestsShiftsHeader({
                 </Button>
                 <Button
                     size="md"
-                    className={`make-shift-requests-header__nav-button ${REQUESTS_NAV_BUTTON_CLASS}`}
+                    className={`make-shift-requests-header__nav-button cursor-pointer border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed ${MAKE_SHIFT_STEP_NAV_BUTTON_CLASS}`}
                     onClick={onNext}
                     disabled={!canNext}
                     type="button"
@@ -75,9 +66,7 @@ type TRequestsPendingPanelProps = {
 
 const PENDING_ACTION_BTN =
     'h-[clamp(22px,1.75vw,28px)] min-w-0 shrink-0 rounded-[clamp(5px,0.45cqw,8px)] px-[clamp(6px,0.55vw,10px)] text-[clamp(9px,0.72cqw,12px)] font-semibold leading-none';
-
-const REQUEST_SUMMARY_ICON_CLASS = 'size-[clamp(10px,0.9cqw,14px)] shrink-0 stroke-[2.25]';
-
+const REQUEST_SUMMARY_ICON_CLASS = 'size-[clamp(10px,0.9cqw,14px)] shrink-0 stroke-[1.25]';
 const REQUEST_SUMMARY_BADGE_CLASS =
     'inline-flex items-center gap-[clamp(2px,0.2cqw,4px)] rounded-full border border-gray-6 bg-main-bg px-[clamp(5px,0.45cqw,8px)] py-[clamp(1px,0.12cqw,3px)]';
 
@@ -100,47 +89,38 @@ export function RequestsPendingPanel({
             id="make_requests_decision_panel"
             className="make-shift-requests-pending flex w-[clamp(200px,17vw,280px)] shrink-0 flex-col overflow-hidden rounded-[clamp(10px,0.9cqw,16px)] bg-white shadow-banner"
         >
-            <div className="make-shift-requests-pending__header flex min-h-0 items-center justify-between gap-[clamp(6px,0.5cqw,10px)] border-b border-sub-4.5 px-[clamp(8px,0.75cqw,12px)] py-[clamp(6px,0.55cqw,10px)]">
-                <p className="make-shift-requests-pending__title min-w-0 truncate font-apple text-[clamp(11px,0.88cqw,14px)] font-semibold leading-tight text-main-1">
+            <div className="make-shift-requests-pending__header flex min-h-0 items-center justify-between gap-[clamp(8px,0.65cqw,12px)] border-b border-sub-4.5 px-[clamp(12px,1.0cqw,16px)] py-[clamp(10px,0.8cqw,14px)]">
+                <p className="make-shift-requests-pending__title min-w-0 truncate font-apple text-[clamp(13px,1.05cqw,16px)] leading-tight font-semibold text-main-1">
                     {t('page.makeShift.requests.panelTitle')}
                 </p>
                 <div
                     className="make-shift-requests-pending__summary flex shrink-0 flex-nowrap items-center justify-end gap-[clamp(4px,0.35cqw,6px)]"
                     aria-label={t('page.makeShift.requests.summaryCountsAria')}
                 >
-                    <span
-                        className={REQUEST_SUMMARY_BADGE_CLASS}
-                        title={t('page.makeShift.requests.badge.accepted')}
-                    >
+                    <span className={REQUEST_SUMMARY_BADGE_CLASS} title={t('page.makeShift.requests.badge.accepted')}>
                         <Check className={cn(REQUEST_SUMMARY_ICON_CLASS, 'text-green-600')} aria-hidden />
-                        <span className="font-apple text-[clamp(9px,0.72cqw,12px)] font-semibold tabular-nums leading-none text-sub-1">
+                        <span className="font-apple text-[clamp(9px,0.72cqw,12px)] leading-none font-semibold text-sub-1 tabular-nums">
                             {acceptedCount}
                         </span>
                     </span>
-                    <span
-                        className={REQUEST_SUMMARY_BADGE_CLASS}
-                        title={t('page.makeShift.requests.badge.pending')}
-                    >
+                    <span className={REQUEST_SUMMARY_BADGE_CLASS} title={t('page.makeShift.requests.badge.pending')}>
                         <Clock className={cn(REQUEST_SUMMARY_ICON_CLASS, 'text-main-1')} aria-hidden />
-                        <span className="font-apple text-[clamp(9px,0.72cqw,12px)] font-semibold tabular-nums leading-none text-sub-1">
+                        <span className="font-apple text-[clamp(9px,0.72cqw,12px)] leading-none font-semibold text-sub-1 tabular-nums">
                             {pendingCount}
                         </span>
                     </span>
-                    <span
-                        className={REQUEST_SUMMARY_BADGE_CLASS}
-                        title={t('page.makeShift.requests.badge.rejected')}
-                    >
+                    <span className={REQUEST_SUMMARY_BADGE_CLASS} title={t('page.makeShift.requests.badge.rejected')}>
                         <X className={cn(REQUEST_SUMMARY_ICON_CLASS, 'text-gray-4')} aria-hidden />
-                        <span className="font-apple text-[clamp(9px,0.72cqw,12px)] font-semibold tabular-nums leading-none text-sub-1">
+                        <span className="font-apple text-[clamp(9px,0.72cqw,12px)] leading-none font-semibold text-sub-1 tabular-nums">
                             {rejectedCount}
                         </span>
                     </span>
                 </div>
             </div>
 
-            <div className="make-shift-requests-pending__body flex min-h-0 flex-1 flex-col gap-[clamp(5px,0.45cqw,8px)] overflow-y-auto px-[clamp(6px,0.55cqw,10px)] py-[clamp(6px,0.55cqw,10px)]">
+            <div className="make-shift-requests-pending__body flex min-h-0 flex-1 flex-col gap-[clamp(5px,0.45cqw,8px)] overflow-y-auto px-[clamp(12px,1.0cqw,16px)] py-[clamp(6px,0.55cqw,10px)]">
                 {pendingRequests.length === 0 ? (
-                    <p className="make-shift-requests-pending__empty font-apple text-[clamp(10px,0.78cqw,13px)] font-medium leading-snug text-gray-4">
+                    <p className="make-shift-requests-pending__empty font-apple text-[clamp(10px,0.78cqw,13px)] leading-snug font-medium text-gray-4">
                         {t('page.makeShift.requests.emptyPending')}
                     </p>
                 ) : (
@@ -150,7 +130,7 @@ export function RequestsPendingPanel({
                             className="make-shift-requests-pending__row flex items-center gap-[clamp(4px,0.35cqw,6px)] rounded-[clamp(6px,0.5cqw,10px)] border border-gray-6 bg-main-bg px-[clamp(5px,0.45cqw,8px)] py-[clamp(4px,0.35cqw,6px)]"
                         >
                             <div className="min-w-0 flex-1">
-                                <p className="truncate font-apple text-[clamp(10px,0.78cqw,13px)] font-medium leading-tight text-sub-1">
+                                <p className="truncate font-apple text-[clamp(10px,0.78cqw,13px)] leading-tight font-medium text-sub-1">
                                     {t('page.makeShift.requests.itemLabel', {name: item.nurseName, date: item.date})}
                                 </p>
                             </div>

--- a/apps/app/src/pages/make-shift/ui/steps/requests-shifts.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/requests-shifts.tsx
@@ -65,7 +65,6 @@ export function RequestsShifts() {
                         <PageState
                             tone="empty"
                             title={t('page.makeShift.requests.empty')}
-                            description={t('page.state.emptyDescription')}
                         />
                     )}
                 </div>

--- a/apps/app/src/pages/make-shift/ui/steps/shared/make-shift-calendar.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/shared/make-shift-calendar.tsx
@@ -41,13 +41,10 @@ const VIOLATION_STYLE: Record<TViolation['level'], {border: string; background: 
     error: {border: '#FF0000', background: 'rgba(255,0,0,0.2)'},
     warning: {border: '#FFD900', background: 'rgba(238,255,0,0.3)'},
 };
-
 const VIOLATION_LEVEL_PRIORITY: Record<TViolation['level'], number> = {error: 1, warning: 0};
-
 const NAME_COL = 'clamp(48px,3.6cqw,68px)';
 const CARRY_COL = 'clamp(20px,1.5cqw,26px)';
 const LAST_COL = 'clamp(74px,5.4cqw,98px)';
-
 /**
  * 행의 좌측(카드 안에 들어가는) 그리드.
  * 사진처럼 division 카드는 이 좌측만 감싸고, 우측 합계(row-summary-counts)는
@@ -57,13 +54,11 @@ const LEFT_GRID_TEMPLATE_COLUMNS = `${NAME_COL} ${CARRY_COL} ${LAST_COL} minmax(
 /** 이월·전달·통계 열 없이 이름 + 일자만 */
 const LEFT_GRID_TEMPLATE_COLUMNS_SIMPLIFIED = `${NAME_COL} minmax(0,1fr)`;
 const ROW_GAP_X = 'clamp(4px,0.5cqw,10px)';
-
 /**
  * division card ↔ division-summary 사이 간격.
  * 너무 좁으면 카드·합계가 붙어 보이므로 최소 여백을 둔다. (헤더·body 행·daily-summary에서 동일 값으로 정렬 유지.)
  */
 const DIVISION_TO_SUMMARY_GAP = 'clamp(8px,0.65cqw,14px)';
-
 /**
  * 우측 합계 영역(type-summary-header / row-summary / daily-summary__spacer)의 좌우 패딩.
  * 합계 열 내부는 좁게 두고, 카드와의 간격은 DIVISION_TO_SUMMARY_GAP으로 맞춘다.
@@ -75,8 +70,7 @@ const SUMMARY_PADDING_X = 'clamp(0px,0.1cqw,2px)';
  * daily-summary__spacer(footer spacer) 세 곳에 동시에 사용된다.
  * 사진처럼 컬럼들이 가깝게 붙도록 작은 값으로 둔다.
  */
-const SUMMARY_GAP = 'clamp(1px,0.15cqw,4px)';
-
+const SUMMARY_GAP = 'clamp(2px,0.22cqw,6px)';
 /**
  * 우측 합계 셀(D/E/N/O/WO 칸)의 크기.
  * - 기존: 정사각형 22px → 한~두 자리 숫자 표시에 비해 폭이 과도하게 큼.
@@ -87,7 +81,8 @@ const SUMMARY_GAP = 'clamp(1px,0.15cqw,4px)';
  */
 const SUMMARY_CELL_HEIGHT = 'h-[clamp(16px,1.4cqw,22px)]';
 const SUMMARY_CELL_WIDTH = 'w-[clamp(14px,1.05cqw,18px)]';
-
+/** row-summary 우측 합계 숫자 · daily-summary 일자별 셀 — 동일 글자 크기·색 */
+const SUMMARY_COUNT_TEXT_CLASS = 'font-poppins text-[clamp(12px,1.02cqw,18px)] leading-none text-gray-4 tabular-nums';
 /**
  * 일자 셀 내부 좌우 패딩.
  * - 최소값을 둬서 사이드바 등으로 컨테이너만 좁아졌을 때도 셀·배지 사이에 숨통이 남게 한다.
@@ -97,20 +92,18 @@ const DAY_CELL_PADDING_X = 'clamp(3px,0.35cqw,6px)';
 const LAST_SHIFTS_GAP = 'clamp(1px,0.15cqw,3px)';
 /** 위반 박스 — 네 면 동일 여백 (좌우와 같은 규칙으로 상하도 맞춤) */
 const VIOLATION_INSET = 'clamp(1px,0.1cqw,2px)';
-
 /**
  * division-card 행 래퍼·헤더·푸터 좌측에 쓰는 미세 인셋.
  * 일자 열은 카드 우측까지 칠해지므로 수평은 좌측만 인셋(paddingRight 0).
  * Y: 카드·division-summary 첫·끝에만 넣어 상하 숨통 — 행 안에서는 items-stretch로 주말 배경이 행 높이를 꽉 채움.
  */
 const DIVISION_PADDING_X = 'clamp(3px,0.3cqw,6px)';
-const DIVISION_PADDING_Y = 'clamp(2px,0.25cqw,5px)';
-
+const DIVISION_PADDING_Y = '0px';
 /**
  * 셀 안의 색상 배지(D/E/N/O 등) 크기.
  *
  * ⚠️ 불변 규칙: 색상 shift-badge는 어떤 viewport에서도 **정사각형**이어야 한다.
- *   - `size-` 단축을 쓰는 경우(예: SHIFT_BADGE_BASE, SHIFT_BADGE_SMALL_BASE)는 width=height가 한 클래스에 묶인다.
+ *   - `size-` 단축을 쓰는 경우(예: SHIFT_BADGE_SUMMARY_ROW, SHIFT_BADGE_SMALL_BASE)는 width=height가 한 클래스에 묶인다.
  *   - 일자 셀은 SHIFT_BADGE_CELL_WRAP(aspect-square) + 자식 !w/h-full 로 정사각형을 만든다.
  *   - 부모가 `flex`인 경우 기본 shrink 때문에 배지가 찌그러질 수 있으므로 SMALL/라벨 계열에는 `shrink-0`을 둔다.
  *   - summary 텍스트 셀(SUMMARY_CELL_*)과 혼동하지 않도록 주의 — 그쪽은 폭만 좁힌 직사각형.
@@ -119,20 +112,14 @@ const DIVISION_PADDING_Y = 'clamp(2px,0.25cqw,5px)';
  *   - SHIFT_BADGE_CELL_WRAP / SHIFT_BADGE_CELL_BADGE: division-card 일자 셀. 래퍼 한 변은 min(셀 폭, clamp 상한).
  *     글자만 키울 때는 CELL_BADGE의 text·leading-none만 조정(행 높이·래퍼 크기 불변).
  *   - SHIFT_BADGE_SMALL_BASE: division-card 전달 근무 4칸 — LAST_COL 안에 들어가도록 size 상한 유지, 글자는 leading-none·큰 text.
- *   - SHIFT_BADGE_BASE: daily-summary__label-badge(D/E/N pill) 전용.
- *
- * round도 화면 폭에 비례해서 변하도록 clamp 기반으로 정의 (ShiftBadge 기본값 6px 고정 → twMerge로 override).
+ *   - SHIFT_BADGE_SUMMARY_ROW: daily-summary__label-badge(D/E/N pill) 전용.
  */
-const SHIFT_BADGE_BASE =
-    'shrink-0 size-[clamp(22px,2.35cqw,38px)] text-[clamp(11px,1.0cqw,19px)] rounded-[clamp(4px,0.52cqw,9px)]';
-
+const SHIFT_BADGE_SUMMARY_ROW = 'shrink-0 size-[clamp(26px,2.75cqw,44px)] text-[clamp(13px,1.12cqw,22px)] rounded-[clamp(4px,0.52cqw,9px)]';
 /** 일자 그리드 셀 래퍼: 한 변 = min(셀 안쪽 폭, cqw 기반 clamp 상한). */
 const SHIFT_BADGE_CELL_WRAP =
     'make-shift-calendar__shift-badge-wrap flex aspect-square w-[min(100%,clamp(22px,2.35cqw,38px))] max-h-[clamp(22px,2.35cqw,38px)] min-w-0 shrink-0 items-center justify-center';
-
 const SHIFT_BADGE_CELL_BADGE =
     'make-shift-calendar__shift-badge !h-full !w-full min-h-0 min-w-0 rounded-[clamp(4px,0.52cqw,9px)] text-[clamp(12px,1.15cqw,21px)] leading-none';
-
 /**
  * 전달 근무 컬럼(LAST_COL)에 4개가 동시에 들어가는 좁은 영역용 배지.
  * 큰 화면에서도 LAST_COL을 넘지 않도록 max를 22px로 제한.
@@ -140,7 +127,6 @@ const SHIFT_BADGE_CELL_BADGE =
  */
 const SHIFT_BADGE_SMALL_BASE =
     'shrink-0 size-[clamp(14px,1.2cqw,22px)] text-[clamp(10px,0.92cqw,15px)] leading-none rounded-[clamp(3px,0.35cqw,6px)]';
-
 /**
  * daily-summary는 D/E/N이 gap=0 으로 빽빽이 붙기 때문에,
  * 중간 행은 모서리 없음 / 첫 행은 위쪽만 / 마지막 행은 아래쪽만 round 되어야
@@ -149,13 +135,11 @@ const SHIFT_BADGE_SMALL_BASE =
 const SHIFT_BADGE_ROUNDED_TOP_ONLY = 'rounded-none rounded-t-[clamp(4px,0.52cqw,9px)]';
 const SHIFT_BADGE_ROUNDED_BOTTOM_ONLY = 'rounded-none rounded-b-[clamp(4px,0.52cqw,9px)]';
 const SHIFT_BADGE_ROUNDED_NONE = 'rounded-none';
-
 /**
  * 배지와 동일한 height 만 갖는 클래스 (daily-summary에서 행 높이를 배지에 정확히 맞추기 위해 사용).
  * SHIFT_BADGE_SIZE의 size = width + height 중 height만 분리한 값.
  */
-const SHIFT_BADGE_SIZE_HEIGHT = 'h-[clamp(22px,2.35cqw,38px)]';
-
+const DAILY_SUMMARY_ROW_HEIGHT = 'h-[clamp(26px,2.75cqw,44px)]';
 /**
  * 이월 박스의 round.
  */
@@ -222,6 +206,7 @@ export function MakeShiftCalendar({
     const summaryColumns = useMemo(() => {
         const counted = shift.wardShiftTypes.filter((t) => t.isCounted);
         const off = shift.wardShiftTypes.find((t) => t.isOff);
+
         return {counted, off};
     }, [shift.wardShiftTypes]);
     const isSimplified = variant === 'simplified';
@@ -265,7 +250,7 @@ export function MakeShiftCalendar({
                     )}
 
                     <div
-                        className="make-shift-calendar__day-header-pill grid min-w-0 rounded-[clamp(14px,1.4cqw,22px)] border border-gray-5 px-0 py-[clamp(2px,0.25cqw,4px)]"
+                        className="make-shift-calendar__day-header-pill grid min-w-0 rounded-[clamp(14px,1.4cqw,22px)] border border-gray-5 px-0 py-0"
                         style={{gridTemplateColumns: `repeat(${shift.days.length}, minmax(0, 1fr))`}}
                     >
                         {shift.days.map((d, j) => (
@@ -305,7 +290,7 @@ export function MakeShiftCalendar({
                                 key={type.wardShiftTypeId}
                                 className={cn(
                                     'make-shift-calendar__type-summary-badge',
-                                    'grid place-items-center font-poppins text-[clamp(10px,0.82cqw,14px)] font-medium leading-none text-sub-2.5',
+                                    'grid place-items-center font-poppins text-[clamp(10px,0.82cqw,14px)] leading-none font-medium text-sub-2.5',
                                     SUMMARY_CELL_HEIGHT,
                                     SUMMARY_CELL_WIDTH,
                                 )}
@@ -317,7 +302,7 @@ export function MakeShiftCalendar({
                             <div
                                 className={cn(
                                     'make-shift-calendar__type-summary-badge make-shift-calendar__type-summary-badge--off',
-                                    'grid place-items-center font-poppins text-[clamp(9px,0.78cqw,13px)] font-medium leading-none text-sub-2.5',
+                                    'grid place-items-center font-poppins text-[clamp(9px,0.78cqw,13px)] leading-none font-medium text-sub-2.5',
                                     SUMMARY_CELL_HEIGHT,
                                     SUMMARY_CELL_WIDTH,
                                 )}
@@ -351,6 +336,7 @@ export function MakeShiftCalendar({
                                 {rows.map((row, i) => {
                                     const workerId = String(row.shiftNurse.shiftNurseId);
                                     const docEntry = workerRowMap.get(workerId);
+
                                     if (!docEntry) return null;
 
                                     return (
@@ -367,7 +353,7 @@ export function MakeShiftCalendar({
                                                 nurseName={row.shiftNurse.name}
                                                 carried={row.shiftNurse.carried}
                                                 lastShifts={row.lastWardShiftList.map((id) =>
-                                                    id != null ? idToType.get(id) ?? null : null,
+                                                    id != null ? (idToType.get(id) ?? null) : null,
                                                 )}
                                                 days={shift.days}
                                                 cells={docEntry.row.cells}
@@ -398,6 +384,7 @@ export function MakeShiftCalendar({
                                     {rows.map((row) => {
                                         const workerId = String(row.shiftNurse.shiftNurseId);
                                         const docEntry = workerRowMap.get(workerId);
+
                                         if (!docEntry) return null;
 
                                         return (
@@ -419,13 +406,7 @@ export function MakeShiftCalendar({
             </div>
 
             {/* FOOTER: 일자별 D / E / N 합계 — simplified 에서는 생략 */}
-            {!isSimplified && (
-                <DailySummary
-                    shift={shift}
-                    doc={doc}
-                    shortNameToType={shortNameToType}
-                />
-            )}
+            {!isSimplified && <DailySummary shift={shift} doc={doc} shortNameToType={shortNameToType} />}
         </div>
     );
 }
@@ -488,13 +469,13 @@ function CalendarRowLeft({
 }: TCalendarRowLeftProps) {
     const [violationTip, setViolationTip] = useState<{message: string; left: number; top: number} | null>(null);
     const [hoveredViolationKey, setHoveredViolationKey] = useState<string | null>(null);
-
     const violationByDayCol = useMemo(() => {
         const byCol = new Map<number, TViolation>();
 
         for (const v of violations.values()) {
             for (const c of v.cells) {
                 if (c.row !== rowIndex) continue;
+
                 const prev = byCol.get(c.col);
 
                 if (!prev || VIOLATION_LEVEL_PRIORITY[v.level] > VIOLATION_LEVEL_PRIORITY[prev.level]) {
@@ -505,7 +486,6 @@ function CalendarRowLeft({
 
         return byCol;
     }, [violations, rowIndex]);
-
     const violationSpanList = useMemo(() => {
         const list: {startCol: number; violation: TViolation}[] = [];
 
@@ -525,198 +505,194 @@ function CalendarRowLeft({
 
         return list;
     }, [days, shiftNurseId, violations]);
-
     const showViolationTipFromTarget = (target: HTMLButtonElement, v: TViolation) => {
         const r = target.getBoundingClientRect();
 
         setViolationTip({message: v.message, left: r.left + r.width / 2, top: r.bottom + 6});
     };
-
     const onViolationTipPointer = (e: MouseEvent<HTMLButtonElement>, v: TViolation | undefined) => {
         if (!showFaults || !v) return;
 
         showViolationTipFromTarget(e.currentTarget, v);
         setHoveredViolationKey(`${shiftNurseId},${v.cells[0]!.col}`);
     };
-
     const getCellShiftType = (j: number): TWardShiftType | null => {
         const cell = cells[j];
+
         if (!cell) return null;
+
         return shortNameToType.get(cell) ?? null;
     };
 
     return (
         <>
-        <div
-            data-shift-nurse-id={shiftNurseId}
-            data-row-index={rowIndex}
-            className="make-shift-calendar__row make-shift-calendar__row-left grid h-[clamp(28px,2.4cqw,40px)] w-full min-w-0 items-stretch"
-            style={{
-                gridTemplateColumns: simplified
-                    ? LEFT_GRID_TEMPLATE_COLUMNS_SIMPLIFIED
-                    : LEFT_GRID_TEMPLATE_COLUMNS,
-                columnGap: ROW_GAP_X,
-            }}
-        >
-            <div className="make-shift-calendar__row-name flex min-h-0 min-w-0 items-center justify-center truncate font-apple text-[clamp(12px,1.05cqw,16px)] leading-none text-sub-1">
-                {nurseName}
-            </div>
-
-            {!simplified && (
-                <>
-                    <div className="make-shift-calendar__row-carry flex min-h-0 items-center justify-center">
-                        <div
-                            className={cn(
-                                'make-shift-calendar__row-carry-value',
-                                'grid size-[clamp(20px,1.8cqw,28px)] place-items-center border border-gray-6 bg-main-bg font-poppins text-[clamp(12px,1.05cqw,16px)] leading-none text-sub-2 tabular-nums',
-                                CARRY_ROUNDED,
-                            )}
-                        >
-                            {carried}
-                        </div>
-                    </div>
-
-                    <div
-                        className="make-shift-calendar__row-last-shifts flex min-h-0 min-w-0 flex-nowrap items-center justify-center overflow-hidden"
-                        style={{gap: LAST_SHIFTS_GAP}}
-                    >
-                        {lastShifts.map((t, i) => (
-                            <ShiftBadge
-                                key={i}
-                                shiftType={t}
-                                className={cn('make-shift-calendar__row-last-shift-badge', SHIFT_BADGE_SMALL_BASE)}
-                            />
-                        ))}
-                    </div>
-                </>
-            )}
-
             <div
-                className="make-shift-calendar__row-days grid h-full min-w-0 items-stretch px-0"
-                style={{gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`}}
+                data-shift-nurse-id={shiftNurseId}
+                data-row-index={rowIndex}
+                className="make-shift-calendar__row make-shift-calendar__row-left grid h-[clamp(28px,2.4cqw,40px)] w-full min-w-0 items-stretch"
+                style={{
+                    gridTemplateColumns: simplified ? LEFT_GRID_TEMPLATE_COLUMNS_SIMPLIFIED : LEFT_GRID_TEMPLATE_COLUMNS,
+                    columnGap: ROW_GAP_X,
+                }}
             >
-                {days.map((day, j) => {
-                    const shiftType = getCellShiftType(j);
-                    const reqId = wardReqShiftList[j] ?? null;
-                    const reqType = reqId != null ? idToType.get(reqId) : null;
-                    const cellViolation = showFaults ? violationByDayCol.get(j) : undefined;
-                    const weekendBg =
-                        day.dayType === 'saturday'
-                            ? separateWeekendColor
-                                ? 'bg-blue/5'
-                                : 'bg-red/5'
-                            : day.dayType === 'sunday' || day.dayType === 'holiday'
-                              ? 'bg-red/5'
-                              : '';
-                    const isSelected =
-                        !readonly &&
-                        selectionRect !== null &&
-                        rowIndex >= selectionRect.top &&
-                        rowIndex <= selectionRect.bottom &&
-                        j >= selectionRect.left &&
-                        j <= selectionRect.right;
+                <div className="make-shift-calendar__row-name flex min-h-0 min-w-0 items-center justify-center truncate font-apple text-[clamp(12px,1.05cqw,16px)] leading-none text-sub-1">
+                    {nurseName}
+                </div>
 
-                    return (
-                        <button
-                            key={j}
-                            type="button"
-                            data-day-index={j}
-                            data-selected={isSelected || undefined}
-                            data-violation-rule={cellViolation?.ruleId}
-                            onClick={() => onCellClick?.(rowIndex, j)}
-                            onMouseEnter={(e) => {
-                                if (!cellViolation) setHoveredViolationKey(null);
-                                onViolationTipPointer(e, cellViolation);
-                            }}
-                            onMouseLeave={() => {
-                                setViolationTip(null);
-                                setHoveredViolationKey(null);
-                            }}
-                            onFocus={(e) => {
-                                if (!showFaults || !cellViolation) return;
-                                showViolationTipFromTarget(e.currentTarget, cellViolation);
-                                setHoveredViolationKey(`${shiftNurseId},${cellViolation.cells[0]!.col}`);
-                            }}
-                            onBlur={() => {
-                                setViolationTip(null);
-                                setHoveredViolationKey(null);
-                            }}
-                            title={cellViolation?.message}
-                            style={{gridRow: 1, gridColumn: j + 1, paddingInline: DAY_CELL_PADDING_X}}
-                            className={cn(
-                                'make-shift-calendar__day-cell',
-                                'group relative z-[1] flex h-full min-w-0 items-center justify-center',
-                                cellViolation ? 'cursor-help' : readonly ? 'cursor-default' : 'cursor-pointer',
-                                weekendBg,
-                            )}
+                {!simplified && (
+                    <>
+                        <div className="make-shift-calendar__row-carry flex min-h-0 items-center justify-center">
+                            <div
+                                className={cn(
+                                    'make-shift-calendar__row-carry-value',
+                                    'grid size-[clamp(20px,1.8cqw,28px)] place-items-center border border-gray-6 bg-main-bg font-poppins text-[clamp(12px,1.05cqw,16px)] leading-none text-sub-2 tabular-nums',
+                                    CARRY_ROUNDED,
+                                )}
+                            >
+                                {carried}
+                            </div>
+                        </div>
+
+                        <div
+                            className="make-shift-calendar__row-last-shifts flex min-h-0 min-w-0 flex-nowrap items-center justify-center overflow-hidden"
+                            style={{gap: LAST_SHIFTS_GAP}}
                         >
-                            {reqType && shiftType && reqType.wardShiftTypeId !== shiftType.wardShiftTypeId && (
-                                <span
-                                    className="make-shift-calendar__request-outline pointer-events-none absolute inset-[clamp(1px,0.18cqw,3px)] rounded-[clamp(4px,0.5cqw,7px)] border-[1.5px] opacity-70"
-                                    style={{borderColor: reqType.color}}
-                                    aria-hidden
-                                />
-                            )}
-                            <span className={SHIFT_BADGE_CELL_WRAP}>
+                            {lastShifts.map((t, i) => (
                                 <ShiftBadge
-                                    shiftType={shiftType}
-                                    isOnlyRequest={shiftType === null && reqType !== null}
-                                    className={cn(
-                                        SHIFT_BADGE_CELL_BADGE,
-                                        isSelected && 'outline outline-[1.5px] outline-main-1',
-                                    )}
+                                    key={i}
+                                    shiftType={t}
+                                    className={cn('make-shift-calendar__row-last-shift-badge', SHIFT_BADGE_SMALL_BASE)}
                                 />
-                            </span>
-                        </button>
-                    );
-                })}
-                {showFaults &&
-                    violationSpanList.map(({startCol, violation: v}) => {
-                        const span = Math.max(1, v.cells.length);
-                        const style = VIOLATION_STYLE[v.level];
-                        const vioKey = `${shiftNurseId},${startCol}`;
-                        const isHovered = hoveredViolationKey === vioKey;
-                        const zByLevel = v.level === 'error' ? 'z-[32]' : 'z-[22]';
+                            ))}
+                        </div>
+                    </>
+                )}
+
+                <div
+                    className="make-shift-calendar__row-days grid h-full min-w-0 items-stretch px-0"
+                    style={{gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`}}
+                >
+                    {days.map((day, j) => {
+                        const shiftType = getCellShiftType(j);
+                        const reqId = wardReqShiftList[j] ?? null;
+                        const reqType = reqId != null ? idToType.get(reqId) : null;
+                        const cellViolation = showFaults ? violationByDayCol.get(j) : undefined;
+                        const weekendBg =
+                            day.dayType === 'saturday'
+                                ? separateWeekendColor
+                                    ? 'bg-blue/5'
+                                    : 'bg-red/5'
+                                : day.dayType === 'sunday' || day.dayType === 'holiday'
+                                  ? 'bg-red/5'
+                                  : '';
+                        const isSelected =
+                            !readonly &&
+                            selectionRect !== null &&
+                            rowIndex >= selectionRect.top &&
+                            rowIndex <= selectionRect.bottom &&
+                            j >= selectionRect.left &&
+                            j <= selectionRect.right;
 
                         return (
-                            <span
-                                key={`vio-${startCol}`}
-                                aria-label={v.message}
-                                title={v.message}
-                                data-violation-level={v.level}
-                                style={{
-                                    gridRow: 1,
-                                    gridColumn: `${startCol + 1} / span ${span}`,
-                                    borderColor: style.border,
-                                    backgroundColor: style.background,
-                                    margin: VIOLATION_INSET,
-                                    transformOrigin: 'center',
-                                    transform: isHovered ? 'scale(1.085)' : undefined,
-                                    transition: 'transform 140ms ease-out',
+                            <button
+                                key={j}
+                                type="button"
+                                data-day-index={j}
+                                data-selected={isSelected || undefined}
+                                data-violation-rule={cellViolation?.ruleId}
+                                onClick={() => onCellClick?.(rowIndex, j)}
+                                onMouseEnter={(e) => {
+                                    if (!cellViolation) setHoveredViolationKey(null);
+
+                                    onViolationTipPointer(e, cellViolation);
                                 }}
+                                onMouseLeave={() => {
+                                    setViolationTip(null);
+                                    setHoveredViolationKey(null);
+                                }}
+                                onFocus={(e) => {
+                                    if (!showFaults || !cellViolation) return;
+
+                                    showViolationTipFromTarget(e.currentTarget, cellViolation);
+                                    setHoveredViolationKey(`${shiftNurseId},${cellViolation.cells[0]!.col}`);
+                                }}
+                                onBlur={() => {
+                                    setViolationTip(null);
+                                    setHoveredViolationKey(null);
+                                }}
+                                title={cellViolation?.message}
+                                style={{gridRow: 1, gridColumn: j + 1, paddingInline: DAY_CELL_PADDING_X}}
                                 className={cn(
-                                    'make-shift-calendar__violation',
-                                    `make-shift-calendar__violation--${v.level}`,
-                                    'pointer-events-none rounded-[clamp(5px,0.55cqw,8px)] border-[1.5px]',
-                                    zByLevel,
-                                    isHovered && 'z-[42]',
+                                    'make-shift-calendar__day-cell',
+                                    'group relative z-[1] flex h-full min-w-0 items-center justify-center',
+                                    cellViolation ? 'cursor-help' : readonly ? 'cursor-default' : 'cursor-pointer',
+                                    weekendBg,
                                 )}
-                            />
+                            >
+                                {reqType && shiftType && reqType.wardShiftTypeId !== shiftType.wardShiftTypeId && (
+                                    <span
+                                        className="make-shift-calendar__request-outline pointer-events-none absolute inset-[clamp(1px,0.18cqw,3px)] rounded-[clamp(4px,0.5cqw,7px)] border-[1.5px] opacity-70"
+                                        style={{borderColor: reqType.color}}
+                                        aria-hidden
+                                    />
+                                )}
+                                <span className={SHIFT_BADGE_CELL_WRAP}>
+                                    <ShiftBadge
+                                        shiftType={shiftType}
+                                        isOnlyRequest={shiftType === null && reqType !== null}
+                                        className={cn(SHIFT_BADGE_CELL_BADGE, isSelected && 'outline outline-[1.5px] outline-main-1')}
+                                    />
+                                </span>
+                            </button>
                         );
                     })}
+                    {showFaults &&
+                        violationSpanList.map(({startCol, violation: v}) => {
+                            const span = Math.max(1, v.cells.length);
+                            const style = VIOLATION_STYLE[v.level];
+                            const vioKey = `${shiftNurseId},${startCol}`;
+                            const isHovered = hoveredViolationKey === vioKey;
+                            const zByLevel = v.level === 'error' ? 'z-[32]' : 'z-[22]';
+
+                            return (
+                                <span
+                                    key={`vio-${startCol}`}
+                                    aria-label={v.message}
+                                    title={v.message}
+                                    data-violation-level={v.level}
+                                    style={{
+                                        gridRow: 1,
+                                        gridColumn: `${startCol + 1} / span ${span}`,
+                                        borderColor: style.border,
+                                        backgroundColor: style.background,
+                                        margin: VIOLATION_INSET,
+                                        transformOrigin: 'center',
+                                        transform: isHovered ? 'scale(1.085)' : undefined,
+                                        transition: 'transform 140ms ease-out',
+                                    }}
+                                    className={cn(
+                                        'make-shift-calendar__violation',
+                                        `make-shift-calendar__violation--${v.level}`,
+                                        'pointer-events-none rounded-[clamp(5px,0.55cqw,8px)] border-[1.5px]',
+                                        zByLevel,
+                                        isHovered && 'z-[42]',
+                                    )}
+                                />
+                            );
+                        })}
+                </div>
             </div>
-        </div>
-        {violationTip != null &&
-            createPortal(
-                <div
-                    role="tooltip"
-                    className="pointer-events-none fixed z-[99999] box-border w-max max-w-[min(24rem,calc(100vw-1rem))] -translate-x-1/2 rounded-md border border-gray-6 bg-white px-2.5 py-1.5 text-left font-apple text-xs leading-snug whitespace-normal text-sub-1 shadow-lg"
-                    style={{left: violationTip.left, top: violationTip.top}}
-                >
-                    {violationTip.message}
-                </div>,
-                document.body,
-            )}
+            {violationTip != null &&
+                createPortal(
+                    <div
+                        role="tooltip"
+                        className="pointer-events-none fixed z-[99999] box-border w-max max-w-[min(24rem,calc(100vw-1rem))] -translate-x-1/2 rounded-md border border-gray-6 bg-white px-2.5 py-1.5 text-left font-apple text-xs leading-snug whitespace-normal text-sub-1 shadow-lg"
+                        style={{left: violationTip.left, top: violationTip.top}}
+                    >
+                        {violationTip.message}
+                    </div>,
+                    document.body,
+                )}
         </>
     );
 }
@@ -740,9 +716,9 @@ function CalendarRowSummary({cells, days, shortNameToType, countedTypes, offType
             const day = days[j];
 
             if (t?.wardShiftTypeId !== typeId) return false;
+
             return day != null;
         }).length;
-
     const offCount =
         offType == null
             ? 0
@@ -763,7 +739,8 @@ function CalendarRowSummary({cells, days, shortNameToType, countedTypes, offType
                     key={t.wardShiftTypeId}
                     className={cn(
                         'make-shift-calendar__row-summary-count',
-                        'grid place-items-center font-poppins text-[clamp(9px,0.78cqw,13px)] tabular-nums leading-none text-sub-2',
+                        'grid place-items-center',
+                        SUMMARY_COUNT_TEXT_CLASS,
                         SUMMARY_CELL_HEIGHT,
                         SUMMARY_CELL_WIDTH,
                     )}
@@ -775,7 +752,8 @@ function CalendarRowSummary({cells, days, shortNameToType, countedTypes, offType
                 <div
                     className={cn(
                         'make-shift-calendar__row-summary-count make-shift-calendar__row-summary-count--off',
-                        'grid place-items-center font-poppins text-[clamp(9px,0.78cqw,13px)] tabular-nums leading-none text-sub-2',
+                        'grid place-items-center',
+                        SUMMARY_COUNT_TEXT_CLASS,
                         SUMMARY_CELL_HEIGHT,
                         SUMMARY_CELL_WIDTH,
                     )}
@@ -787,27 +765,18 @@ function CalendarRowSummary({cells, days, shortNameToType, countedTypes, offType
     );
 }
 
-function DailySummary({
-    shift,
-    doc,
-    shortNameToType,
-}: {
-    shift: TShift;
-    doc: TDutyDoc;
-    shortNameToType: Map<string, TWardShiftType>;
-}) {
+function DailySummary({shift, doc, shortNameToType}: {shift: TShift; doc: TDutyDoc; shortNameToType: Map<string, TWardShiftType>}) {
     /*
      * 사진 기준: daily-summary는 isCounted 타입만 표시하고 off는 표시하지 않는다.
      * (사진의 하단 합계도 D / E / N 만 있고 O / WO 행은 없음.)
      */
-    const counted = useMemo(
-        () => shift.wardShiftTypes.filter((t) => t.isCounted && !t.isOff),
-        [shift.wardShiftTypes],
-    );
+    const counted = useMemo(() => shift.wardShiftTypes.filter((t) => t.isCounted && !t.isOff), [shift.wardShiftTypes]);
     const countByDay = (j: number, typeId: number) =>
         doc.rows.filter((row) => {
             const cell = row.cells[j] ?? null;
+
             if (!cell) return false;
+
             return shortNameToType.get(cell)?.wardShiftTypeId === typeId;
         }).length;
 
@@ -836,13 +805,13 @@ function DailySummary({
                      * - 단일 행(D만 있는 경우)은 양쪽 다 round.
                      */
                     /*
-                     * SHIFT_BADGE_BASE에 이미 `rounded-[clamp(...)]`이 포함되어 있지만,
+                     * SHIFT_BADGE_SUMMARY_ROW에 이미 `rounded-[clamp(...)]`이 포함되어 있지만,
                      * 첫/마지막/중간 행에 따라 다른 round를 줘야 하므로 여기서 override 한다.
                      * cn() → twMerge가 같은 카테고리(rounded-*) 내에서 마지막 값을 유효하게 처리.
                      */
                     const labelRoundedClass =
                         isFirst && isLast
-                            ? '' // SHIFT_BADGE_BASE의 기본 rounded 그대로 사용
+                            ? '' // SHIFT_BADGE_SUMMARY_ROW의 기본 rounded 그대로 사용
                             : isFirst
                               ? SHIFT_BADGE_ROUNDED_TOP_ONLY
                               : isLast
@@ -866,27 +835,22 @@ function DailySummary({
                             <div className="make-shift-daily-summary__label flex justify-end">
                                 <ShiftBadge
                                     shiftType={type}
-                                    className={cn(
-                                        'make-shift-daily-summary__label-badge',
-                                        SHIFT_BADGE_BASE,
-                                        labelRoundedClass,
-                                    )}
+                                    className={cn('make-shift-daily-summary__label-badge', SHIFT_BADGE_SUMMARY_ROW, labelRoundedClass)}
                                 />
                             </div>
                             <div
-                                className={cn(
-                                    'make-shift-daily-summary__cells',
-                                    'grid min-w-0 px-0',
-                                    SHIFT_BADGE_SIZE_HEIGHT,
-                                )}
+                                className={cn('make-shift-daily-summary__cells', 'grid min-w-0 px-0', DAILY_SUMMARY_ROW_HEIGHT)}
                                 style={{gridTemplateColumns: `repeat(${doc.columns.length}, minmax(0, 1fr))`}}
                             >
                                 {doc.columns.map((_d, j) => (
                                     <div
                                         key={j}
                                         data-day-index={j}
-                                        // 행 높이(SHIFT_BADGE_SIZE_HEIGHT)는 유지. 글꼴만 키우고 leading-none + 좁은 패딩(px-0)으로 셀 안에 맞춤.
-                                        className="make-shift-daily-summary__cell grid h-full min-w-0 place-items-center font-poppins text-[clamp(11px,1.05cqw,16px)] leading-none tabular-nums text-sub-2.5"
+                                        // 행 높이(DAILY_SUMMARY_ROW_HEIGHT)는 라벨 배지와 맞춤.
+                                        className={cn(
+                                            'make-shift-daily-summary__cell grid h-full min-w-0 place-items-center',
+                                            SUMMARY_COUNT_TEXT_CLASS,
+                                        )}
                                     >
                                         {countByDay(j, type.wardShiftTypeId)}
                                     </div>

--- a/apps/app/src/pages/make-shift/ui/steps/shared/make-shift-calendar.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/shared/make-shift-calendar.tsx
@@ -597,6 +597,7 @@ function CalendarRowLeft({
                             <button
                                 key={j}
                                 type="button"
+                                tabIndex={-1}
                                 data-day-index={j}
                                 data-selected={isSelected || undefined}
                                 data-violation-rule={cellViolation?.ruleId}

--- a/apps/app/src/pages/make-shift/ui/steps/shared/use-duty-editor-step.ts
+++ b/apps/app/src/pages/make-shift/ui/steps/shared/use-duty-editor-step.ts
@@ -89,7 +89,7 @@ export function useDutyEditorStep({onContextChanged}: TUseDutyEditorStepOptions 
     const commands = useShiftEditorCommands();
     const editorRef = useRef<HTMLDivElement>(null);
     const workKeyMap = useMemo(() => buildWorkKeyMap(dutyQuery.data), [dutyQuery.data]);
-    const {onKeyDown, onPaste} = useShiftEditorKeyBindings({workKeyMap});
+    const {onKeyDown, onPasteCapture} = useShiftEditorKeyBindings({workKeyMap});
     const violationMap = useViolationMap(editorDoc);
     const hydratedContextKeyRef = useRef<string | null>(null);
     const initialHydrationDoneRef = useRef(false);
@@ -186,7 +186,7 @@ export function useDutyEditorStep({onContextChanged}: TUseDutyEditorStepOptions 
         editorDoc,
         editorRef,
         onKeyDown,
-        onPaste,
+        onPasteCapture,
         violationMap,
         focusEditor,
     };

--- a/apps/app/src/pages/make-shift/ui/steps/workers-sections.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/workers-sections.tsx
@@ -169,9 +169,15 @@ function WorkerRow({nurse, index, level, skillConfig}: TWorkerRowProps) {
                                 <span className="font-apple text-[clamp(10px,0.85vw,14px)] text-gray-4">-</span>
                             )}
                         </div>
-                        <p className="make-shift-workers__row-memo text-center font-apple text-[clamp(12px,1.1vw,18px)] font-medium text-sub-1">
-                            {memo || '-'}
-                        </p>
+                        <div className="make-shift-workers__row-memo flex min-w-0 items-center justify-center">
+                            {memo ? (
+                                <p className="min-w-0 truncate text-center font-apple text-[clamp(12px,1.1vw,18px)] font-medium text-sub-1">
+                                    {memo}
+                                </p>
+                            ) : (
+                                <span className="text-[clamp(10px,0.85vw,14px)] font-normal text-gray-4">-</span>
+                            )}
+                        </div>
                     </div>
                 );
             }}

--- a/apps/app/src/pages/make-shift/ui/steps/workers.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/workers.tsx
@@ -167,16 +167,16 @@ export function Workers() {
                         description={t('page.makeShift.workers.emptyDescription')}
                         className="mt-[clamp(4px,0.5vw,10px)] min-h-[220px] border-solid"
                     />
-                ) : (
+                ) : currentShiftTeamId !== null ? (
                     <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
                         <WorkersList
                             grouped={grouped}
-                            shiftTeamId={currentShiftTeamId!}
+                            shiftTeamId={currentShiftTeamId}
                             levelsByNurseId={levelsByNurseId}
                             skillConfig={skillConfig}
                         />
                     </DragDropContext>
-                )}
+                ) : null}
             </div>
         </div>
     );

--- a/apps/app/src/pages/make-shift/ui/steps/workers.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/workers.tsx
@@ -154,10 +154,7 @@ export function Workers() {
                     className="inline-flex items-center gap-[clamp(3px,0.35vw,6px)] font-apple text-[clamp(12px,1.05vw,17px)] font-semibold text-sub-2"
                     aria-label={t('page.makeShift.workers.totalCount', {count: workerCount})}
                 >
-                    <PersonIcon
-                        aria-hidden
-                        className="size-[clamp(14px,1.15vw,18px)] shrink-0 [&>g]:fill-current"
-                    />
+                    <PersonIcon aria-hidden className="size-[clamp(14px,1.15vw,18px)] shrink-0" />
                     <span className="tabular-nums">{workerCount}</span>
                 </span>
             </div>
@@ -174,7 +171,7 @@ export function Workers() {
                     <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
                         <WorkersList
                             grouped={grouped}
-                            shiftTeamId={currentShiftTeamId}
+                            shiftTeamId={currentShiftTeamId!}
                             levelsByNurseId={levelsByNurseId}
                             skillConfig={skillConfig}
                         />

--- a/apps/app/src/pages/member/ui/connection-manage/target-step.tsx
+++ b/apps/app/src/pages/member/ui/connection-manage/target-step.tsx
@@ -105,7 +105,7 @@ function ConnectionManageTargetStep({
                         <div className="relative flex w-full items-center justify-between rounded-t-[.9375rem] bg-sub-2 px-5 py-[.875rem]">
                             <div className="flex flex-col gap-[.3125rem]">
                                 <h2 className="font-apple text-[1.5rem] font-semibold text-white">{shiftTeam.name}</h2>
-                                <div className="flex items-center">
+                                <div className="flex items-center text-white">
                                     <PersonIcon className="h-4 w-4" />
                                     <p className="font-poppins text-[.75rem] text-white">{shiftTeam.nurses.length}</p>
                                 </div>

--- a/apps/app/src/pages/member/ui/shift-team-card.tsx
+++ b/apps/app/src/pages/member/ui/shift-team-card.tsx
@@ -84,7 +84,7 @@ function ShiftTeamCard({
                         </button>
                     )}
 
-                    <div className="flex items-center">
+                    <div className="flex items-center text-white">
                         <PersonIcon className="h-4 w-4" />
                         <p className="font-poppins text-[.75rem] text-white">{shiftTeam.nurses.length}</p>
                     </div>
@@ -116,7 +116,7 @@ function ShiftTeamCard({
                             aria-label={t('page.member.shiftTeamList.card.addNurse')}
                         >
                             {isAddingNurse ? '간호사 추가 중...' : t('page.member.shiftTeamList.card.addNurse')}
-                            <InfoIcon className="peer h-5 w-5" />
+                            <InfoIcon className="peer h-5 w-5 text-sub-2.5" />
                             <div className="invisible absolute top-[50%] -right-86 z-30 flex w-91 translate-y-[-50%] items-center gap-[.5rem] rounded-[.3125rem] bg-white px-2 py-1 font-apple text-[.875rem] text-sub-2 shadow-shadow-2 peer-hover:visible">
                                 <div
                                     className="absolute top-[50%] left-[-.4375rem] h-0 w-0 translate-y-[-50%]"

--- a/apps/app/src/shared/assets/svg/InfoIcon.tsx
+++ b/apps/app/src/shared/assets/svg/InfoIcon.tsx
@@ -1,16 +1,18 @@
 import type {SVGProps} from 'react';
 
 const SvgInfoIcon = (props: SVGProps<SVGSVGElement>) => (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 26 26" {...props}>
-        <g stroke="#93939D" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} clipPath="url(#info_icon_svg__a)">
-            <path d="M1.913 17.592a12 12 0 1 1 22.173-9.184 12 12 0 0 1-22.173 9.184ZM13 9.596h.012" />
-            <path d="M11.753 13.464h1.245v5.16h1.246" />
-        </g>
-        <defs>
-            <clipPath id="info_icon_svg__a">
-                <path fill="#fff" d="M0 0h26v26H0z" />
-            </clipPath>
-        </defs>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26" fill="none" {...props}>
+        <circle
+            cx="13"
+            cy="13"
+            r="10.75"
+            fill="currentColor"
+            fillOpacity={0.22}
+            stroke="currentColor"
+            strokeWidth={2}
+        />
+        <circle cx="13" cy="9.6" r="1.35" fill="currentColor" />
+        <rect x="11.35" y="13.25" width="3.3" height="5.5" rx="1.65" fill="currentColor" />
     </svg>
 );
 

--- a/apps/app/src/shared/assets/svg/PersonIcon.tsx
+++ b/apps/app/src/shared/assets/svg/PersonIcon.tsx
@@ -2,7 +2,7 @@ import type {SVGProps} from 'react';
 
 const SvgPersonIcon = (props: SVGProps<SVGSVGElement>) => (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" {...props}>
-        <g fill="#fff" clipPath="url(#person_icon_svg__a)">
+        <g fill="currentColor" clipPath="url(#person_icon_svg__a)">
             <path d="M5.334 4.667a2.667 2.667 0 1 0 5.333 0 2.667 2.667 0 0 0-5.333 0ZM3 14v-1.667A3.333 3.333 0 0 1 6.333 9h3.334A3.333 3.333 0 0 1 13 12.333V14" />
         </g>
         <defs>

--- a/apps/app/src/shared/locales/en.ts
+++ b/apps/app/src/shared/locales/en.ts
@@ -96,6 +96,7 @@ export const en: TLocale = {
             monthRangeDescription: 'On Dutying, you can only create schedules for this month and the next month.',
             requests: {
                 title: 'Please confirm requested shifts',
+                descriptionLine: 'Approved requests are fixed on the schedule.',
                 descriptionPrefix: 'Accepted requests are',
                 descriptionHighlight: 'locked into the schedule',
                 descriptionSuffix: '.',
@@ -135,6 +136,7 @@ export const en: TLocale = {
                     weak: 'Soft constraints',
                 },
                 info: 'You can drag to reorder by your preferred priority.',
+                infoTooltipAria: 'About constraint priority',
                 count: '{{count}}',
                 empty: 'No constraints to show.',
                 dragHandleAria: 'Drag to reorder',
@@ -177,6 +179,9 @@ export const en: TLocale = {
             },
             aiRefill: {
                 action: 'Refill with AI',
+                firstFill: 'Fill with AI',
+                toolbarTitle: 'Finish your schedule',
+                toolbarHint: 'AI can help you complete it more easily.',
                 retry: 'Retry AI fill',
                 generating: 'Filling with AI...',
                 intro: 'Your current edits stay in place even if AI fails.\nYou can go back to the previous step to revisit conditions, or retry and confirm here.',

--- a/apps/app/src/shared/locales/en.ts
+++ b/apps/app/src/shared/locales/en.ts
@@ -5,7 +5,7 @@ export const en: TLocale = {
         state: {
             loadingTitle: 'Preparing the screen',
             loadingDescription: 'Please wait a moment.',
-            emptyDescription: 'Content will appear here once it becomes available.',
+            emptyDescription: 'Follow the on-screen guidance to continue.',
             errorDescription: 'Please try again shortly. If the issue continues, refresh and check again.',
             retry: 'Retry',
         },
@@ -83,6 +83,8 @@ export const en: TLocale = {
             overview: {
                 loading: 'Loading duty schedule...',
                 shiftExists: '{{teamName}} has a schedule for {{month}}.',
+                shiftPartialFill: "{{teamName}}'s {{month}} schedule still has empty slots.",
+                fullyAssignedCantStart: "This month's schedule is fully filled. You can't start the creation flow here.",
                 shiftEmpty: "{{teamName}}'s {{month}} schedule is empty.",
                 checking: 'Checking schedule status.',
                 error: 'Failed to check the schedule status.',

--- a/apps/app/src/shared/locales/ko.ts
+++ b/apps/app/src/shared/locales/ko.ts
@@ -3,7 +3,7 @@ export const ko = {
         state: {
             loadingTitle: '화면을 준비하고 있어요',
             loadingDescription: '잠시만 기다려 주세요.',
-            emptyDescription: '조건이 충족되면 여기에 내용이 표시됩니다.',
+            emptyDescription: '화면 안내에 따라 진행해 주세요.',
             errorDescription: '잠시 후 다시 시도해 주세요. 문제가 계속되면 새로고침 후 다시 확인해 주세요.',
             retry: '다시 시도',
         },
@@ -79,6 +79,8 @@ export const ko = {
             overview: {
                 loading: '근무표를 불러오는 중입니다...',
                 shiftExists: '{{teamName}}의 {{month}}월 근무표가 존재합니다.',
+                shiftPartialFill: '{{teamName}}의 {{month}}월 근무표에 빈 칸이 남아 있어요',
+                fullyAssignedCantStart: '이번 달 근무표가 모두 채워져 있어 여기서는 만들기를 진행할 수 없어요.',
                 shiftEmpty: '{{teamName}}의 {{month}}월 근무표가 비어있어요',
                 checking: '근무표 상태를 확인 중입니다.',
                 error: '근무표 상태를 확인하지 못했어요.',

--- a/apps/app/src/shared/locales/ko.ts
+++ b/apps/app/src/shared/locales/ko.ts
@@ -92,6 +92,7 @@ export const ko = {
             monthRangeDescription: '듀팅에서는 이번 달과 다음 달의 근무표만 생성할 수 있어요.',
             requests: {
                 title: '신청 근무를 확정해 주세요',
+                descriptionLine: '승인된 신청 근무는 근무표에 고정돼요',
                 descriptionPrefix: '반영된 스케줄은',
                 descriptionHighlight: '근무표에 고정',
                 descriptionSuffix: '됩니다.',
@@ -131,6 +132,7 @@ export const ko = {
                     weak: '약 제약 조건',
                 },
                 info: '위치를 옮겨서 원하는 우선순위대로 정렬할 수 있어요',
+                infoTooltipAria: '제약 조건 우선순위 안내',
                 count: '{{count}}개',
                 empty: '표시할 제약조건이 없습니다.',
                 dragHandleAria: '드래그하여 위치를 변경',
@@ -173,7 +175,10 @@ export const ko = {
             },
             aiRefill: {
                 action: 'AI 다시 채우기',
-                retry: 'AI 다시 시도',
+                firstFill: 'AI 채우기',
+                toolbarTitle: '최종 근무표를 작성해 주세요',
+                toolbarHint: 'AI의 도움을 받아 더 쉽게 작성할 수 있어요',
+                retry: 'AI 다시 채우기',
                 generating: 'AI 채우는 중...',
                 intro: '실패해도 현재 편집본은 유지돼요.\n이전 단계로 돌아가 조건을 다시 보고 오거나, 여기서 바로 재시도하고 확정할 수 있어요.',
                 loading: '근무표를 불러오는 중이에요',


### PR DESCRIPTION
## 요약
- 스텝 레이아웃·스텝퍼·AI/요청/고정 화면 토큰 정리, 이전·다음 버튼은 `make-shift-step-nav`로 통일
- 제약 조건: `TooltipProvider`, info 툴팁, `InfoIcon`(fill+stroke·`currentColor`)
- 캘린더: 행 합계·일별 요약 숫자 타이포 공유(`SUMMARY_COUNT_TEXT_CLASS`), 합계 칸 간격 소폭 확대
- `PersonIcon` → `currentColor`, 어두운 카드 헤더는 `text-white`로 대비
- i18n(ko/en), `/duty` 툴바 `InfoIcon` 색 정리
- **근무표 만들기**: `isDutyShiftFullyAssigned`로 전 칸 배정 시 플로 진입 차단; 개요는 전부 배정(보기·다음 달) / 일부 배정(보기·이번 달 이어하기) / 빈 표 분기
- 부트스트랩에서 `shiftFullyAssigned` 갱신, stepping 중 전칸 배정이면 개요로 복귀; `start()` 토스트(`fullyAssignedCantStart`)
- 개요·신청 단계에서 부적절한 `page.state.emptyDescription` 사용 제거 및 공용 문구 중립화
- **stepping 중** 상단 근무표 보러가기 바 제거(개요에서만 노출)
- `shift-adapter` 전칸 배정 판별 테스트 보강, `make-shift-use-case` 중복 `const s` 수정

## 참고
- 로컬 전용이던 `vite.config` mkcert hosts, `duty-management` 커서 스타일은 PR 범위에서 제외
