### PR TITLE
feat(make-shift): 근무표 만들기 UI 폴리시

### DIFF
--- a/apps/app/src/features/shift-editor/model/__tests__/merge-schedule-violations.test.ts
+++ b/apps/app/src/features/shift-editor/model/__tests__/merge-schedule-violations.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from 'vitest';
+import {mergeServerScheduleViolations} from '../merge-schedule-violations';
+import {buildViolationMapAll} from '../validator';
+import type {TDutyDoc, TViolation} from '../types';
+
+const doc: TDutyDoc = {
+    columns: ['2026-05-01', '2026-05-02', '2026-05-03'],
+    rows: [{workerId: '10', cells: ['D', 'E', 'N']}],
+    workerMeta: {10: {name: 'Kim'}},
+    fixedCells: {},
+    requestCells: {},
+};
+
+const v = (partial: Partial<TViolation> & Pick<TViolation, 'ruleId' | 'cells'>): TViolation => ({
+    message: partial.message ?? partial.ruleId,
+    level: partial.level ?? 'error',
+    ...partial,
+});
+
+describe('mergeServerScheduleViolations', () => {
+    it('returns all non-empty violations without deduping', () => {
+        const input = [
+            v({ruleId: 'llm.hard-a', cells: [{row: 0, col: 0}]}),
+            v({ruleId: 'llm.hard-b', cells: [{row: 0, col: 0}]}),
+            v({ruleId: 'llm.soft-a', level: 'warning', cells: [{row: 0, col: 0}]}),
+            v({ruleId: 'llm.empty', cells: []}),
+        ];
+
+        expect(mergeServerScheduleViolations(input)).toHaveLength(3);
+    });
+});
+
+describe('buildViolationMapAll', () => {
+    it('keeps every violation even when they share the same start cell', () => {
+        const map = buildViolationMapAll(
+            [
+                v({ruleId: 'llm.hard-a', cells: [{row: 0, col: 1}]}),
+                v({ruleId: 'llm.soft-a', level: 'warning', cells: [{row: 0, col: 1}]}),
+            ],
+            doc,
+        );
+
+        expect(map.size).toBe(2);
+        expect(map.get('10,1,llm.hard-a')).toBeDefined();
+        expect(map.get('10,1,llm.soft-a')).toBeDefined();
+    });
+});

--- a/apps/app/src/features/shift-editor/model/__tests__/persistence.test.ts
+++ b/apps/app/src/features/shift-editor/model/__tests__/persistence.test.ts
@@ -1,6 +1,8 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {createScheduleValidationSnapshot} from '../schedule-violations';
 import {createShiftEditorPersistence} from '../persistence';
-import {type TDutyDoc, type THistoryState} from '../types';
+import {type TDutyDoc, type THistoryState, type TViolation} from '../types';
+import type {TAiValidation} from '@dutying/api/ward';
 
 const storageKey = 'shift-editor:draft:test';
 const mockDoc: TDutyDoc = {
@@ -15,6 +17,31 @@ const mockHistory: THistoryState = {
     future: [],
     maxDepth: 50,
 };
+const mockValidation: TAiValidation = {
+    valid: false,
+    hard_constraints_violated: [],
+    soft_constraints_violated: [
+        {
+            id: 'test',
+            severity: 'SOFT',
+            message: 'test violation',
+            nurse_id: '1',
+            period: {start_day: 1, end_day: 1},
+        },
+    ],
+    warnings: [],
+};
+const mockScheduleViolations = {
+    validationSnapshot: createScheduleValidationSnapshot(mockValidation, 42),
+};
+const mockLegacyViolations: TViolation[] = [
+    {
+        ruleId: 'llm.test',
+        message: 'test violation',
+        level: 'warning',
+        cells: [{row: 0, col: 0}],
+    },
+];
 
 describe('createShiftEditorPersistence', () => {
     beforeEach(() => {
@@ -33,7 +60,7 @@ describe('createShiftEditorPersistence', () => {
             saveDebounceMs: 400,
         });
 
-        persistence.save(mockDoc, mockHistory);
+        persistence.save(mockDoc, mockHistory, mockScheduleViolations);
         vi.advanceTimersByTime(400);
 
         const raw = window.localStorage.getItem(storageKey);
@@ -42,6 +69,7 @@ describe('createShiftEditorPersistence', () => {
         expect(JSON.parse(raw!)).toEqual({
             doc: mockDoc,
             history: JSON.stringify(mockHistory),
+            scheduleViolations: mockScheduleViolations,
             savedAt: expect.any(Number),
         });
     });
@@ -52,13 +80,34 @@ describe('createShiftEditorPersistence', () => {
             saveDebounceMs: 400,
         });
 
-        persistence.save(mockDoc, mockHistory);
+        persistence.save(mockDoc, mockHistory, mockScheduleViolations);
         vi.advanceTimersByTime(400);
 
         expect(persistence.load()).toEqual({
             doc: mockDoc,
             history: JSON.stringify(mockHistory),
+            scheduleViolations: mockScheduleViolations,
             savedAt: expect.any(Number),
+        });
+    });
+
+    it('구 llmViolations 드래프트를 legacy로 마이그레이션해야 한다', () => {
+        window.localStorage.setItem(
+            storageKey,
+            JSON.stringify({
+                doc: mockDoc,
+                history: JSON.stringify(mockHistory),
+                llmViolations: mockLegacyViolations,
+                savedAt: Date.now(),
+            }),
+        );
+
+        const persistence = createShiftEditorPersistence({storageKey, saveDebounceMs: 400});
+        const loaded = persistence.load();
+
+        expect(loaded?.scheduleViolations).toEqual({
+            validationSnapshot: null,
+            legacyDisplayViolations: mockLegacyViolations,
         });
     });
 

--- a/apps/app/src/features/shift-editor/model/index.ts
+++ b/apps/app/src/features/shift-editor/model/index.ts
@@ -8,5 +8,6 @@ export * from './draft-status-store';
 export * from './use-shift-excel-export';
 export * from './use-shift-image-export';
 export * from './use-shift-editor-key-bindings';
-export {buildViolationMap} from './validator';
-export {useViolationMap} from './use-duty-violation-map';
+export {buildViolationMap, buildViolationMapAll} from './validator';
+export {mergeServerScheduleViolations, mergeScheduleViolations} from './merge-schedule-violations';
+export {useViolationMap, type TScheduleViolationView} from './use-duty-violation-map';

--- a/apps/app/src/features/shift-editor/model/index.ts
+++ b/apps/app/src/features/shift-editor/model/index.ts
@@ -11,3 +11,14 @@ export * from './use-shift-editor-key-bindings';
 export {buildViolationMap, buildViolationMapAll} from './validator';
 export {mergeServerScheduleViolations, mergeScheduleViolations} from './merge-schedule-violations';
 export {useViolationMap, type TScheduleViolationView} from './use-duty-violation-map';
+export {useScheduleDisplayViolations} from './use-schedule-display-violations';
+export {
+    aiValidationToViolations,
+    createScheduleValidationSnapshot,
+    refreshScheduleViolations,
+    resolveScheduleDisplayViolations,
+    violationsFromApiValidation,
+    type TRefreshScheduleViolationsParams,
+    type TScheduleValidationSnapshot,
+    type TScheduleViolationPersisted,
+} from './schedule-violations';

--- a/apps/app/src/features/shift-editor/model/merge-schedule-violations.ts
+++ b/apps/app/src/features/shift-editor/model/merge-schedule-violations.ts
@@ -1,0 +1,11 @@
+import type {TViolation} from './types';
+
+/** 서버 validation 위반을 그대로 반환한다 (빈 cells만 제외). */
+export function mergeServerScheduleViolations(violations: TViolation[]): TViolation[] {
+    return violations.filter((violation) => violation.cells.length > 0);
+}
+
+/** @deprecated mergeServerScheduleViolations 사용 */
+export function mergeScheduleViolations(_frontendViolations: TViolation[], llmViolations: TViolation[]): TViolation[] {
+    return mergeServerScheduleViolations(llmViolations);
+}

--- a/apps/app/src/features/shift-editor/model/persistence.ts
+++ b/apps/app/src/features/shift-editor/model/persistence.ts
@@ -1,3 +1,5 @@
+import {migratePersistedViolations} from './schedule-violations';
+import type {TScheduleViolationPersisted} from './schedule-violations';
 import type {TDutyDoc, THistoryState, TPersisted} from './types';
 
 export type TDraftSaveStatus = 'idle' | 'saving' | 'saved';
@@ -5,8 +7,8 @@ export type TDraftSaveStatus = 'idle' | 'saving' | 'saved';
 export type TShiftEditorPersistence = {
     readonly storageKey: string;
     saveDebounceMs: number;
-    save: (doc: TDutyDoc, history: THistoryState) => void;
-    saveImmediate: (doc: TDutyDoc, history: THistoryState) => void;
+    save: (doc: TDutyDoc, history: THistoryState, scheduleViolations?: TScheduleViolationPersisted) => void;
+    saveImmediate: (doc: TDutyDoc, history: THistoryState, scheduleViolations?: TScheduleViolationPersisted) => void;
     load: () => TPersisted | null;
     clear: () => void;
     setStorageKey: (key: string) => void;
@@ -25,6 +27,8 @@ function deserializeHistory(raw: string): THistoryState | null {
     }
 }
 
+const emptyScheduleViolations: TScheduleViolationPersisted = {validationSnapshot: null};
+
 export function createShiftEditorPersistence(opts: {
     storageKey: string;
     saveDebounceMs?: number;
@@ -34,16 +38,17 @@ export function createShiftEditorPersistence(opts: {
 
     let currentKey = opts.storageKey;
     let timer: number | null = null;
-    let pending: {doc: TDutyDoc; history: THistoryState; key: string} | null = null;
+    let pending: {doc: TDutyDoc; history: THistoryState; scheduleViolations: TScheduleViolationPersisted; key: string} | null = null;
 
     const emitStatus = (status: TDraftSaveStatus) => {
         onStatusChange?.(status);
     };
 
-    const saveNow = (doc: TDutyDoc, history: THistoryState, key: string) => {
+    const saveNow = (doc: TDutyDoc, history: THistoryState, scheduleViolations: TScheduleViolationPersisted, key: string) => {
         const persisted: TPersisted = {
             doc,
             history: serializeHistory(history),
+            scheduleViolations,
             savedAt: Date.now(),
         };
 
@@ -61,7 +66,7 @@ export function createShiftEditorPersistence(opts: {
         cancelTimer();
 
         if (pending) {
-            saveNow(pending.doc, pending.history, pending.key);
+            saveNow(pending.doc, pending.history, pending.scheduleViolations, pending.key);
             pending = null;
             emitStatus('saved');
         }
@@ -72,23 +77,23 @@ export function createShiftEditorPersistence(opts: {
             return currentKey;
         },
         saveDebounceMs,
-        save: (doc, history) => {
-            pending = {doc, history, key: currentKey};
+        save: (doc, history, scheduleViolations = emptyScheduleViolations) => {
+            pending = {doc, history, scheduleViolations, key: currentKey};
             cancelTimer();
             emitStatus('saving');
 
             timer = window.setTimeout(() => {
-                if (pending) saveNow(pending.doc, pending.history, pending.key);
+                if (pending) saveNow(pending.doc, pending.history, pending.scheduleViolations, pending.key);
 
                 pending = null;
                 timer = null;
                 emitStatus('saved');
             }, saveDebounceMs);
         },
-        saveImmediate: (doc, history) => {
+        saveImmediate: (doc, history, scheduleViolations = emptyScheduleViolations) => {
             cancelTimer();
             pending = null;
-            saveNow(doc, history, currentKey);
+            saveNow(doc, history, scheduleViolations, currentKey);
             emitStatus('saved');
         },
         load: () => {
@@ -109,6 +114,8 @@ export function createShiftEditorPersistence(opts: {
 
                 if (!parsed.doc || typeof parsed.doc !== 'object') return null;
 
+                const scheduleViolations = migratePersistedViolations(parsed);
+
                 return {
                     ...parsed,
                     doc: {
@@ -116,6 +123,7 @@ export function createShiftEditorPersistence(opts: {
                         fixedCells: parsed.doc.fixedCells ?? {},
                         requestCells: parsed.doc.requestCells ?? {},
                     },
+                    scheduleViolations,
                 };
             } catch {
                 return null;

--- a/apps/app/src/features/shift-editor/model/schedule-violations/__tests__/convert-api-validation.test.ts
+++ b/apps/app/src/features/shift-editor/model/schedule-violations/__tests__/convert-api-validation.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest';
 import type {TAiValidation} from '@dutying/api/ward';
-import {aiValidationToViolations} from '../ai-validation-to-violations';
-import type {TDutyDoc} from '@/features/shift-editor';
+import type {TDutyDoc} from '../../types';
+import {violationsFromApiValidation} from '../convert-api-validation';
 
 const doc: TDutyDoc = {
     columns: Array.from({length: 5}, (_, i) => `2026-05-0${i + 1}`),
@@ -17,7 +17,7 @@ const doc: TDutyDoc = {
     requestCells: {},
 };
 
-describe('aiValidationToViolations', () => {
+describe('violationsFromApiValidation', () => {
     it('maps nurse-specific soft violations to warning level with nurse row', () => {
         const validation: TAiValidation = {
             valid: false,
@@ -35,7 +35,7 @@ describe('aiValidationToViolations', () => {
             warnings: [],
         };
 
-        const violations = aiValidationToViolations(validation, doc);
+        const violations = violationsFromApiValidation(validation, doc);
 
         expect(violations).toEqual([
             {
@@ -69,7 +69,7 @@ describe('aiValidationToViolations', () => {
             warnings: [],
         };
 
-        const violations = aiValidationToViolations(validation, doc);
+        const violations = violationsFromApiValidation(validation, doc);
 
         expect(violations).toHaveLength(1);
         expect(violations[0]).toMatchObject({

--- a/apps/app/src/features/shift-editor/model/schedule-violations/__tests__/resolve-display-violations.test.ts
+++ b/apps/app/src/features/shift-editor/model/schedule-violations/__tests__/resolve-display-violations.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, it} from 'vitest';
+import type {TAiValidation} from '@dutying/api/ward';
+import type {TDutyDoc, TViolation} from '../../types';
+import {createScheduleValidationSnapshot, resolveScheduleDisplayViolations} from '../resolve-display-violations';
+
+const doc: TDutyDoc = {
+    columns: ['2026-05-01', '2026-05-02', '2026-05-03'],
+    rows: [{workerId: '1', cells: ['D', 'N', 'O']}],
+    workerMeta: {1: {name: 'Kim', nurseId: 10}},
+    fixedCells: {},
+    requestCells: {},
+};
+
+const validation: TAiValidation = {
+    valid: false,
+    hard_constraints_violated: [],
+    soft_constraints_violated: [
+        {
+            id: 'test',
+            severity: 'SOFT',
+            message: 'msg',
+            nurse_id: '10',
+            period: {start_day: 1, end_day: 2},
+        },
+    ],
+    warnings: [],
+};
+
+describe('resolveScheduleDisplayViolations', () => {
+    it('re-derives cells from snapshot when doc rows change', () => {
+        const snapshot = createScheduleValidationSnapshot(validation);
+        const reorderedDoc: TDutyDoc = {
+            ...doc,
+            rows: [{workerId: '99', cells: ['O', 'D', 'N']}],
+            workerMeta: {99: {name: 'Other', nurseId: 10}},
+        };
+
+        const violations = resolveScheduleDisplayViolations(reorderedDoc, snapshot, []);
+
+        expect(violations[0]?.cells).toEqual([
+            {row: 0, col: 0},
+            {row: 0, col: 1},
+        ]);
+    });
+
+    it('uses legacy display violations when snapshot is absent', () => {
+        const legacy: TViolation[] = [
+            {
+                ruleId: 'legacy',
+                message: 'cached',
+                level: 'warning',
+                cells: [{row: 0, col: 0}],
+            },
+        ];
+
+        expect(resolveScheduleDisplayViolations(doc, null, legacy)).toEqual(legacy);
+    });
+});

--- a/apps/app/src/features/shift-editor/model/schedule-violations/convert-api-validation.ts
+++ b/apps/app/src/features/shift-editor/model/schedule-violations/convert-api-validation.ts
@@ -1,5 +1,5 @@
 import type {TAiConstraintViolation, TAiValidation} from '@dutying/api/ward';
-import type {TCellPos, TDutyDoc, TViolation} from '@/features/shift-editor';
+import type {TCellPos, TDutyDoc, TViolation} from '../types';
 
 function formatViolationMessage(item: TAiConstraintViolation): string {
     const title = item.title?.trim();
@@ -53,6 +53,7 @@ function toViolation(
     item: TAiConstraintViolation,
     level: TViolation['level'],
     cells: TCellPos[],
+    scope: TViolation['scope'],
 ): TViolation | null {
     if (cells.length === 0) return null;
 
@@ -61,7 +62,7 @@ function toViolation(
         message: formatViolationMessage(item),
         level,
         cells,
-        scope: 'nurse',
+        scope,
     };
 }
 
@@ -78,20 +79,19 @@ function violationFromApiItem(doc: TDutyDoc, item: TAiConstraintViolation, level
         if (row === null) return [];
 
         const cells = dayRangeToCells(row, range.startDay, range.endDay, doc.columns.length);
-        const violation = toViolation(item, level, cells);
+        const violation = toViolation(item, level, cells, 'nurse');
 
         return violation ? [violation] : [];
     }
 
     const cells = dayRangeToCells(0, range.startDay, range.endDay, doc.columns.length);
-    const violation = toViolation(item, level, cells);
+    const violation = toViolation(item, level, cells, 'team');
 
-    if (!violation) return [];
-
-    return [{...violation, scope: 'team'}];
+    return violation ? [violation] : [];
 }
 
-export function aiValidationToViolations(validation: TAiValidation, doc: TDutyDoc): TViolation[] {
+/** API validation → 캘린더 표시용 TViolation[] (현재 doc 행/열에 맞춰 매핑) */
+export function violationsFromApiValidation(validation: TAiValidation, doc: TDutyDoc): TViolation[] {
     const hard = validation.hard_constraints_violated.flatMap((item) => violationFromApiItem(doc, item, 'error'));
     const soft = validation.soft_constraints_violated.flatMap((item) => violationFromApiItem(doc, item, 'warning'));
 

--- a/apps/app/src/features/shift-editor/model/schedule-violations/index.ts
+++ b/apps/app/src/features/shift-editor/model/schedule-violations/index.ts
@@ -1,0 +1,12 @@
+export type {TScheduleValidationSnapshot, TScheduleViolationPersisted} from './types';
+export {violationsFromApiValidation} from './convert-api-validation';
+export {
+    createScheduleValidationSnapshot,
+    migratePersistedViolations,
+    resolveScheduleDisplayViolations,
+    toScheduleViolationPersisted,
+} from './resolve-display-violations';
+export {refreshScheduleViolations, type TRefreshScheduleViolationsParams} from './refresh-schedule-violations';
+
+/** @deprecated violationsFromApiValidation 사용 */
+export {violationsFromApiValidation as aiValidationToViolations} from './convert-api-validation';

--- a/apps/app/src/features/shift-editor/model/schedule-violations/refresh-schedule-violations.ts
+++ b/apps/app/src/features/shift-editor/model/schedule-violations/refresh-schedule-violations.ts
@@ -1,0 +1,21 @@
+import type {TAiValidation} from '@dutying/api/ward';
+import type {TDutyDoc} from '../types';
+
+export type TRefreshScheduleViolationsParams = {
+    doc: TDutyDoc;
+    shiftTeamId: number;
+    year: number;
+    month: number;
+    /** 직전 generate 응답 id — 재검증 API가 생기면 전달 */
+    generationId?: number;
+};
+
+/**
+ * 재진입·수동 편집 후 서버에서 제약 위반을 다시 계산한다.
+ *
+ * @returns 갱신된 validation. 아직 API가 없으면 `null`(호출부는 기존 스냅샷 유지).
+ */
+export async function refreshScheduleViolations(_params: TRefreshScheduleViolationsParams): Promise<TAiValidation | null> {
+    // TODO: POST /llm/schedule/validate (가칭) 등 재검증 API 연동
+    return null;
+}

--- a/apps/app/src/features/shift-editor/model/schedule-violations/resolve-display-violations.ts
+++ b/apps/app/src/features/shift-editor/model/schedule-violations/resolve-display-violations.ts
@@ -1,0 +1,61 @@
+import type {TDutyDoc, TViolation} from '../types';
+import {violationsFromApiValidation} from './convert-api-validation';
+import type {TScheduleValidationSnapshot, TScheduleViolationPersisted} from './types';
+
+export function createScheduleValidationSnapshot(
+    validation: TScheduleValidationSnapshot['validation'],
+    generationId?: number,
+): TScheduleValidationSnapshot {
+    return {
+        validation,
+        generationId,
+        capturedAt: Date.now(),
+    };
+}
+
+/**
+ * 스냅샷이 있으면 현재 doc 기준으로 재변환(행 매핑·팀 열 span 갱신).
+ * 없으면 구 드래프트 legacy 캐시를 그대로 쓴다.
+ */
+export function resolveScheduleDisplayViolations(
+    doc: TDutyDoc,
+    validationSnapshot: TScheduleValidationSnapshot | null,
+    legacyDisplayViolations: TViolation[],
+): TViolation[] {
+    if (validationSnapshot) {
+        return violationsFromApiValidation(validationSnapshot.validation, doc);
+    }
+
+    return legacyDisplayViolations;
+}
+
+export function toScheduleViolationPersisted(
+    validationSnapshot: TScheduleValidationSnapshot | null,
+    legacyDisplayViolations: TViolation[],
+): TScheduleViolationPersisted {
+    if (validationSnapshot) {
+        return {validationSnapshot};
+    }
+
+    if (legacyDisplayViolations.length > 0) {
+        return {validationSnapshot: null, legacyDisplayViolations};
+    }
+
+    return {validationSnapshot: null};
+}
+
+/** 구 TPersisted.llmViolations 필드 → 신규 persisted 형태 */
+export function migratePersistedViolations(persisted: {
+    scheduleViolations?: TScheduleViolationPersisted;
+    llmViolations?: TViolation[];
+}): TScheduleViolationPersisted {
+    if (persisted.scheduleViolations) {
+        return persisted.scheduleViolations;
+    }
+
+    if (persisted.llmViolations && persisted.llmViolations.length > 0) {
+        return {validationSnapshot: null, legacyDisplayViolations: persisted.llmViolations};
+    }
+
+    return {validationSnapshot: null};
+}

--- a/apps/app/src/features/shift-editor/model/schedule-violations/types.ts
+++ b/apps/app/src/features/shift-editor/model/schedule-violations/types.ts
@@ -1,0 +1,22 @@
+import type {TAiValidation} from '@dutying/api/ward';
+import type {TViolation} from '../types';
+
+/**
+ * 서버 `validation` 응답 스냅샷.
+ * 재진입·수동 편집 후 `refreshScheduleViolations`로 갱신할 예정 — UI는 항상 snapshot + 현재 doc으로 재변환한다.
+ */
+export type TScheduleValidationSnapshot = {
+    validation: TAiValidation;
+    generationId?: number;
+    capturedAt: number;
+};
+
+/** localStorage 드래프트에 함께 보관하는 위반 상태 */
+export type TScheduleViolationPersisted = {
+    validationSnapshot: TScheduleValidationSnapshot | null;
+    /**
+     * 구 드래프트(`llmViolations`만 있던 시절) 호환용.
+     * snapshot이 있으면 무시하고 재변환한다.
+     */
+    legacyDisplayViolations?: TViolation[];
+};

--- a/apps/app/src/features/shift-editor/model/store.ts
+++ b/apps/app/src/features/shift-editor/model/store.ts
@@ -8,7 +8,8 @@ export type TShiftEditorStore = {
     // state (data only)
     doc: TDutyDoc;
     selection: TSelection | null;
-    violations: TViolation[];
+    /** LLM generate API `validation`에서 변환한 위반. 수동 편집 시 비운다. */
+    llmViolations: TViolation[];
     history: THistoryState;
     dutyValidationInput: TDutyValidationInput | null;
     dutyRuleBoard: TDutyRuleBoard | null;
@@ -17,7 +18,7 @@ export type TShiftEditorStore = {
     // primitive setters (no business rules here)
     setDoc: (doc: TDutyDoc) => void;
     setSelection: (selection: TSelection | null) => void;
-    setViolations: (violations: TViolation[]) => void;
+    setLlmViolations: (violations: TViolation[]) => void;
     setHistory: (history: THistoryState) => void;
     setDutyValidationInput: (input: TDutyValidationInput | null) => void;
     setDutyRuleBoard: (board: TDutyRuleBoard | null) => void;
@@ -33,7 +34,7 @@ export const useShiftEditorStore = create<TShiftEditorStore>()(
     devtools((set) => ({
         doc: emptyDoc,
         selection: null,
-        violations: [],
+        llmViolations: [],
         history: initialHistory,
         dutyValidationInput: null,
         dutyRuleBoard: null,
@@ -41,7 +42,7 @@ export const useShiftEditorStore = create<TShiftEditorStore>()(
 
         setDoc: (doc) => set(() => ({doc})),
         setSelection: (selection) => set(() => ({selection})),
-        setViolations: (violations) => set(() => ({violations})),
+        setLlmViolations: (llmViolations) => set(() => ({llmViolations})),
         setHistory: (history) => set(() => ({history})),
         setDutyValidationInput: (dutyValidationInput) => set(() => ({dutyValidationInput})),
         setDutyRuleBoard: (dutyRuleBoard) => set(() => ({dutyRuleBoard})),
@@ -53,7 +54,7 @@ export const useShiftEditorStore = create<TShiftEditorStore>()(
             set(() => ({
                 doc: emptyDoc,
                 selection: null,
-                violations: [],
+                llmViolations: [],
                 history: {past: [], future: [], maxDepth},
                 dutyValidationInput: null,
                 dutyRuleBoard: null,

--- a/apps/app/src/features/shift-editor/model/store.ts
+++ b/apps/app/src/features/shift-editor/model/store.ts
@@ -1,5 +1,6 @@
 import {create} from 'zustand';
 import {devtools} from 'zustand/middleware';
+import type {TScheduleValidationSnapshot} from './schedule-violations';
 import type {TDutyDoc, TDutyRuleBoard, TDutyValidationInput, THistoryState, TSelection, TViolation} from './types';
 
 export type TEditorMode = 'normal' | 'fixed';
@@ -8,8 +9,10 @@ export type TShiftEditorStore = {
     // state (data only)
     doc: TDutyDoc;
     selection: TSelection | null;
-    /** LLM generate API `validation`에서 변환한 위반. 수동 편집 시 비운다. */
-    llmViolations: TViolation[];
+    /** 서버 validation 원본 스냅샷 — 표시는 doc 기준으로 재변환 */
+    scheduleValidationSnapshot: TScheduleValidationSnapshot | null;
+    /** 구 드래프트 호환: snapshot 없을 때만 사용 */
+    legacyDisplayViolations: TViolation[];
     history: THistoryState;
     dutyValidationInput: TDutyValidationInput | null;
     dutyRuleBoard: TDutyRuleBoard | null;
@@ -18,7 +21,8 @@ export type TShiftEditorStore = {
     // primitive setters (no business rules here)
     setDoc: (doc: TDutyDoc) => void;
     setSelection: (selection: TSelection | null) => void;
-    setLlmViolations: (violations: TViolation[]) => void;
+    setScheduleValidationSnapshot: (snapshot: TScheduleValidationSnapshot | null) => void;
+    setLegacyDisplayViolations: (violations: TViolation[]) => void;
     setHistory: (history: THistoryState) => void;
     setDutyValidationInput: (input: TDutyValidationInput | null) => void;
     setDutyRuleBoard: (board: TDutyRuleBoard | null) => void;
@@ -34,7 +38,8 @@ export const useShiftEditorStore = create<TShiftEditorStore>()(
     devtools((set) => ({
         doc: emptyDoc,
         selection: null,
-        llmViolations: [],
+        scheduleValidationSnapshot: null,
+        legacyDisplayViolations: [],
         history: initialHistory,
         dutyValidationInput: null,
         dutyRuleBoard: null,
@@ -42,7 +47,8 @@ export const useShiftEditorStore = create<TShiftEditorStore>()(
 
         setDoc: (doc) => set(() => ({doc})),
         setSelection: (selection) => set(() => ({selection})),
-        setLlmViolations: (llmViolations) => set(() => ({llmViolations})),
+        setScheduleValidationSnapshot: (scheduleValidationSnapshot) => set(() => ({scheduleValidationSnapshot})),
+        setLegacyDisplayViolations: (legacyDisplayViolations) => set(() => ({legacyDisplayViolations})),
         setHistory: (history) => set(() => ({history})),
         setDutyValidationInput: (dutyValidationInput) => set(() => ({dutyValidationInput})),
         setDutyRuleBoard: (dutyRuleBoard) => set(() => ({dutyRuleBoard})),
@@ -54,7 +60,8 @@ export const useShiftEditorStore = create<TShiftEditorStore>()(
             set(() => ({
                 doc: emptyDoc,
                 selection: null,
-                llmViolations: [],
+                scheduleValidationSnapshot: null,
+                legacyDisplayViolations: [],
                 history: {past: [], future: [], maxDepth},
                 dutyValidationInput: null,
                 dutyRuleBoard: null,

--- a/apps/app/src/features/shift-editor/model/types.ts
+++ b/apps/app/src/features/shift-editor/model/types.ts
@@ -70,11 +70,15 @@ export type TTransaction<Op> = {
     timestamp: number;
 };
 
+export type TViolationScope = 'nurse' | 'team';
+
 export type TViolation = {
     ruleId: string;
     message: string;
     cells: TCellPos[];
     level: 'warning' | 'error';
+    /** team: division 일자 열 전체. nurse(기본): 해당 간호사 행만 */
+    scope?: TViolationScope;
 };
 
 export type TDutyRuleLevel = TViolation['level'];

--- a/apps/app/src/features/shift-editor/model/types.ts
+++ b/apps/app/src/features/shift-editor/model/types.ts
@@ -1,4 +1,5 @@
 import {type TWardConstraint} from '@/entities';
+import type {TScheduleViolationPersisted} from './schedule-violations';
 
 export type TCellValue = string | null;
 export type TWorkKeyMap = Record<string, TCellValue>;
@@ -30,6 +31,10 @@ export type TDutyDoc = {
 export type TPersisted = {
     doc: TDutyDoc;
     history: string;
+    /** 서버 validation 스냅샷 — doc·history와 함께 드래프트로 보관 */
+    scheduleViolations?: TScheduleViolationPersisted;
+    /** @deprecated scheduleViolations 사용 */
+    llmViolations?: TViolation[];
     savedAt: number;
 };
 

--- a/apps/app/src/features/shift-editor/model/use-duty-violation-map.ts
+++ b/apps/app/src/features/shift-editor/model/use-duty-violation-map.ts
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 import {mergeServerScheduleViolations} from './merge-schedule-violations';
-import {useShiftEditorStore} from './store';
+import {useScheduleDisplayViolations} from './use-schedule-display-violations';
 import type {TDutyDoc, TViolation} from './types';
 import {buildViolationMapAll} from './validator';
 
@@ -15,10 +15,10 @@ export type TScheduleViolationView = {
  * - team: division 일자 열 전체 span (별도 오버레이)
  */
 export function useViolationMap(doc: TDutyDoc): TScheduleViolationView {
-    const llmViolations = useShiftEditorStore((s) => s.llmViolations);
+    const displayViolations = useScheduleDisplayViolations(doc);
 
     return useMemo(() => {
-        const all = mergeServerScheduleViolations(llmViolations);
+        const all = mergeServerScheduleViolations(displayViolations);
         const teamViolations = all.filter((violation) => violation.scope === 'team');
         const nurseViolations = all.filter((violation) => violation.scope !== 'team');
 
@@ -26,5 +26,5 @@ export function useViolationMap(doc: TDutyDoc): TScheduleViolationView {
             violationMap: buildViolationMapAll(nurseViolations, doc),
             teamViolations,
         };
-    }, [llmViolations, doc]);
+    }, [displayViolations, doc]);
 }

--- a/apps/app/src/features/shift-editor/model/use-duty-violation-map.ts
+++ b/apps/app/src/features/shift-editor/model/use-duty-violation-map.ts
@@ -1,13 +1,30 @@
 import {useMemo} from 'react';
+import {mergeServerScheduleViolations} from './merge-schedule-violations';
 import {useShiftEditorStore} from './store';
-import type {TDutyDoc} from './types';
-import {buildViolationMap} from './validator';
+import type {TDutyDoc, TViolation} from './types';
+import {buildViolationMapAll} from './validator';
+
+export type TScheduleViolationView = {
+    violationMap: Map<string, TViolation>;
+    teamViolations: TViolation[];
+};
 
 /**
- * 편집기 store의 violations를 doc 형상에 맞춰 ShiftCalendar / MakeShiftCalendar용 Map으로 변환.
+ * 서버(LLM API) validation 위반을 캘린더용으로 변환.
+ * - nurse: 행·일자 span
+ * - team: division 일자 열 전체 span (별도 오버레이)
  */
-export function useViolationMap(doc: TDutyDoc) {
-    const violations = useShiftEditorStore((s) => s.violations);
+export function useViolationMap(doc: TDutyDoc): TScheduleViolationView {
+    const llmViolations = useShiftEditorStore((s) => s.llmViolations);
 
-    return useMemo(() => buildViolationMap(violations, doc), [violations, doc]);
+    return useMemo(() => {
+        const all = mergeServerScheduleViolations(llmViolations);
+        const teamViolations = all.filter((violation) => violation.scope === 'team');
+        const nurseViolations = all.filter((violation) => violation.scope !== 'team');
+
+        return {
+            violationMap: buildViolationMapAll(nurseViolations, doc),
+            teamViolations,
+        };
+    }, [llmViolations, doc]);
 }

--- a/apps/app/src/features/shift-editor/model/use-schedule-display-violations.ts
+++ b/apps/app/src/features/shift-editor/model/use-schedule-display-violations.ts
@@ -1,0 +1,17 @@
+import {useMemo} from 'react';
+import {resolveScheduleDisplayViolations} from './schedule-violations';
+import {useShiftEditorStore} from './store';
+import type {TDutyDoc, TViolation} from './types';
+
+/** 현재 doc + validation 스냅샷(또는 legacy)으로 표시용 위반 목록을 계산한다. */
+export function useScheduleDisplayViolations(doc?: TDutyDoc): TViolation[] {
+    const storeDoc = useShiftEditorStore((s) => s.doc);
+    const validationSnapshot = useShiftEditorStore((s) => s.scheduleValidationSnapshot);
+    const legacyDisplayViolations = useShiftEditorStore((s) => s.legacyDisplayViolations);
+    const resolvedDoc = doc ?? storeDoc;
+
+    return useMemo(
+        () => resolveScheduleDisplayViolations(resolvedDoc, validationSnapshot, legacyDisplayViolations),
+        [resolvedDoc, validationSnapshot, legacyDisplayViolations],
+    );
+}

--- a/apps/app/src/features/shift-editor/model/use-shift-editor-commands.ts
+++ b/apps/app/src/features/shift-editor/model/use-shift-editor-commands.ts
@@ -1,3 +1,4 @@
+import type {TAiValidation} from '@dutying/api/ward';
 import toast from 'react-hot-toast';
 import {type TWardConstraint} from '@/entities';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
@@ -6,6 +7,12 @@ import {useShiftEditorDraftStatusStore} from './draft-status-store';
 import {applyBoardToWardConstraint, buildInitialDutyRuleBoard, buildRuleLevelByKeyFromBoard} from './duty-constraints';
 import {applyOperation, invertOperation} from './operation';
 import {createShiftEditorPersistence} from './persistence';
+import {
+    createScheduleValidationSnapshot,
+    migratePersistedViolations,
+    toScheduleViolationPersisted,
+    type TScheduleViolationPersisted,
+} from './schedule-violations';
 import {getCellsInSelection, makeSelectAllSelection, moveSelection as moveSelectionModel, moveSelectionToEdge} from './selection';
 import {useShiftEditorStore} from './store';
 import type {
@@ -36,10 +43,6 @@ export function getShiftEditorDraftStorageKey(ctx: {wardId: number; shiftTeamId:
     return `${DEFAULT_STORAGE_KEY}:${ctx.wardId}:${ctx.shiftTeamId}:${ctx.year}:${ctx.month}`;
 }
 
-function clearLlmViolationsUnlessAi(source: TTxSource, setLlmViolations: (violations: TViolation[]) => void) {
-    if (source !== 'ai') setLlmViolations([]);
-}
-
 function invertOps(ops: TOperation[]): TOperation[] {
     return ops
         .slice()
@@ -54,12 +57,19 @@ function pushHistory(history: THistoryState, entry: THistoryEntry): THistoryStat
     return {past: trimmedPast, future: [], maxDepth: history.maxDepth};
 }
 
-function persistDoc(doc: TDutyDoc, history: THistoryState) {
-    persistence.save(doc, history);
+function scheduleViolationsFromState(state: {
+    scheduleValidationSnapshot: ReturnType<typeof useShiftEditorStore.getState>['scheduleValidationSnapshot'];
+    legacyDisplayViolations: TViolation[];
+}): TScheduleViolationPersisted {
+    return toScheduleViolationPersisted(state.scheduleValidationSnapshot, state.legacyDisplayViolations);
 }
 
-function persistDocImmediate(doc: TDutyDoc, history: THistoryState) {
-    persistence.saveImmediate(doc, history);
+function persistDoc(doc: TDutyDoc, history: THistoryState, scheduleViolations: TScheduleViolationPersisted) {
+    persistence.save(doc, history, scheduleViolations);
+}
+
+function persistDocImmediate(doc: TDutyDoc, history: THistoryState, scheduleViolations: TScheduleViolationPersisted) {
+    persistence.saveImmediate(doc, history, scheduleViolations);
 }
 
 /**
@@ -93,7 +103,8 @@ export function useShiftEditorCommands() {
     const setDoc = useShiftEditorStore((s) => s.setDoc);
     const setHistory = useShiftEditorStore((s) => s.setHistory);
     const setSelection = useShiftEditorStore((s) => s.setSelection);
-    const setLlmViolations = useShiftEditorStore((s) => s.setLlmViolations);
+    const setScheduleValidationSnapshot = useShiftEditorStore((s) => s.setScheduleValidationSnapshot);
+    const setLegacyDisplayViolations = useShiftEditorStore((s) => s.setLegacyDisplayViolations);
     const reset = useShiftEditorStore((s) => s.reset);
     const getState = () => useShiftEditorStore.getState();
     const notifyFixedLocked = () => toast.error(t('page.makeShift.fixedShifts.lockedToast'));
@@ -157,16 +168,15 @@ export function useShiftEditorCommands() {
         const nextDoc = tx.ops.reduce((d, op) => applyOperation(d, op), doc);
 
         setDoc(nextDoc);
-        clearLlmViolationsUnlessAi(source, setLlmViolations);
 
         if (editorMode !== 'fixed') {
             const entry: THistoryEntry = {tx, inverseOps, selectionBefore: selection, selectionAfter: selection};
             const nextHistory = pushHistory(history, entry);
 
             setHistory(nextHistory);
-            persistDoc(nextDoc, nextHistory);
+            persistDoc(nextDoc, nextHistory, scheduleViolationsFromState(getState()));
         } else {
-            persistDocImmediate(nextDoc, history);
+            persistDocImmediate(nextDoc, history, scheduleViolationsFromState(getState()));
         }
     };
     const cmdSetSelectionValue = (value: TCellValue, source?: TTxSource) => {
@@ -194,7 +204,9 @@ export function useShiftEditorCommands() {
             setDoc(doc);
             setSelection(null);
             setHistory(nextHistory);
-            persistDoc(doc, nextHistory);
+            setScheduleValidationSnapshot(null);
+            setLegacyDisplayViolations([]);
+            persistDoc(doc, nextHistory, {validationSnapshot: null});
         },
         getPersisted: (): TPersisted | null => persistence.load(),
         hydrate: (persisted: TPersisted) => {
@@ -213,6 +225,11 @@ export function useShiftEditorCommands() {
             setDoc(persisted.doc);
             setSelection(null);
             setHistory(appliedHistory);
+            const scheduleViolations =
+                persisted.scheduleViolations ?? migratePersistedViolations(persisted);
+
+            setScheduleValidationSnapshot(scheduleViolations.validationSnapshot);
+            setLegacyDisplayViolations(scheduleViolations.legacyDisplayViolations ?? []);
         },
         discardPersisted: () => persistence.clear(),
         setPersistenceKey: (key: string) => persistence.setStorageKey(key),
@@ -220,7 +237,18 @@ export function useShiftEditorCommands() {
         persistImmediate: () => {
             const {doc, history} = getState();
 
-            persistDocImmediate(doc, history);
+            persistDocImmediate(doc, history, scheduleViolationsFromState(getState()));
+        },
+        /** AI generate 등 서버 validation 스냅샷 저장 — 표시는 현재 doc 기준으로 재변환 */
+        setScheduleValidationFromApi: (validation: TAiValidation, generationId?: number) => {
+            const snapshot = createScheduleValidationSnapshot(validation, generationId);
+
+            setScheduleValidationSnapshot(snapshot);
+            setLegacyDisplayViolations([]);
+
+            const {doc, history} = getState();
+
+            persistDocImmediate(doc, history, {validationSnapshot: snapshot});
         },
         setDutyValidationInput: (input: TDutyValidationInput | null) => {
             const {doc} = getState();
@@ -321,9 +349,8 @@ export function useShiftEditorCommands() {
 
             setDoc(nextDoc);
             setHistory(nextHistory);
-            clearLlmViolationsUnlessAi(source, setLlmViolations);
 
-            persistDoc(nextDoc, nextHistory);
+            persistDoc(nextDoc, nextHistory, scheduleViolationsFromState(getState()));
         },
         applySchedule: (schedule: Record<string, TCellValue[]>, source: TTxSource = 'ai') => {
             const {doc, history, dutyValidationInput, selection} = getState();
@@ -367,11 +394,9 @@ export function useShiftEditorCommands() {
 
             setDoc(nextDoc);
             setHistory(nextHistory);
-            clearLlmViolationsUnlessAi(source, setLlmViolations);
 
-            persistDoc(nextDoc, nextHistory);
+            persistDoc(nextDoc, nextHistory, scheduleViolationsFromState(getState()));
         },
-        setLlmViolations,
         reorderRowsByName: (source: TTxSource = 'user') => {
             const {doc, history, dutyValidationInput, selection} = getState();
 
@@ -399,9 +424,8 @@ export function useShiftEditorCommands() {
             setDoc(nextDoc);
             setSelection(null);
             setHistory(nextHistory);
-            setLlmViolations([]);
 
-            persistDoc(nextDoc, nextHistory);
+            persistDoc(nextDoc, nextHistory, scheduleViolationsFromState(getState()));
         },
         copy: (): TClipboardPayload | null => {
             const {doc, selection} = getState();
@@ -499,16 +523,15 @@ export function useShiftEditorCommands() {
             const nextDoc = applyOperation(doc, op);
 
             setDoc(nextDoc);
-            clearLlmViolationsUnlessAi(source, setLlmViolations);
 
             if (editorMode !== 'fixed') {
                 const entry: THistoryEntry = {tx, inverseOps, selectionBefore: selection, selectionAfter: selection};
                 const nextHistory = pushHistory(history, entry);
 
                 setHistory(nextHistory);
-                persistDoc(nextDoc, nextHistory);
+                persistDoc(nextDoc, nextHistory, scheduleViolationsFromState(getState()));
             } else {
-                persistDocImmediate(nextDoc, history);
+                persistDocImmediate(nextDoc, history, scheduleViolationsFromState(getState()));
             }
         },
         undo: () => {
@@ -526,10 +549,9 @@ export function useShiftEditorCommands() {
 
             setDoc(nextDoc);
             setHistory(nextHistory);
-            setLlmViolations([]);
             setSelection(entry.selectionBefore ?? selection);
 
-            persistDoc(nextDoc, nextHistory);
+            persistDoc(nextDoc, nextHistory, scheduleViolationsFromState(getState()));
         },
         redo: () => {
             const {doc, history, dutyValidationInput, selection} = getState();
@@ -548,10 +570,9 @@ export function useShiftEditorCommands() {
 
             setDoc(nextDoc);
             setHistory(nextHistory);
-            setLlmViolations([]);
             setSelection(entry.selectionAfter ?? selection);
 
-            persistDoc(nextDoc, nextHistory);
+            persistDoc(nextDoc, nextHistory, scheduleViolationsFromState(getState()));
         },
     };
 }

--- a/apps/app/src/features/shift-editor/model/use-shift-editor-commands.ts
+++ b/apps/app/src/features/shift-editor/model/use-shift-editor-commands.ts
@@ -24,8 +24,6 @@ import type {
     TTxSource,
     TViolation,
 } from './types';
-import {createDutyValidator} from './validator';
-
 const DEFAULT_STORAGE_KEY = 'shift-editor:draft';
 const DRAFT_SAVE_DEBOUNCE_MS = 1500;
 const persistence = createShiftEditorPersistence({
@@ -38,12 +36,8 @@ export function getShiftEditorDraftStorageKey(ctx: {wardId: number; shiftTeamId:
     return `${DEFAULT_STORAGE_KEY}:${ctx.wardId}:${ctx.shiftTeamId}:${ctx.year}:${ctx.month}`;
 }
 
-function computeViolations(doc: TDutyDoc, input: TDutyValidationInput | null): TViolation[] {
-    if (!input) return [];
-
-    const validator = createDutyValidator(input);
-
-    return validator(doc as never) as TViolation[];
+function clearLlmViolationsUnlessAi(source: TTxSource, setLlmViolations: (violations: TViolation[]) => void) {
+    if (source !== 'ai') setLlmViolations([]);
 }
 
 function invertOps(ops: TOperation[]): TOperation[] {
@@ -99,7 +93,7 @@ export function useShiftEditorCommands() {
     const setDoc = useShiftEditorStore((s) => s.setDoc);
     const setHistory = useShiftEditorStore((s) => s.setHistory);
     const setSelection = useShiftEditorStore((s) => s.setSelection);
-    const setViolations = useShiftEditorStore((s) => s.setViolations);
+    const setLlmViolations = useShiftEditorStore((s) => s.setLlmViolations);
     const reset = useShiftEditorStore((s) => s.reset);
     const getState = () => useShiftEditorStore.getState();
     const notifyFixedLocked = () => toast.error(t('page.makeShift.fixedShifts.lockedToast'));
@@ -163,7 +157,7 @@ export function useShiftEditorCommands() {
         const nextDoc = tx.ops.reduce((d, op) => applyOperation(d, op), doc);
 
         setDoc(nextDoc);
-        setViolations(computeViolations(nextDoc, dutyValidationInput));
+        clearLlmViolationsUnlessAi(source, setLlmViolations);
 
         if (editorMode !== 'fixed') {
             const entry: THistoryEntry = {tx, inverseOps, selectionBefore: selection, selectionAfter: selection};
@@ -200,8 +194,6 @@ export function useShiftEditorCommands() {
             setDoc(doc);
             setSelection(null);
             setHistory(nextHistory);
-            setViolations(computeViolations(doc, dutyValidationInput));
-
             persistDoc(doc, nextHistory);
         },
         getPersisted: (): TPersisted | null => persistence.load(),
@@ -221,7 +213,6 @@ export function useShiftEditorCommands() {
             setDoc(persisted.doc);
             setSelection(null);
             setHistory(appliedHistory);
-            setViolations(computeViolations(persisted.doc, dutyValidationInput));
         },
         discardPersisted: () => persistence.clear(),
         setPersistenceKey: (key: string) => persistence.setStorageKey(key),
@@ -235,7 +226,6 @@ export function useShiftEditorCommands() {
             const {doc} = getState();
 
             setDutyValidationInput(input);
-            setViolations(computeViolations(doc, input));
 
             // constraints board는 input을 기반으로 UI에서 드래그/편집하기 쉽도록 별도로 유지한다.
             // - 기존 board가 없을 때만 초기화 (사용자가 이미 정렬/제외를 바꾼 경우 유지)
@@ -263,7 +253,6 @@ export function useShiftEditorCommands() {
             const {doc} = getState();
 
             setDutyValidationInput(nextInput);
-            setViolations(computeViolations(doc, nextInput));
         },
         setWardConstraint: (wardConstraint: TWardConstraint) => {
             const {dutyValidationInput, doc} = getState();
@@ -276,7 +265,6 @@ export function useShiftEditorCommands() {
             };
 
             setDutyValidationInput(nextInput);
-            setViolations(computeViolations(doc, nextInput));
         },
         select: (cell: TCellPos) => setSelection({type: 'single', anchor: cell}),
         clearSelection: () => setSelection(null),
@@ -333,7 +321,7 @@ export function useShiftEditorCommands() {
 
             setDoc(nextDoc);
             setHistory(nextHistory);
-            setViolations(computeViolations(nextDoc, dutyValidationInput));
+            clearLlmViolationsUnlessAi(source, setLlmViolations);
 
             persistDoc(nextDoc, nextHistory);
         },
@@ -379,10 +367,11 @@ export function useShiftEditorCommands() {
 
             setDoc(nextDoc);
             setHistory(nextHistory);
-            setViolations(computeViolations(nextDoc, dutyValidationInput));
+            clearLlmViolationsUnlessAi(source, setLlmViolations);
 
             persistDoc(nextDoc, nextHistory);
         },
+        setLlmViolations,
         reorderRowsByName: (source: TTxSource = 'user') => {
             const {doc, history, dutyValidationInput, selection} = getState();
 
@@ -410,7 +399,7 @@ export function useShiftEditorCommands() {
             setDoc(nextDoc);
             setSelection(null);
             setHistory(nextHistory);
-            setViolations(computeViolations(nextDoc, dutyValidationInput));
+            setLlmViolations([]);
 
             persistDoc(nextDoc, nextHistory);
         },
@@ -510,7 +499,7 @@ export function useShiftEditorCommands() {
             const nextDoc = applyOperation(doc, op);
 
             setDoc(nextDoc);
-            setViolations(computeViolations(nextDoc, dutyValidationInput));
+            clearLlmViolationsUnlessAi(source, setLlmViolations);
 
             if (editorMode !== 'fixed') {
                 const entry: THistoryEntry = {tx, inverseOps, selectionBefore: selection, selectionAfter: selection};
@@ -537,7 +526,7 @@ export function useShiftEditorCommands() {
 
             setDoc(nextDoc);
             setHistory(nextHistory);
-            setViolations(computeViolations(nextDoc, dutyValidationInput));
+            setLlmViolations([]);
             setSelection(entry.selectionBefore ?? selection);
 
             persistDoc(nextDoc, nextHistory);
@@ -559,7 +548,7 @@ export function useShiftEditorCommands() {
 
             setDoc(nextDoc);
             setHistory(nextHistory);
-            setViolations(computeViolations(nextDoc, dutyValidationInput));
+            setLlmViolations([]);
             setSelection(entry.selectionAfter ?? selection);
 
             persistDoc(nextDoc, nextHistory);

--- a/apps/app/src/features/shift-editor/model/validator.ts
+++ b/apps/app/src/features/shift-editor/model/validator.ts
@@ -190,3 +190,27 @@ export function buildViolationMap(violations: TViolation[], doc: TDutyDoc): Map<
 
     return map;
 }
+
+/**
+ * 서버 validation 위반을 모두 캘린더에 표시한다.
+ * key: `${workerId},${startCol},${ruleId}` — 시작 셀·ruleId 조합마다 하나씩.
+ */
+export function buildViolationMapAll(violations: TViolation[], doc: TDutyDoc): Map<string, TViolation> {
+    const map = new Map<string, TViolation>();
+
+    for (const v of violations) {
+        if (v.scope === 'team') continue;
+
+        const startCell = v.cells[0];
+
+        if (!startCell) continue;
+
+        const workerId = doc.rows[startCell.row]?.workerId;
+
+        if (!workerId) continue;
+
+        map.set(`${workerId},${startCell.col},${v.ruleId}`, v);
+    }
+
+    return map;
+}

--- a/apps/app/src/features/shift-editor/ui/complex-view/panel.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/panel.tsx
@@ -38,7 +38,7 @@ function getHistoryLabel(
  */
 function Panel({shift, readonly = false}: IPanelProps) {
     const {t} = useTypedTranslation();
-    const violations = useShiftEditorStore((s) => s.violations);
+    const violations = useShiftEditorStore((s) => s.llmViolations);
     const history = useShiftEditorStore((s) => s.history);
     const [open, setOpen] = useState(false);
     const [currentTab, setCurrentTab] = useState('histories');

--- a/apps/app/src/features/shift-editor/ui/complex-view/panel.tsx
+++ b/apps/app/src/features/shift-editor/ui/complex-view/panel.tsx
@@ -2,7 +2,7 @@ import {useState} from 'react';
 import {twMerge} from 'tailwind-merge';
 import {events, sendEvent} from '@/analytics';
 import {type TShift} from '@/entities';
-import {useShiftEditorStore} from '@/features/shift-editor/model';
+import {useScheduleDisplayViolations, useShiftEditorStore} from '@/features/shift-editor/model';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 
 interface IPanelProps {
@@ -38,7 +38,7 @@ function getHistoryLabel(
  */
 function Panel({shift, readonly = false}: IPanelProps) {
     const {t} = useTypedTranslation();
-    const violations = useShiftEditorStore((s) => s.llmViolations);
+    const violations = useScheduleDisplayViolations();
     const history = useShiftEditorStore((s) => s.history);
     const [open, setOpen] = useState(false);
     const [currentTab, setCurrentTab] = useState('histories');

--- a/apps/app/src/features/shift-editor/ui/shift-editor-grid.tsx
+++ b/apps/app/src/features/shift-editor/ui/shift-editor-grid.tsx
@@ -5,7 +5,7 @@ import {normalizeSelection} from '../model/selection';
 export function ShiftEditorGrid() {
     const doc = useShiftEditorStore((s) => s.doc);
     const selection = useShiftEditorStore((s) => s.selection);
-    const violations = useShiftEditorStore((s) => s.violations);
+    const violations = useShiftEditorStore((s) => s.llmViolations);
     const commands = useShiftEditorCommands();
     const {onKeyDown, onPasteCapture} = useShiftEditorKeyBindings({
         // TODO: 사용자별 주입 지점 (예: settings)

--- a/apps/app/src/features/shift-editor/ui/shift-editor-grid.tsx
+++ b/apps/app/src/features/shift-editor/ui/shift-editor-grid.tsx
@@ -30,28 +30,28 @@ export function ShiftEditorGrid() {
         <div className="flex w-full flex-col gap-2 overflow-auto outline-none" tabIndex={0} onKeyDown={onKeyDown} onPasteCapture={onPasteCapture}>
             <div className="flex items-center gap-2">
                 <button
-                    className="h-9 rounded-lg bg-sub-5 px-3 font-apple text-sm text-sub-2.5"
+                    className="box-border h-9 rounded-lg px-3 py-0 font-apple text-sm leading-none text-sub-2.5"
                     onClick={() => commands.undo()}
                     type="button"
                 >
                     Undo
                 </button>
                 <button
-                    className="h-9 rounded-lg bg-sub-5 px-3 font-apple text-sm text-sub-2.5"
+                    className="box-border h-9 rounded-lg px-3 py-0 font-apple text-sm leading-none text-sub-2.5"
                     onClick={() => commands.redo()}
                     type="button"
                 >
                     Redo
                 </button>
                 <button
-                    className="h-9 rounded-lg bg-main-2 px-3 font-apple text-sm text-white"
+                    className="box-border h-9 rounded-lg px-3 py-0 font-apple text-sm leading-none text-white"
                     onClick={() => commands.setSelectionValue('D')}
                     type="button"
                 >
                     선택에 D 입력
                 </button>
                 <button
-                    className="h-9 rounded-lg bg-sub-5 px-3 font-apple text-sm text-sub-2.5"
+                    className="box-border h-9 rounded-lg px-3 py-0 font-apple text-sm leading-none text-sub-2.5"
                     onClick={() => commands.clearSelectionCells()}
                     type="button"
                 >

--- a/apps/app/src/features/shift-editor/ui/shift-editor-grid.tsx
+++ b/apps/app/src/features/shift-editor/ui/shift-editor-grid.tsx
@@ -1,11 +1,11 @@
 import {useMemo} from 'react';
-import {useShiftEditorCommands, useShiftEditorKeyBindings, useShiftEditorStore} from '../model';
+import {useScheduleDisplayViolations, useShiftEditorCommands, useShiftEditorKeyBindings, useShiftEditorStore} from '../model';
 import {normalizeSelection} from '../model/selection';
 
 export function ShiftEditorGrid() {
     const doc = useShiftEditorStore((s) => s.doc);
     const selection = useShiftEditorStore((s) => s.selection);
-    const violations = useShiftEditorStore((s) => s.llmViolations);
+    const violations = useScheduleDisplayViolations();
     const commands = useShiftEditorCommands();
     const {onKeyDown, onPasteCapture} = useShiftEditorKeyBindings({
         // TODO: 사용자별 주입 지점 (예: settings)

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -1,3 +1,4 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.css');
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
@@ -6,10 +7,25 @@
 @custom-variant dark (&:is(.dark *));
 @config '../tailwind.config.ts';
 
+@layer base {
+    button {
+        box-sizing: border-box;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: inherit;
+        line-height: 1;
+    }
+
+    button[class*='text-left'] {
+        justify-content: flex-start;
+    }
+}
+
 @layer utilities {
     body {
         background-color: #fdfcfe;
-        font-family: 'Public Sans';
+        font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
         box-sizing: border-box;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;

--- a/apps/app/src/pages/make-shift/model/__tests__/ai-validation-to-violations.test.ts
+++ b/apps/app/src/pages/make-shift/model/__tests__/ai-validation-to-violations.test.ts
@@ -1,0 +1,81 @@
+import {describe, expect, it} from 'vitest';
+import type {TAiValidation} from '@dutying/api/ward';
+import {aiValidationToViolations} from '../ai-validation-to-violations';
+import type {TDutyDoc} from '@/features/shift-editor';
+
+const doc: TDutyDoc = {
+    columns: Array.from({length: 5}, (_, i) => `2026-05-0${i + 1}`),
+    rows: [
+        {workerId: '8753', cells: ['D', 'N', 'O', 'E', 'D']},
+        {workerId: '8754', cells: ['E', 'D', 'D', 'N', 'O']},
+    ],
+    workerMeta: {
+        8753: {name: 'Kim', nurseId: 3414},
+        8754: {name: 'Lee', nurseId: 3415},
+    },
+    fixedCells: {},
+    requestCells: {},
+};
+
+describe('aiValidationToViolations', () => {
+    it('maps nurse-specific soft violations to warning level with nurse row', () => {
+        const validation: TAiValidation = {
+            valid: false,
+            hard_constraints_violated: [],
+            soft_constraints_violated: [
+                {
+                    id: 'L2_MIN_OFF_AFTER_NIGHT:3414',
+                    severity: 'SOFT',
+                    title: '야간 후 휴무 부족',
+                    message: 'off days after night shift are insufficient',
+                    nurse_id: '3414',
+                    period: {start_day: 2, end_day: 4},
+                },
+            ],
+            warnings: [],
+        };
+
+        const violations = aiValidationToViolations(validation, doc);
+
+        expect(violations).toEqual([
+            {
+                ruleId: 'llm.L2_MIN_OFF_AFTER_NIGHT:3414',
+                message: '야간 후 휴무 부족: off days after night shift are insufficient',
+                level: 'warning',
+                scope: 'nurse',
+                cells: [
+                    {row: 0, col: 1},
+                    {row: 0, col: 2},
+                    {row: 0, col: 3},
+                ],
+            },
+        ]);
+    });
+
+    it('maps team hard violations to a single division-column overlay', () => {
+        const validation: TAiValidation = {
+            valid: false,
+            hard_constraints_violated: [
+                {
+                    id: 'L3_MIN_STAFF_SHORTAGE:E:2026-05-03',
+                    severity: 'HARD',
+                    title: '필요 인원 부족',
+                    message: 'E shift staffing is low',
+                    nurse_id: null,
+                    affected_days: [3],
+                },
+            ],
+            soft_constraints_violated: [],
+            warnings: [],
+        };
+
+        const violations = aiValidationToViolations(validation, doc);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0]).toMatchObject({
+            level: 'error',
+            scope: 'team',
+            cells: [{row: 0, col: 2}],
+        });
+    });
+});

--- a/apps/app/src/pages/make-shift/model/ai-validation-to-violations.ts
+++ b/apps/app/src/pages/make-shift/model/ai-validation-to-violations.ts
@@ -1,0 +1,99 @@
+import type {TAiConstraintViolation, TAiValidation} from '@dutying/api/ward';
+import type {TCellPos, TDutyDoc, TViolation} from '@/features/shift-editor';
+
+function formatViolationMessage(item: TAiConstraintViolation): string {
+    const title = item.title?.trim();
+
+    if (title && title !== item.message) return `${title}: ${item.message}`;
+
+    return item.message;
+}
+
+function resolveDayRange(item: TAiConstraintViolation): {startDay: number; endDay: number} | null {
+    if (item.period) {
+        return {startDay: item.period.start_day, endDay: item.period.end_day};
+    }
+
+    const days = item.affected_days;
+
+    if (!days || days.length === 0) return null;
+
+    return {startDay: Math.min(...days), endDay: Math.max(...days)};
+}
+
+function dayRangeToCells(row: number, startDay: number, endDay: number, colCount: number): TCellPos[] {
+    const cells: TCellPos[] = [];
+
+    for (let day = startDay; day <= endDay; day += 1) {
+        const col = day - 1;
+
+        if (col < 0 || col >= colCount) continue;
+
+        cells.push({row, col});
+    }
+
+    return cells;
+}
+
+function findRowIndexByNurseId(doc: TDutyDoc, nurseId: string): number | null {
+    for (let row = 0; row < doc.rows.length; row += 1) {
+        const workerId = doc.rows[row]?.workerId;
+
+        if (!workerId) continue;
+
+        const meta = doc.workerMeta[workerId];
+
+        if (workerId === nurseId || String(meta?.nurseId ?? '') === nurseId) return row;
+    }
+
+    return null;
+}
+
+function toViolation(
+    item: TAiConstraintViolation,
+    level: TViolation['level'],
+    cells: TCellPos[],
+): TViolation | null {
+    if (cells.length === 0) return null;
+
+    return {
+        ruleId: `llm.${item.id}`,
+        message: formatViolationMessage(item),
+        level,
+        cells,
+        scope: 'nurse',
+    };
+}
+
+function violationFromApiItem(doc: TDutyDoc, item: TAiConstraintViolation, level: TViolation['level']): TViolation[] {
+    const range = resolveDayRange(item);
+
+    if (!range) return [];
+
+    const nurseId = item.nurse_id?.trim();
+
+    if (nurseId) {
+        const row = findRowIndexByNurseId(doc, nurseId);
+
+        if (row === null) return [];
+
+        const cells = dayRangeToCells(row, range.startDay, range.endDay, doc.columns.length);
+        const violation = toViolation(item, level, cells);
+
+        return violation ? [violation] : [];
+    }
+
+    const cells = dayRangeToCells(0, range.startDay, range.endDay, doc.columns.length);
+    const violation = toViolation(item, level, cells);
+
+    if (!violation) return [];
+
+    return [{...violation, scope: 'team'}];
+}
+
+export function aiValidationToViolations(validation: TAiValidation, doc: TDutyDoc): TViolation[] {
+    const hard = validation.hard_constraints_violated.flatMap((item) => violationFromApiItem(doc, item, 'error'));
+    const soft = validation.soft_constraints_violated.flatMap((item) => violationFromApiItem(doc, item, 'warning'));
+
+    return [...hard, ...soft];
+}

--- a/apps/app/src/pages/make-shift/ui/make-shift-step-nav.ts
+++ b/apps/app/src/pages/make-shift/ui/make-shift-step-nav.ts
@@ -2,4 +2,4 @@
  * 근무표 만들기 — 이전/다음 공통 높이·패딩·타이포 (narrow intro, 신청 탭 헤더, 고정 근무 툴바).
  */
 export const MAKE_SHIFT_STEP_NAV_BUTTON_CLASS =
-    'h-[clamp(30px,2.5vw,42px)] rounded-[clamp(8px,0.7vw,10px)] px-[clamp(12px,1.0vw,20px)] text-[clamp(11px,0.95vw,16px)] font-semibold';
+    'box-border inline-flex h-[clamp(30px,2.5vw,42px)] items-center justify-center rounded-[clamp(8px,0.7vw,10px)] px-[clamp(12px,1.0vw,20px)] py-0 text-[clamp(11px,0.95vw,16px)] font-semibold leading-none';

--- a/apps/app/src/pages/make-shift/ui/make-shift-stepper.tsx
+++ b/apps/app/src/pages/make-shift/ui/make-shift-stepper.tsx
@@ -6,7 +6,7 @@ type TStepState = 'prev' | 'current' | 'next';
 
 const STEP_CIRCLE_BASE =
     'flex shrink-0 items-center justify-center rounded-full font-poppins font-medium leading-none size-[clamp(20px,1.6vw,26px)] text-[clamp(11px,0.85vw,14px)]';
-const STEP_LABEL_BASE = 'whitespace-nowrap font-apple text-[clamp(13px,1.05vw,18px)] leading-[1.05]';
+const STEP_LABEL_BASE = 'inline-flex items-center whitespace-nowrap font-apple text-[clamp(13px,1.05vw,18px)] leading-none';
 
 function StepCircle({state, step}: {state: TStepState; step: number}) {
     if (state === 'current') {
@@ -57,7 +57,7 @@ export function MakeShiftStepper({
                             onClick={() => clickable && onClickStep(step)}
                             data-step={step}
                             data-step-state={state}
-                            className={`make-shift-stepper__step relative flex items-center gap-[clamp(6px,0.55vw,10px)] py-[clamp(10px,0.95vw,18px)] ${
+                            className={`make-shift-stepper__step relative flex items-center gap-[clamp(6px,0.55vw,10px)] py-[clamp(10px,0.95vw,18px)] leading-none ${
                                 clickable ? 'cursor-pointer' : 'cursor-default'
                             }`}
                         >

--- a/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/ai-autofill-toolbar.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/ai-autofill-toolbar.tsx
@@ -106,9 +106,9 @@ export function AiAutofillToolbar({
                     disabled={isAiGenerating}
                     className={cn(
                         'ai-autofill-toolbar__cta ai-autofill-toolbar__cta--ai-fill',
-                        'flex shrink-0 items-center gap-[clamp(4px,0.4vw,8px)] rounded-[12px] px-[clamp(12px,1vw,18px)]',
-                        'h-[clamp(30px,2.5vw,40px)] font-apple text-[clamp(12px,0.95vw,16px)] font-semibold whitespace-nowrap text-white',
-                        'disabled:opacity-60',
+                        'box-border inline-flex shrink-0 cursor-pointer items-center justify-center gap-[clamp(4px,0.4vw,8px)] rounded-[12px] px-[clamp(12px,1vw,18px)] py-0',
+                        'h-[clamp(30px,2.5vw,40px)] font-apple text-[clamp(12px,0.95vw,16px)] leading-none font-semibold whitespace-nowrap text-white',
+                        'disabled:cursor-not-allowed disabled:opacity-60',
                     )}
                     style={{backgroundImage: 'linear-gradient(105deg, #B53DFA 0%, #663DFA 100%)'}}
                 >
@@ -122,9 +122,9 @@ export function AiAutofillToolbar({
                     disabled={!canConfirm}
                     className={cn(
                         'ai-autofill-toolbar__cta ai-autofill-toolbar__cta--confirm',
-                        'flex shrink-0 items-center justify-center rounded-[12px] bg-[#0A0F15] px-[clamp(14px,1.1vw,20px)]',
-                        'h-[clamp(30px,2.5vw,40px)] font-apple text-[clamp(12px,0.95vw,16px)] font-semibold whitespace-nowrap text-white',
-                        'disabled:opacity-50',
+                        'box-border inline-flex shrink-0 cursor-pointer items-center justify-center rounded-[12px] bg-[#0A0F15] px-[clamp(14px,1.1vw,20px)] py-0',
+                        'h-[clamp(30px,2.5vw,40px)] font-apple text-[clamp(12px,0.95vw,16px)] leading-none font-semibold whitespace-nowrap text-white',
+                        'disabled:cursor-not-allowed disabled:opacity-50',
                     )}
                 >
                     {t('page.makeShift.aiRefill.confirm')}
@@ -150,8 +150,8 @@ function ToggleChip({
             type="button"
             onClick={onClick}
             className={cn(
-                'flex shrink-0 cursor-pointer items-center gap-[clamp(3px,0.35vw,6px)] rounded-[6px] border whitespace-nowrap',
-                'h-[clamp(20px,1.7vw,26px)] px-[clamp(6px,0.55vw,10px)] font-apple text-[clamp(9px,0.72vw,12px)]',
+                'box-border inline-flex shrink-0 cursor-pointer items-center justify-center gap-[clamp(3px,0.35vw,6px)] rounded-[6px] border whitespace-nowrap',
+                'h-[clamp(20px,1.7vw,26px)] px-[clamp(6px,0.55vw,10px)] py-0 font-apple text-[clamp(9px,0.72vw,12px)] leading-none',
                 active ? 'border-gray-5 bg-white text-sub-2' : 'border-gray-5 bg-gray-6 text-sub-2.5 opacity-90',
                 className,
             )}

--- a/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
@@ -8,6 +8,7 @@ import WardAPI from '@/shared/api/ward';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import PageState from '@/shared/ui/PageState';
 import {canConfirmAiAutofill, type TAiAutofillStatus} from '../../../model/ai-autofill-state';
+import {aiValidationToViolations} from '../../../model/ai-validation-to-violations';
 import {requestAiSchedule} from '../../../model/ai-schedule-provider';
 import {useMakeShiftStore} from '../../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../../model/make-shift-use-case';
@@ -47,6 +48,7 @@ export function AiAutofill() {
         onKeyDown,
         onPasteCapture,
         violationMap,
+        teamViolations,
         focusEditor,
     } = useDutyEditorStep({onContextChanged: resetAiStatus});
     const aiRequestSeqRef = useRef(0);
@@ -130,6 +132,7 @@ export function AiAutofill() {
             }
 
             commands.applySchedule(result.response.schedule, 'ai');
+            commands.setLlmViolations(aiValidationToViolations(result.response.validation, useShiftEditorStore.getState().doc));
             setAiStatus('success');
             setHasCompletedAiFill(true);
         } finally {
@@ -183,6 +186,7 @@ export function AiAutofill() {
                     shift={dutyQuery.data}
                     doc={calendarDoc}
                     violationMap={violationMap}
+                    teamViolations={teamViolations}
                     showFaults={showFaults}
                     onCellClick={focusEditor}
                 />

--- a/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
@@ -96,6 +96,10 @@ export function AiAutofill() {
         setIsAiGenerating(true);
         setAiStatus('loading');
 
+        const progressToastId = 'make-shift-ai-fill-progress';
+
+        toast.loading(t('page.makeShift.aiRefill.progressToast'), {id: progressToastId});
+
         try {
             const result = await requestAiSchedule({
                 shiftTeamId: requestContext.shiftTeamId,
@@ -129,6 +133,8 @@ export function AiAutofill() {
             setAiStatus('success');
             setHasCompletedAiFill(true);
         } finally {
+            toast.dismiss(progressToastId);
+
             if (aiRequestSeqRef.current === requestSeq) {
                 setIsAiGenerating(false);
             }

--- a/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/ai-auto-fill/index.tsx
@@ -8,7 +8,6 @@ import WardAPI from '@/shared/api/ward';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import PageState from '@/shared/ui/PageState';
 import {canConfirmAiAutofill, type TAiAutofillStatus} from '../../../model/ai-autofill-state';
-import {aiValidationToViolations} from '../../../model/ai-validation-to-violations';
 import {requestAiSchedule} from '../../../model/ai-schedule-provider';
 import {useMakeShiftStore} from '../../../model/make-shift-store';
 import {useMakeShiftUseCase} from '../../../model/make-shift-use-case';
@@ -132,7 +131,7 @@ export function AiAutofill() {
             }
 
             commands.applySchedule(result.response.schedule, 'ai');
-            commands.setLlmViolations(aiValidationToViolations(result.response.validation, useShiftEditorStore.getState().doc));
+            commands.setScheduleValidationFromApi(result.response.validation, result.response.generation_id);
             setAiStatus('success');
             setHasCompletedAiFill(true);
         } finally {

--- a/apps/app/src/pages/make-shift/ui/steps/constraints-section-info.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/constraints-section-info.tsx
@@ -1,0 +1,48 @@
+import {useState} from 'react';
+import {InfoIcon} from '@/shared/assets/svg';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@/shared/ui/primitives/tooltip';
+
+type TConstraintSectionInfoProps = {
+    label: string;
+    ariaLabel: string;
+};
+
+export function ConstraintSectionInfo({label, ariaLabel}: TConstraintSectionInfoProps) {
+    const [pinned, setPinned] = useState(false);
+    const [hovered, setHovered] = useState(false);
+    const open = pinned || hovered;
+
+    return (
+        <Tooltip
+            open={open}
+            onOpenChange={(next) => {
+                if (pinned && !next) return;
+
+                if (!pinned) setHovered(next);
+            }}
+        >
+            <TooltipTrigger asChild>
+                <button
+                    type="button"
+                    className="make-shift-constraints__section-info-trigger bg-transparent text-sub-3 outline-none transition-colors hover:bg-transparent hover:text-gray-4 focus-visible:ring-2 focus-visible:ring-main-4 focus-visible:ring-offset-2"
+                    aria-label={ariaLabel}
+                    aria-expanded={open}
+                    onClick={() => setPinned((prev) => !prev)}
+                    onPointerEnter={() => setHovered(true)}
+                    onPointerLeave={() => setHovered(false)}
+                >
+                    <InfoIcon className="size-[clamp(13px,1.12vw,19px)] shrink-0" />
+                </button>
+            </TooltipTrigger>
+            <TooltipContent
+                side="top"
+                align="start"
+                sideOffset={6}
+                className="max-w-none whitespace-nowrap border border-gray-5 bg-white px-[clamp(10px,0.9vw,14px)] py-[clamp(6px,0.55vw,10px)] font-apple text-[clamp(11px,0.95vw,14px)] leading-none font-medium text-sub-1 shadow-md"
+                onPointerDown={(e) => e.preventDefault()}
+            >
+                {label}
+            </TooltipContent>
+        </Tooltip>
+    );
+}

--- a/apps/app/src/pages/make-shift/ui/steps/constraints-sections.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/constraints-sections.tsx
@@ -4,10 +4,10 @@ import {ChevronDown, Minus} from 'lucide-react';
 import {type ReactNode} from 'react';
 import {type TDutyRuleMeta, DUTY_RULE_META} from '@/features/shift-editor/model/duty-constraints';
 import {type TDutyRuleKey} from '@/features/shift-editor/model/types';
-import {InfoIcon, SixDotsIcon} from '@/shared/assets/svg';
+import {SixDotsIcon} from '@/shared/assets/svg';
 import {type useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import Select from '@/shared/ui/form-controls/Select';
-import {Tooltip, TooltipContent, TooltipTrigger} from '@/shared/ui/primitives/tooltip';
+import {ConstraintSectionInfo} from './constraints-section-info';
 
 type TActiveBucket = 'error' | 'warning';
 type TTypedT = ReturnType<typeof useTypedTranslation>['t'];
@@ -78,25 +78,7 @@ export function ConstraintSection({
                         >
                             <div aria-hidden className="w-full" />
                             <div className="flex min-w-0 justify-end">
-                                <Tooltip>
-                                    <TooltipTrigger asChild>
-                                        <button
-                                            type="button"
-                                            className="make-shift-constraints__section-info-trigger text-sub-3 outline-none transition-colors hover:text-gray-4 focus-visible:ring-2 focus-visible:ring-main-4 focus-visible:ring-offset-2"
-                                            aria-label={infoTooltipAria}
-                                        >
-                                            <InfoIcon className="size-[clamp(13px,1.12vw,19px)] shrink-0" />
-                                        </button>
-                                    </TooltipTrigger>
-                                    <TooltipContent
-                                        side="top"
-                                        align="start"
-                                        sideOffset={6}
-                                        className="max-w-none whitespace-nowrap border border-gray-5 bg-white px-[clamp(10px,0.9vw,14px)] py-[clamp(6px,0.55vw,10px)] font-apple text-[clamp(11px,0.95vw,14px)] leading-none font-medium text-sub-1 shadow-md"
-                                    >
-                                        {infoLabel}
-                                    </TooltipContent>
-                                </Tooltip>
+                                <ConstraintSectionInfo label={infoLabel} ariaLabel={infoTooltipAria} />
                             </div>
                         </div>
                     ) : null}
@@ -241,12 +223,13 @@ export function ConstraintBucketList({
                                                     <button
                                                         type="button"
                                                         aria-label={t('page.makeShift.constraints.excludeRuleAria')}
-                                                        className="make-shift-constraints__rule-exclude ml-[clamp(6px,0.6vw,10px)] grid size-[clamp(18px,1.55vw,26px)] shrink-0 place-items-center rounded-full border border-gray-5 bg-white text-gray-4 transition-colors hover:border-gray-4 hover:bg-gray-7 hover:text-gray-3 disabled:opacity-40"
+                                                        title={t('page.makeShift.constraints.excludeRuleAria')}
+                                                        className="make-shift-constraints__rule-exclude ml-[clamp(6px,0.6vw,10px)] grid size-[clamp(13px,1.15vw,18px)] shrink-0 place-items-center rounded-full border border-gray-5 bg-white text-gray-4 transition-colors hover:border-gray-4 hover:bg-gray-7 hover:text-gray-3 disabled:opacity-40"
                                                         disabled={disabled}
                                                         onClick={() => onExcludeRule(key)}
                                                     >
                                                         <Minus
-                                                            className="size-[clamp(10px,0.82vw,14px)] shrink-0 stroke-[1.85]"
+                                                            className="size-[clamp(7px,0.65vw,10px)] shrink-0 stroke-[1.85]"
                                                             aria-hidden
                                                         />
                                                     </button>

--- a/apps/app/src/pages/make-shift/ui/steps/constraints.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/constraints.tsx
@@ -14,15 +14,8 @@ export function Constraints() {
     const editor = useShiftEditorCommands();
     const dutyValidationInput = useShiftEditorStore((s) => s.dutyValidationInput);
     const board = useShiftEditorStore((s) => s.dutyRuleBoard);
-    const violations = useShiftEditorStore((s) => s.violations);
     const [open, setOpen] = useState<{error: boolean; warning: boolean}>({error: false, warning: true});
-    const ruleViolationCount = useMemo(() => {
-        const map = new Map<string, number>();
-
-        for (const v of violations) map.set(v.ruleId, (map.get(v.ruleId) ?? 0) + 1);
-
-        return map;
-    }, [violations]);
+    const ruleViolationCount = useMemo(() => new Map<string, number>(), []);
     const onDragEnd = (result: DropResult) => {
         if (!board) return;
 

--- a/apps/app/src/pages/make-shift/ui/steps/requests-shifts.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/requests-shifts.tsx
@@ -12,7 +12,7 @@ export function RequestsShifts() {
     const useCase = useMakeShiftUseCase();
     const canPrev = useMakeShiftStore((s) => canGoPrev(s));
     const canNext = useMakeShiftStore((s) => canGoNext(s));
-    const {dutyQuery, editorDoc, violationMap} = useDutyEditorStep();
+    const {dutyQuery, editorDoc, violationMap, teamViolations} = useDutyEditorStep();
     const {
         state: {acceptedRequests, pendingRequests, rejectedRequests, wardShiftTypeMap},
         status: {loading: requestsLoading, error: requestsError, updatingRequestId},

--- a/apps/app/src/pages/make-shift/ui/steps/shared/__tests__/format-nurse-display-name.test.ts
+++ b/apps/app/src/pages/make-shift/ui/steps/shared/__tests__/format-nurse-display-name.test.ts
@@ -1,0 +1,14 @@
+import {describe, expect, it} from 'vitest';
+import {formatNurseDisplayName} from '../format-nurse-display-name';
+
+describe('formatNurseDisplayName', () => {
+    it('4자 이하면 그대로 반환한다', () => {
+        expect(formatNurseDisplayName('김민')).toBe('김민');
+        expect(formatNurseDisplayName('홍길동')).toBe('홍길동');
+    });
+
+    it('4자 초과면 4자 + 말줄임을 반환한다', () => {
+        expect(formatNurseDisplayName('박서연지희')).toBe('박서연지…');
+        expect(formatNurseDisplayName('  김철수영희  ')).toBe('김철수영…');
+    });
+});

--- a/apps/app/src/pages/make-shift/ui/steps/shared/format-nurse-display-name.ts
+++ b/apps/app/src/pages/make-shift/ui/steps/shared/format-nurse-display-name.ts
@@ -1,0 +1,8 @@
+/** 근무표·근무자 목록 등에서 표시용 이름 (4자 초과 시 말줄임). */
+export function formatNurseDisplayName(name: string, maxChars = 4): string {
+    const trimmed = name.trim();
+
+    if (trimmed.length <= maxChars) return trimmed;
+
+    return `${trimmed.slice(0, maxChars)}…`;
+}

--- a/apps/app/src/pages/make-shift/ui/steps/shared/make-shift-calendar.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/shared/make-shift-calendar.tsx
@@ -6,6 +6,7 @@ import ShiftBadge from '@/entities/shift/ui/shift-badge';
 import {useUIConfigStore} from '@/entities/ui/useUIConfig/store';
 import {type TDutyDoc, type TViolation, useShiftEditorCommands, useShiftEditorStore} from '@/features/shift-editor/model';
 import {normalizeSelection} from '@/features/shift-editor/model/selection';
+import {formatNurseDisplayName} from './format-nurse-display-name';
 
 type TViolationMap = Map<string, TViolation>;
 
@@ -81,6 +82,8 @@ const SUMMARY_GAP = 'clamp(2px,0.22cqw,6px)';
  */
 const SUMMARY_CELL_HEIGHT = 'h-[clamp(16px,1.4cqw,22px)]';
 const SUMMARY_CELL_WIDTH = 'w-[clamp(14px,1.05cqw,18px)]';
+/** 우측 row-summary 행 · footer daily-summary 행 공통 높이 */
+const ROW_SUMMARY_HEIGHT = 'h-[clamp(28px,2.4cqw,40px)]';
 /** row-summary 우측 합계 숫자 · daily-summary 일자별 셀 — 동일 글자 크기·색 */
 const SUMMARY_COUNT_TEXT_CLASS = 'font-poppins text-[clamp(12px,1.02cqw,18px)] leading-none text-gray-4 tabular-nums';
 /**
@@ -114,7 +117,9 @@ const DIVISION_PADDING_Y = '0px';
  *   - SHIFT_BADGE_SMALL_BASE: division-card 전달 근무 4칸 — LAST_COL 안에 들어가도록 size 상한 유지, 글자는 leading-none·큰 text.
  *   - SHIFT_BADGE_SUMMARY_ROW: daily-summary__label-badge(D/E/N pill) 전용.
  */
-const SHIFT_BADGE_SUMMARY_ROW = 'shrink-0 size-[clamp(26px,2.75cqw,44px)] text-[clamp(13px,1.12cqw,22px)] rounded-[clamp(4px,0.52cqw,9px)]';
+/** footer daily-summary D/E/N pill — row-summary 숫자 셀(SUMMARY_CELL_*)과 동일 스케일, 행 안에서 중앙 정렬 */
+const SHIFT_BADGE_SUMMARY_ROW =
+    'shrink-0 size-[clamp(16px,1.4cqw,22px)] text-[clamp(10px,0.82cqw,14px)] leading-none rounded-[clamp(3px,0.35cqw,6px)]';
 /** 일자 그리드 셀 래퍼: 한 변 = min(셀 안쪽 폭, cqw 기반 clamp 상한). */
 const SHIFT_BADGE_CELL_WRAP =
     'make-shift-calendar__shift-badge-wrap flex aspect-square w-[min(100%,clamp(22px,2.35cqw,38px))] max-h-[clamp(22px,2.35cqw,38px)] min-w-0 shrink-0 items-center justify-center';
@@ -128,18 +133,11 @@ const SHIFT_BADGE_CELL_BADGE =
 const SHIFT_BADGE_SMALL_BASE =
     'shrink-0 size-[clamp(14px,1.2cqw,22px)] text-[clamp(10px,0.92cqw,15px)] leading-none rounded-[clamp(3px,0.35cqw,6px)]';
 /**
- * daily-summary는 D/E/N이 gap=0 으로 빽빽이 붙기 때문에,
- * 중간 행은 모서리 없음 / 첫 행은 위쪽만 / 마지막 행은 아래쪽만 round 되어야
- * 하나의 알약(pill)처럼 보인다.
+ * footer daily-summary 행 높이 — 배지·숫자 셀(SUMMARY_CELL_HEIGHT)에 맞춤.
+ * row-summary 본문 행(28–40px)과 달리 footer는 콤팩트하게 두고,
+ * D/E/N 행 사이 세로 간격만 SUMMARY_GAP(우측 합계 열 가로 gap)으로 맞춘다.
  */
-const SHIFT_BADGE_ROUNDED_TOP_ONLY = 'rounded-none rounded-t-[clamp(4px,0.52cqw,9px)]';
-const SHIFT_BADGE_ROUNDED_BOTTOM_ONLY = 'rounded-none rounded-b-[clamp(4px,0.52cqw,9px)]';
-const SHIFT_BADGE_ROUNDED_NONE = 'rounded-none';
-/**
- * 배지와 동일한 height 만 갖는 클래스 (daily-summary에서 행 높이를 배지에 정확히 맞추기 위해 사용).
- * SHIFT_BADGE_SIZE의 size = width + height 중 height만 분리한 값.
- */
-const DAILY_SUMMARY_ROW_HEIGHT = 'h-[clamp(26px,2.75cqw,44px)]';
+const DAILY_SUMMARY_ROW_HEIGHT = SUMMARY_CELL_HEIGHT;
 /**
  * 이월 박스의 round.
  */
@@ -535,8 +533,11 @@ function CalendarRowLeft({
                     columnGap: ROW_GAP_X,
                 }}
             >
-                <div className="make-shift-calendar__row-name flex min-h-0 min-w-0 items-center justify-center truncate font-apple text-[clamp(12px,1.05cqw,16px)] leading-none text-sub-1">
-                    {nurseName}
+                <div
+                    className="make-shift-calendar__row-name flex min-h-0 min-w-0 items-center justify-center truncate whitespace-nowrap text-center font-apple text-[clamp(12px,1.05cqw,16px)] leading-none text-sub-1"
+                    title={nurseName}
+                >
+                    {formatNurseDisplayName(nurseName)}
                 </div>
 
                 {!simplified && (
@@ -732,7 +733,7 @@ function CalendarRowSummary({cells, days, shortNameToType, countedTypes, offType
 
     return (
         <div
-            className="make-shift-calendar__row-summary flex h-[clamp(28px,2.4cqw,40px)] shrink-0 items-center"
+            className={cn('make-shift-calendar__row-summary flex shrink-0 items-center', ROW_SUMMARY_HEIGHT)}
             style={{gap: SUMMARY_GAP, paddingInline: SUMMARY_PADDING_X}}
         >
             {countedTypes.map((t) => (
@@ -786,68 +787,44 @@ function DailySummary({shift, doc, shortNameToType}: {shift: TShift; doc: TDutyD
         // body division과 동일한 좌(card-area 폭) / 우(row-summary 폭) 분리 구조를 유지해서
         // 라벨(D/E/N)과 일자별 숫자가 위쪽 헤더·body의 일자 컬럼과 정확히 정렬된다.
         //
-        // 행 사이 여백은 사진처럼 거의 0으로 두고 (D/E/N이 빽빽하게 붙음),
-        // 각 행의 높이는 배지 크기와 동일하게 두어 위/아래 패딩이 생기지 않게 한다.
+        // 행 높이는 배지·숫자에 맞추고, 행 간 세로 gap만 row-summary 가로 gap(SUMMARY_GAP)과 동일.
         <div
-            className="make-shift-daily-summary mt-[clamp(6px,0.5cqw,12px)] flex w-full min-w-0 items-stretch"
+            className="make-shift-daily-summary mt-[clamp(4px,0.35cqw,8px)] flex w-full min-w-0 items-stretch"
             style={{gap: DIVISION_TO_SUMMARY_GAP}}
         >
             <div
-                className="make-shift-daily-summary__rows flex min-w-0 flex-1 flex-col gap-0"
+                className="make-shift-daily-summary__rows flex min-w-0 flex-1 flex-col"
                 // body division-card와 동일한 수평 인셋(좌만, 일자는 우측까지)으로 컬럼 정렬.
-                style={{paddingLeft: DIVISION_PADDING_X, paddingRight: 0}}
+                // 행 간 세로 gap = row-summary 열 간 가로 gap(SUMMARY_GAP).
+                style={{paddingLeft: DIVISION_PADDING_X, paddingRight: 0, gap: SUMMARY_GAP}}
             >
-                {counted.map((type, index) => {
-                    const isFirst = index === 0;
-                    const isLast = index === counted.length - 1;
-                    /*
-                     * 행이 gap=0 으로 빽빽이 붙어있으니, 인접한 배지 모서리는 사각으로 두고
-                     * 위·아래 끝만 round를 줘서 전체가 하나의 알약처럼 보이게 한다.
-                     * - 단일 행(D만 있는 경우)은 양쪽 다 round.
-                     */
-                    /*
-                     * SHIFT_BADGE_SUMMARY_ROW에 이미 `rounded-[clamp(...)]`이 포함되어 있지만,
-                     * 첫/마지막/중간 행에 따라 다른 round를 줘야 하므로 여기서 override 한다.
-                     * cn() → twMerge가 같은 카테고리(rounded-*) 내에서 마지막 값을 유효하게 처리.
-                     */
-                    const labelRoundedClass =
-                        isFirst && isLast
-                            ? '' // SHIFT_BADGE_SUMMARY_ROW의 기본 rounded 그대로 사용
-                            : isFirst
-                              ? SHIFT_BADGE_ROUNDED_TOP_ONLY
-                              : isLast
-                                ? SHIFT_BADGE_ROUNDED_BOTTOM_ONLY
-                                : SHIFT_BADGE_ROUNDED_NONE;
-
+                {counted.map((type) => {
                     return (
                         <div
                             key={type.wardShiftTypeId}
                             data-shift-type-id={type.wardShiftTypeId}
-                            className="make-shift-daily-summary__row grid w-full min-w-0 items-center"
+                            className={cn(
+                                'make-shift-daily-summary__row grid w-full min-w-0 items-center',
+                                DAILY_SUMMARY_ROW_HEIGHT,
+                            )}
                             style={{gridTemplateColumns: LEFT_GRID_TEMPLATE_COLUMNS, columnGap: ROW_GAP_X}}
                         >
                             <div />
                             <div />
-                            {/*
-                             * D/E/N 배지: 사진처럼 인접 배지가 붙어있는 알약(pill) 형태.
-                             * 모양/크기/컬러 스타일은 셀 배지와 동일하지만, round만 위치별로 다르게 준다.
-                             * 위치는 last-shift 컬럼 안에서 "우측 끝"에 정렬 → 일자 영역 시작점 직전에 붙음.
-                             */}
-                            <div className="make-shift-daily-summary__label flex justify-end">
+                            <div className="make-shift-daily-summary__label flex items-center justify-end">
                                 <ShiftBadge
                                     shiftType={type}
-                                    className={cn('make-shift-daily-summary__label-badge', SHIFT_BADGE_SUMMARY_ROW, labelRoundedClass)}
+                                    className={cn('make-shift-daily-summary__label-badge', SHIFT_BADGE_SUMMARY_ROW)}
                                 />
                             </div>
                             <div
-                                className={cn('make-shift-daily-summary__cells', 'grid min-w-0 px-0', DAILY_SUMMARY_ROW_HEIGHT)}
+                                className="make-shift-daily-summary__cells grid h-full min-w-0 items-center px-0"
                                 style={{gridTemplateColumns: `repeat(${doc.columns.length}, minmax(0, 1fr))`}}
                             >
                                 {doc.columns.map((_d, j) => (
                                     <div
                                         key={j}
                                         data-day-index={j}
-                                        // 행 높이(DAILY_SUMMARY_ROW_HEIGHT)는 라벨 배지와 맞춤.
                                         className={cn(
                                             'make-shift-daily-summary__cell grid h-full min-w-0 place-items-center',
                                             SUMMARY_COUNT_TEXT_CLASS,

--- a/apps/app/src/pages/make-shift/ui/steps/shared/make-shift-calendar.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/shared/make-shift-calendar.tsx
@@ -14,6 +14,7 @@ type TMakeShiftCalendarProps = {
     shift: TShift;
     doc: TDutyDoc;
     violationMap: TViolationMap;
+    teamViolations?: TViolation[];
     showFaults: boolean;
     /**
      * default: 이름·이월·전달·일자·우측 행 합계·하단 일자별 통계.
@@ -121,10 +122,11 @@ const DIVISION_PADDING_Y = '0px';
 const SHIFT_BADGE_SUMMARY_ROW =
     'shrink-0 size-[clamp(16px,1.4cqw,22px)] text-[clamp(10px,0.82cqw,14px)] leading-none rounded-[clamp(3px,0.35cqw,6px)]';
 /** 일자 그리드 셀 래퍼: 한 변 = min(셀 안쪽 폭, cqw 기반 clamp 상한). */
+/** violation 오버레이(z-[5]~[8])보다 위 — 배지 배경색이 위반 하이라이트에 가리지 않도록 */
 const SHIFT_BADGE_CELL_WRAP =
-    'make-shift-calendar__shift-badge-wrap flex aspect-square w-[min(100%,clamp(22px,2.35cqw,38px))] max-h-[clamp(22px,2.35cqw,38px)] min-w-0 shrink-0 items-center justify-center';
+    'make-shift-calendar__shift-badge-wrap relative z-[20] flex aspect-square w-[min(100%,clamp(22px,2.35cqw,38px))] max-h-[clamp(22px,2.35cqw,38px)] min-w-0 shrink-0 items-center justify-center';
 const SHIFT_BADGE_CELL_BADGE =
-    'make-shift-calendar__shift-badge !h-full !w-full min-h-0 min-w-0 rounded-[clamp(4px,0.52cqw,9px)] text-[clamp(12px,1.15cqw,21px)] leading-none';
+    'make-shift-calendar__shift-badge relative z-[20] !h-full !w-full min-h-0 min-w-0 rounded-[clamp(4px,0.52cqw,9px)] text-[clamp(12px,1.15cqw,21px)] leading-none';
 /**
  * 전달 근무 컬럼(LAST_COL)에 4개가 동시에 들어가는 좁은 영역용 배지.
  * 큰 화면에서도 LAST_COL을 넘지 않도록 max를 22px로 제한.
@@ -143,10 +145,82 @@ const DAILY_SUMMARY_ROW_HEIGHT = SUMMARY_CELL_HEIGHT;
  */
 const CARRY_ROUNDED = 'rounded-[clamp(3px,0.35cqw,6px)]';
 
+function getDaysAreaInsetLeft(simplified: boolean): string {
+    if (simplified) {
+        return `calc(${DIVISION_PADDING_X} + ${NAME_COL} + ${ROW_GAP_X})`;
+    }
+
+    return `calc(${DIVISION_PADDING_X} + ${NAME_COL} + ${ROW_GAP_X} + ${CARRY_COL} + ${ROW_GAP_X} + ${LAST_COL} + ${ROW_GAP_X})`;
+}
+
+function getViolationColSpan(violation: TViolation): {startCol: number; span: number} {
+    const cols = violation.cells.map((cell) => cell.col);
+    const startCol = Math.min(...cols);
+    const endCol = Math.max(...cols);
+
+    return {startCol, span: endCol - startCol + 1};
+}
+
+type TDivisionTeamViolationOverlayProps = {
+    violations: TViolation[];
+    dayCount: number;
+    rowCount: number;
+    simplified: boolean;
+};
+
+function DivisionTeamViolationOverlay({violations, dayCount, rowCount, simplified}: TDivisionTeamViolationOverlayProps) {
+    if (violations.length === 0 || rowCount === 0) return null;
+
+    return (
+        <div
+            className="make-shift-calendar__team-violations pointer-events-none absolute right-0 z-[4] grid"
+            style={{
+                left: getDaysAreaInsetLeft(simplified),
+                top: 0,
+                bottom: 0,
+                paddingTop: DIVISION_PADDING_Y,
+                paddingBottom: DIVISION_PADDING_Y,
+                gridTemplateColumns: `repeat(${dayCount}, minmax(0, 1fr))`,
+                gridTemplateRows: `repeat(${rowCount}, clamp(28px, 2.4cqw, 40px))`,
+            }}
+        >
+            {violations.map((violation) => {
+                const {startCol, span} = getViolationColSpan(violation);
+                const style = VIOLATION_STYLE[violation.level];
+
+                return (
+                    <span
+                        key={violation.ruleId}
+                        aria-label={violation.message}
+                        title={violation.message}
+                        data-violation-level={violation.level}
+                        data-violation-scope="team"
+                        style={{
+                            gridColumn: `${startCol + 1} / span ${span}`,
+                            gridRow: '1 / -1',
+                            borderColor: style.border,
+                            backgroundColor: style.background,
+                            margin: VIOLATION_INSET,
+                        }}
+                        className={cn(
+                            'make-shift-calendar__violation',
+                            `make-shift-calendar__violation--${violation.level}`,
+                            'make-shift-calendar__violation--team',
+                            'rounded-[clamp(5px,0.55cqw,8px)] border-[1.5px]',
+                            violation.level === 'error' ? 'z-[6]' : 'z-[5]',
+                        )}
+                    />
+                );
+            })}
+        </div>
+    );
+}
+
 export function MakeShiftCalendar({
     shift,
     doc,
     violationMap,
+    teamViolations = [],
     showFaults,
     variant = 'default',
     onCellClick,
@@ -330,7 +404,15 @@ export function MakeShiftCalendar({
                              * 카드 상·하만 DIVISION_PADDING_Y(첫·끝 행 래퍼). 좌는 이름 열만 인셋, 일자는 우측까지.
                              * 행 그리드는 items-stretch → 주말 셀이 행 높이 전체를 칠함(행 안에서 잘리지 않음).
                              */}
-                            <div className="make-shift-calendar__division-card flex min-w-0 flex-1 flex-col overflow-hidden rounded-[clamp(14px,1.2cqw,20px)] bg-white shadow-banner">
+                            <div className="make-shift-calendar__division-card relative flex min-w-0 flex-1 flex-col overflow-hidden rounded-[clamp(14px,1.2cqw,20px)] bg-white shadow-banner">
+                                {showFaults && teamViolations.length > 0 && (
+                                    <DivisionTeamViolationOverlay
+                                        violations={teamViolations}
+                                        dayCount={shift.days.length}
+                                        rowCount={rows.length}
+                                        simplified={isSimplified}
+                                    />
+                                )}
                                 {rows.map((row, i) => {
                                     const workerId = String(row.shiftNurse.shiftNurseId);
                                     const docEntry = workerRowMap.get(workerId);
@@ -467,30 +549,36 @@ function CalendarRowLeft({
 }: TCalendarRowLeftProps) {
     const [violationTip, setViolationTip] = useState<{message: string; left: number; top: number} | null>(null);
     const [hoveredViolationKey, setHoveredViolationKey] = useState<string | null>(null);
-    const violationByDayCol = useMemo(() => {
-        const byCol = new Map<number, TViolation>();
+    const rowViolationPrefix = `${shiftNurseId},`;
+    const violationsByDayCol = useMemo(() => {
+        const byCol = new Map<number, TViolation[]>();
 
-        for (const v of violations.values()) {
+        for (const [key, v] of violations) {
+            if (!key.startsWith(rowViolationPrefix)) continue;
+
             for (const c of v.cells) {
                 if (c.row !== rowIndex) continue;
 
-                const prev = byCol.get(c.col);
+                const list = byCol.get(c.col) ?? [];
 
-                if (!prev || VIOLATION_LEVEL_PRIORITY[v.level] > VIOLATION_LEVEL_PRIORITY[prev.level]) {
-                    byCol.set(c.col, v);
-                }
+                list.push(v);
+                byCol.set(c.col, list);
             }
         }
 
         return byCol;
-    }, [violations, rowIndex]);
+    }, [violations, rowIndex, rowViolationPrefix]);
     const violationSpanList = useMemo(() => {
         const list: {startCol: number; violation: TViolation}[] = [];
 
-        for (let j = 0; j < days.length; j += 1) {
-            const violation = violations.get(`${shiftNurseId},${j}`);
+        for (const [key, v] of violations) {
+            if (!key.startsWith(rowViolationPrefix)) continue;
 
-            if (violation) list.push({startCol: j, violation});
+            const startCol = v.cells[0]?.col;
+
+            if (startCol === undefined) continue;
+
+            list.push({startCol, violation: v});
         }
 
         list.sort((a, b) => {
@@ -502,7 +590,15 @@ function CalendarRowLeft({
         });
 
         return list;
-    }, [days, shiftNurseId, violations]);
+    }, [rowViolationPrefix, violations]);
+    const violationTipMessage = (items: TViolation[] | undefined) => items?.map((v) => v.message).join('\n\n');
+    const primaryViolation = (items: TViolation[] | undefined) => {
+        if (!items || items.length === 0) return undefined;
+
+        return [...items].sort(
+            (a, b) => VIOLATION_LEVEL_PRIORITY[b.level] - VIOLATION_LEVEL_PRIORITY[a.level],
+        )[0];
+    };
     const showViolationTipFromTarget = (target: HTMLButtonElement, v: TViolation) => {
         const r = target.getBoundingClientRect();
 
@@ -512,7 +608,7 @@ function CalendarRowLeft({
         if (!showFaults || !v) return;
 
         showViolationTipFromTarget(e.currentTarget, v);
-        setHoveredViolationKey(`${shiftNurseId},${v.cells[0]!.col}`);
+        setHoveredViolationKey(`${shiftNurseId},${v.cells[0]!.col},${v.ruleId}`);
     };
     const getCellShiftType = (j: number): TWardShiftType | null => {
         const cell = cells[j];
@@ -577,7 +673,9 @@ function CalendarRowLeft({
                         const shiftType = getCellShiftType(j);
                         const reqId = wardReqShiftList[j] ?? null;
                         const reqType = reqId != null ? idToType.get(reqId) : null;
-                        const cellViolation = showFaults ? violationByDayCol.get(j) : undefined;
+                        const cellViolationList = showFaults ? violationsByDayCol.get(j) : undefined;
+                        const cellViolation = primaryViolation(cellViolationList);
+                        const cellViolationTitle = violationTipMessage(cellViolationList);
                         const weekendBg =
                             day.dayType === 'saturday'
                                 ? separateWeekendColor
@@ -604,9 +702,16 @@ function CalendarRowLeft({
                                 data-violation-rule={cellViolation?.ruleId}
                                 onClick={() => onCellClick?.(rowIndex, j)}
                                 onMouseEnter={(e) => {
-                                    if (!cellViolation) setHoveredViolationKey(null);
+                                    if (!cellViolation) {
+                                        setHoveredViolationKey(null);
 
-                                    onViolationTipPointer(e, cellViolation);
+                                        return;
+                                    }
+
+                                    onViolationTipPointer(e, {
+                                        ...cellViolation,
+                                        message: cellViolationTitle ?? cellViolation.message,
+                                    });
                                 }}
                                 onMouseLeave={() => {
                                     setViolationTip(null);
@@ -615,18 +720,23 @@ function CalendarRowLeft({
                                 onFocus={(e) => {
                                     if (!showFaults || !cellViolation) return;
 
-                                    showViolationTipFromTarget(e.currentTarget, cellViolation);
-                                    setHoveredViolationKey(`${shiftNurseId},${cellViolation.cells[0]!.col}`);
+                                    showViolationTipFromTarget(e.currentTarget, {
+                                        ...cellViolation,
+                                        message: cellViolationTitle ?? cellViolation.message,
+                                    });
+                                    if (cellViolation) {
+                                        setHoveredViolationKey(`${shiftNurseId},${cellViolation.cells[0]!.col},${cellViolation.ruleId}`);
+                                    }
                                 }}
                                 onBlur={() => {
                                     setViolationTip(null);
                                     setHoveredViolationKey(null);
                                 }}
-                                title={cellViolation?.message}
+                                title={cellViolationTitle}
                                 style={{gridRow: 1, gridColumn: j + 1, paddingInline: DAY_CELL_PADDING_X}}
                                 className={cn(
                                     'make-shift-calendar__day-cell',
-                                    'group relative z-[1] flex h-full min-w-0 items-center justify-center',
+                                    'group relative z-[10] flex h-full min-w-0 items-center justify-center',
                                     cellViolation ? 'cursor-help' : readonly ? 'cursor-default' : 'cursor-pointer',
                                     weekendBg,
                                 )}
@@ -652,13 +762,13 @@ function CalendarRowLeft({
                         violationSpanList.map(({startCol, violation: v}) => {
                             const span = Math.max(1, v.cells.length);
                             const style = VIOLATION_STYLE[v.level];
-                            const vioKey = `${shiftNurseId},${startCol}`;
+                            const vioKey = `${shiftNurseId},${startCol},${v.ruleId}`;
                             const isHovered = hoveredViolationKey === vioKey;
-                            const zByLevel = v.level === 'error' ? 'z-[32]' : 'z-[22]';
+                            const zByLevel = v.level === 'error' ? 'z-[6]' : 'z-[5]';
 
                             return (
                                 <span
-                                    key={`vio-${startCol}`}
+                                    key={`vio-${v.ruleId}-${startCol}`}
                                     aria-label={v.message}
                                     title={v.message}
                                     data-violation-level={v.level}
@@ -677,7 +787,7 @@ function CalendarRowLeft({
                                         `make-shift-calendar__violation--${v.level}`,
                                         'pointer-events-none rounded-[clamp(5px,0.55cqw,8px)] border-[1.5px]',
                                         zByLevel,
-                                        isHovered && 'z-[42]',
+                                        isHovered && 'z-[8]',
                                     )}
                                 />
                             );

--- a/apps/app/src/pages/make-shift/ui/steps/shared/use-duty-editor-step.ts
+++ b/apps/app/src/pages/make-shift/ui/steps/shared/use-duty-editor-step.ts
@@ -90,7 +90,7 @@ export function useDutyEditorStep({onContextChanged}: TUseDutyEditorStepOptions 
     const editorRef = useRef<HTMLDivElement>(null);
     const workKeyMap = useMemo(() => buildWorkKeyMap(dutyQuery.data), [dutyQuery.data]);
     const {onKeyDown, onPasteCapture} = useShiftEditorKeyBindings({workKeyMap});
-    const violationMap = useViolationMap(editorDoc);
+    const {violationMap, teamViolations} = useViolationMap(editorDoc);
     const hydratedContextKeyRef = useRef<string | null>(null);
     const initialHydrationDoneRef = useRef(false);
     const lastHydratedDutyDataRef = useRef<typeof dutyQuery.data | null>(null);
@@ -188,6 +188,7 @@ export function useDutyEditorStep({onContextChanged}: TUseDutyEditorStepOptions 
         onKeyDown,
         onPasteCapture,
         violationMap,
+        teamViolations,
         focusEditor,
     };
 }

--- a/apps/app/src/pages/make-shift/ui/steps/workers-sections.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/workers-sections.tsx
@@ -4,6 +4,7 @@ import {type TNurse} from '@/entities';
 import SkillBadge from '@/features/ward-skill/ui/skill-badge';
 import {type TGroupedDivisionNurses} from '@/pages/member/model/shift-team-list';
 import {SixDotsIcon} from '@/shared/assets/svg';
+import {formatNurseDisplayName} from './shared/format-nurse-display-name';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 
 const SHIFT_TYPE_STYLE: Record<string, {bg: string; text: string}> = {
@@ -149,8 +150,11 @@ function WorkerRow({nurse, index, level, skillConfig}: TWorkerRowProps) {
                         >
                             <SixDotsIcon className="size-[clamp(14px,1.35vw,20px)]" />
                         </button>
-                        <p className="make-shift-workers__row-name font-apple text-[clamp(12px,1.1vw,18px)] font-medium text-sub-1">
-                            {nurse.name}
+                        <p
+                            className="make-shift-workers__row-name min-w-0 truncate whitespace-nowrap text-center font-apple text-[clamp(12px,1.1vw,18px)] font-medium text-sub-1"
+                            title={nurse.name}
+                        >
+                            {formatNurseDisplayName(nurse.name)}
                         </p>
                         <div className="make-shift-workers__row-level flex justify-center">
                             {/*

--- a/apps/app/src/pages/onboarding-ward-create/__tests__/index.test.tsx
+++ b/apps/app/src/pages/onboarding-ward-create/__tests__/index.test.tsx
@@ -47,6 +47,16 @@ vi.mock('@/features/register', () => ({
     }),
 }));
 
+vi.mock('@/features/auth', () => ({
+    default: () => ({
+        state: {
+            accountMe: {
+                status: 'WARD_SELECT_PENDING',
+            },
+        },
+    }),
+}));
+
 vi.mock('@/shared/hook/use-typed-translation', () => ({
     useTypedTranslation: () => ({
         t: (key: string, values?: Record<string, string | number>) => {

--- a/apps/app/src/pages/onboarding-ward-create/index.tsx
+++ b/apps/app/src/pages/onboarding-ward-create/index.tsx
@@ -1,4 +1,6 @@
+import {useEffect} from 'react';
 import {useNavigate} from 'react-router';
+import useAuth from '@/features/auth';
 import ROUTE from '@/shared/constant/path';
 import Card from '@/shared/ui/Card';
 import {useOnboardingWardWizard} from './model';
@@ -13,6 +15,9 @@ import WizardButton from './ui/wizard-button';
 
 function OnboardingWardCreatePage() {
     const navigate = useNavigate();
+    const {
+        state: {accountMe},
+    } = useAuth();
     const {
         draft,
         activeTeamId,
@@ -44,6 +49,13 @@ function OnboardingWardCreatePage() {
     } = useOnboardingWardWizard();
     const isSubmitting = submissionStatus === 'submitting';
     const isSuccess = submissionStatus === 'success';
+
+    useEffect(() => {
+        if (accountMe && accountMe.status !== 'WARD_SELECT_PENDING') {
+            navigate(ROUTE.REGISTER);
+        }
+    }, [accountMe, navigate]);
+
     const stepContent = (() => {
         switch (draft.currentStep) {
             case 1:

--- a/apps/app/src/pages/register/ui/enter-ward.tsx
+++ b/apps/app/src/pages/register/ui/enter-ward.tsx
@@ -145,13 +145,13 @@ function EnterWard() {
                                               setCodeList([null, null, null, null, null, null]);
                                               setOpen(false);
                                           }}
-                                          className="h-17.5 flex-1 rounded-[.625rem] bg-sub-4 font-apple text-[1.5rem] font-semibold text-sub-2"
+                                          className="box-border h-17.5 flex-1 rounded-[.625rem] bg-sub-4 py-0 font-apple text-[1.5rem] leading-none font-semibold text-sub-2"
                                       >
                                           다시 입력
                                       </button>
                                       <button
                                           onClick={() => ward && enterWard(ward.wardId)}
-                                          className="h-17.5 flex-1 rounded-[.625rem] bg-main-1 font-apple text-[1.5rem] font-semibold text-white"
+                                          className="box-border h-17.5 flex-1 rounded-[.625rem] bg-main-1 py-0 font-apple text-[1.5rem] leading-none font-semibold text-white"
                                       >
                                           입장
                                       </button>

--- a/apps/app/src/pages/register/ui/select-enter-or-create.tsx
+++ b/apps/app/src/pages/register/ui/select-enter-or-create.tsx
@@ -22,7 +22,7 @@ function SelectEnterOrCreate() {
             <div className="flex w-full gap-7.5">
                 <div
                     className="group flex-1 cursor-pointer rounded-[.9375rem] bg-white p-[1.875rem_1.25rem_1.25rem_1.875rem] shadow-banner hover:bg-main-1"
-                    onClick={() => naviagte(ROUTE.REGISTER_WARD)}
+                    onClick={() => naviagte(ROUTE.ONBOARDING_WARD_CREATE)}
                 >
                     <h2 className="font-apple text-[1.75rem] font-bold text-main-1 group-hover:text-white">병동 생성</h2>
                     <p className="font-apple text-[1rem] text-main-2 group-hover:text-main-4">병동을 새로 생성합니다.</p>

--- a/apps/app/src/shared/assets/svg/InfoIcon.tsx
+++ b/apps/app/src/shared/assets/svg/InfoIcon.tsx
@@ -2,15 +2,7 @@ import type {SVGProps} from 'react';
 
 const SvgInfoIcon = (props: SVGProps<SVGSVGElement>) => (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26" fill="none" {...props}>
-        <circle
-            cx="13"
-            cy="13"
-            r="10.75"
-            fill="currentColor"
-            fillOpacity={0.22}
-            stroke="currentColor"
-            strokeWidth={2}
-        />
+        <circle cx="13" cy="13" r="10.75" fill="none" stroke="currentColor" strokeWidth={2} />
         <circle cx="13" cy="9.6" r="1.35" fill="currentColor" />
         <rect x="11.35" y="13.25" width="3.3" height="5.5" rx="1.65" fill="currentColor" />
     </svg>

--- a/apps/app/src/shared/locales/en.ts
+++ b/apps/app/src/shared/locales/en.ts
@@ -186,6 +186,7 @@ export const en: TLocale = {
                 toolbarHint: 'AI can help you complete it more easily.',
                 retry: 'Retry AI fill',
                 generating: 'Filling with AI...',
+                progressToast: 'AI fill in progress',
                 intro: 'Your current edits stay in place even if AI fails.\nYou can go back to the previous step to revisit conditions, or retry and confirm here.',
                 loading: 'Loading the duty schedule',
                 error: 'Failed to load the duty schedule',

--- a/apps/app/src/shared/locales/ko.ts
+++ b/apps/app/src/shared/locales/ko.ts
@@ -182,6 +182,7 @@ export const ko = {
                 toolbarHint: 'AI의 도움을 받아 더 쉽게 작성할 수 있어요',
                 retry: 'AI 다시 채우기',
                 generating: 'AI 채우는 중...',
+                progressToast: 'AI 채우기 진행 중',
                 intro: '실패해도 현재 편집본은 유지돼요.\n이전 단계로 돌아가 조건을 다시 보고 오거나, 여기서 바로 재시도하고 확정할 수 있어요.',
                 loading: '근무표를 불러오는 중이에요',
                 error: '근무표를 불러오지 못했어요',

--- a/apps/app/src/shared/ui/primitives/button.tsx
+++ b/apps/app/src/shared/ui/primitives/button.tsx
@@ -4,7 +4,7 @@ import {cva, type VariantProps} from 'class-variance-authority';
 import * as React from 'react';
 
 const buttonVariants = cva(
-    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+    'inline-flex box-border items-center justify-center gap-2 whitespace-nowrap rounded-md py-0 text-sm font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
     {
         variants: {
             variant: {
@@ -20,12 +20,12 @@ const buttonVariants = cva(
                 subtle: 'border border-transparent bg-main-light text-main-1 hover:bg-main-light/80',
             },
             size: {
-                default: 'h-9 px-4 py-2',
+                default: 'h-9 px-4',
                 sm: 'h-8 rounded-md px-3 text-xs',
                 lg: 'h-10 rounded-md px-8',
                 icon: 'h-9 w-9',
                 pill: 'h-[42px] rounded-[10px] px-5 font-apple text-[20px] font-semibold',
-                hero: 'rounded-[50px] px-8 py-4 font-apple text-[2.25rem] font-semibold',
+                hero: 'rounded-[50px] px-8 py-[1.625rem] font-apple text-[2.25rem] font-semibold',
             },
         },
         defaultVariants: {

--- a/apps/app/src/widgets/duty-management/ui.tsx
+++ b/apps/app/src/widgets/duty-management/ui.tsx
@@ -115,11 +115,11 @@ export function DutyManagementMonthTeamHeader({
                                 onClick={() => onSelectShiftTeam(team.shiftTeamId)}
                                 disabled={disabled}
                                 className={cn(
-                                    'flex h-[32px] items-center justify-center rounded-[10px] px-[16px] py-[6px] transition-colors disabled:cursor-not-allowed disabled:opacity-40',
+                                    'box-border grid h-[32px] min-h-[32px] max-h-[32px] place-items-center rounded-[10px] px-[16px] py-0 font-apple text-[14px] leading-none font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40',
                                     selected ? 'bg-main-1 text-white' : 'text-gray-3 hover:bg-white/70 disabled:hover:bg-transparent',
                                 )}
                             >
-                                <p className="font-apple text-base leading-normal font-medium">{team.name}</p>
+                                <span className="block leading-none">{team.name}</span>
                             </button>
                         );
                     })}

--- a/apps/app/src/widgets/navigation-bar/index.tsx
+++ b/apps/app/src/widgets/navigation-bar/index.tsx
@@ -1,3 +1,4 @@
+import {cn} from '@dutying/utils/style';
 import {useState} from 'react';
 import {useNavigate} from 'react-router';
 import {events, sendEvent} from '@/analytics';
@@ -6,63 +7,68 @@ import ROUTE from '@/shared/constant/path';
 import {useTypedTranslation} from '@/shared/hook/use-typed-translation';
 import NavigationBarItemGroups from './NavigationBarItemGroup';
 
+const NAV_WIDTH_EXPANDED = 'w-[172px]';
+const NAV_WIDTH_COLLAPSED = 'w-[48px]';
+
 const NavigationBar = () => {
     const navigate = useNavigate();
     const {t} = useTypedTranslation();
     const [isFold, setIsFold] = useState(false);
 
-    // 펼친 상태: 사이드바는 숨기고 좌측 상단에 fixed 버튼만 유지
-    if (isFold) {
-        return (
-            <button
-                data-testid="navigation-bar-fold-trigger"
-                type="button"
-                aria-label={t('page.navigationBar.expandAria')}
-                className="fixed top-[7px] left-[14px] z-997 flex size-[42px] items-center justify-center rounded-[10px] border border-[#BFC7D4] bg-white p-[6px]"
-                onClick={() => {
-                    setIsFold(false);
-                    sendEvent(events.navigationBar.spreadNavigation);
-                }}
-            >
-                <FoldIcon className="h-[30px] w-[30px] rotate-180 text-gray-5" />
-            </button>
-        );
-    }
-
     return (
         <aside
             data-testid="navigation-bar"
-            className="sticky top-0 z-997 h-screen w-[172px] shrink-0 border-r border-gray-6 bg-white font-apple transition-[width] duration-300 ease-out"
+            className={cn(
+                'sticky top-0 z-997 h-screen shrink-0 overflow-hidden border-r border-gray-6 bg-white font-apple transition-[width] duration-300 ease-out',
+                isFold ? NAV_WIDTH_COLLAPSED : NAV_WIDTH_EXPANDED,
+            )}
         >
-            <div className="relative flex h-full w-full flex-col">
-                <div className="px-[20px]">
+            {isFold ? (
+                <div className="flex h-full flex-col items-center pt-[13px]">
                     <button
+                        data-testid="navigation-bar-fold-trigger"
                         type="button"
-                        aria-label={t('page.navigationBar.foldAria')}
-                        className="absolute top-[13px] right-[9px] flex size-[30px] items-center justify-center"
+                        aria-label={t('page.navigationBar.expandAria')}
+                        className="flex size-[30px] items-center justify-center"
                         onClick={() => {
-                            setIsFold(true);
-                            sendEvent(events.navigationBar.foldNavigation);
+                            setIsFold(false);
+                            sendEvent(events.navigationBar.spreadNavigation);
                         }}
                     >
-                        <FoldIcon className="h-[30px] w-[30px] text-gray-5" />
+                        <FoldIcon className="h-[30px] w-[30px] rotate-180 text-gray-5" />
                     </button>
-
-                    <LogoV2 className="mt-[85px] size-[28px]" />
-
-                    <div className="mt-6 w-full">
+                </div>
+            ) : (
+                <div className="relative flex h-full w-full flex-col">
+                    <div className="px-[20px]">
                         <button
                             type="button"
-                            className="w-full cursor-pointer rounded-[7px] border border-gray-6 bg-gray-7 py-[11px] text-[16px] font-medium text-gray-3"
-                            onClick={() => navigate(ROUTE.DUTY)}
+                            aria-label={t('page.navigationBar.foldAria')}
+                            className="absolute top-[13px] right-[9px] flex size-[30px] items-center justify-center"
+                            onClick={() => {
+                                setIsFold(true);
+                                sendEvent(events.navigationBar.foldNavigation);
+                            }}
                         >
-                            {t('page.navigationBar.home')}
+                            <FoldIcon className="h-[30px] w-[30px] text-gray-5" />
                         </button>
-                    </div>
-                </div>
 
-                <NavigationBarItemGroups />
-            </div>
+                        <LogoV2 className="mt-[85px] size-[28px]" />
+
+                        <div className="mt-6 w-full">
+                            <button
+                                type="button"
+                                className="w-full cursor-pointer rounded-[7px] border border-gray-6 bg-gray-7 py-[11px] text-[16px] font-medium text-gray-3"
+                                onClick={() => navigate(ROUTE.DUTY)}
+                            >
+                                {t('page.navigationBar.home')}
+                            </button>
+                        </div>
+                    </div>
+
+                    <NavigationBarItemGroups />
+                </div>
+            )}
         </aside>
     );
 };

--- a/apps/app/tailwind.config.ts
+++ b/apps/app/tailwind.config.ts
@@ -35,9 +35,11 @@ export default {
                 blue: '#436DFF',
             },
             fontFamily: {
-                poppins: ['Poppins', 'sans-serif'],
-                apple: ['Apple-SDG', 'sans-serif'],
-                line: ['LINESeedKR', 'sans-serif'],
+                sans: ['Pretendard Variable', 'Pretendard', 'sans-serif'],
+                pretendard: ['Pretendard Variable', 'Pretendard', 'sans-serif'],
+                poppins: ['Pretendard Variable', 'Pretendard', 'sans-serif'],
+                apple: ['Pretendard Variable', 'Pretendard', 'sans-serif'],
+                line: ['Pretendard Variable', 'Pretendard', 'sans-serif'],
             },
             boxShadow: {
                 banner: '0rem .25rem 2.125rem #EDE9F5',

--- a/packages/api/src/ward/contracts.ts
+++ b/packages/api/src/ward/contracts.ts
@@ -24,28 +24,35 @@ export type TShiftResponse = TShift;
 export type TRequestShiftResponse = TRequestShift;
 export type TDutyRequestResponse = TDutyRequest;
 
-export type TAiHardConstraintViolation = {
-    severity: 'HARD';
-    constraint: string;
-    rule: string;
-    date: string;
-    shift: string;
-    required: number;
-    actual: number;
+export type TAiConstraintViolationPeriod = {
+    start_day: number;
+    end_day: number;
+    start_date?: string;
+    end_date?: string;
+    label?: string;
 };
 
-export type TAiSoftConstraintViolation = {
-    severity: 'SOFT';
-    constraint: string;
-    rule: string;
-    nurse_id: string;
-    night_count: number;
+/** LLM generate API `validation.*_constraints_violated` 항목 (dev/prod 공통 확장 필드) */
+export type TAiConstraintViolation = {
+    id: string;
+    type?: string;
+    severity: 'HARD' | 'SOFT';
+    constraint?: string;
+    title?: string;
+    message: string;
+    rule?: string;
+    nurse_id?: string | null;
+    nurse_name?: string | null;
+    shift?: string;
+    period?: TAiConstraintViolationPeriod;
+    affected_days?: number[];
+    detected_day?: number;
 };
 
 export type TAiValidation = {
     valid: boolean;
-    hard_constraints_violated: TAiHardConstraintViolation[];
-    soft_constraints_violated: TAiSoftConstraintViolation[];
+    hard_constraints_violated: TAiConstraintViolation[];
+    soft_constraints_violated: TAiConstraintViolation[];
     warnings: string[];
 };
 


### PR DESCRIPTION
## Summary

- **타이포·버튼**: Pretendard를 앱 기본 폰트로 통일하고, 전역 버튼·CTA·근무팀 탭·스텝퍼 등 텍스트 수직·수평 중앙 정렬을 맞춤
- **레이아웃**: 사이드바 접기 시 48px 최소 너비 유지, 근무표 캘린더 하단 합계 간격·근무자 이름(4자 말줄임·한 줄·중앙) 개선
- **제약조건·AI 채우기**: 안내 아이콘 배경 제거·클릭 고정 툴팁, 규칙 제외 버튼 UI, AI 채우기 진행 중 하단 토스트
- **플로·연동**(기존 브랜치 포함): /make 스텝 UI·공용 캘린더, 확정 후 /duty 이동, 전칸 배정 시 만들기 차단, Duty·shift-editor 편집 경로 정리, AI LLM 서버 연동

## Test plan

- [ ] `/make` 1~5단계: 스텝퍼·이전/다음·제약조건 안내/제외 버튼·4·5탭 캘린더(이름·하단 합계)
- [ ] 5단계 AI 채우기: 진행 토스트, CTA hover·커서
- [ ] 상단 근무팀 탭·월 네비: 버튼 텍스트 중앙(Pretendard)
- [ ] 사이드바 접기/펼치기: 최소 너비 레이아웃
- [ ] 전칸 배정된 월: 만들기 플로 진입 차단·개요 문구 확인


Made with [Cursor](https://cursor.com)