### PR TITLE
feat(onboarding): 비프로덕션 도메인 온보딩 미리보기

### DIFF
--- a/apps/app/src/pages/onboarding-ward-create/index.tsx
+++ b/apps/app/src/pages/onboarding-ward-create/index.tsx
@@ -1,6 +1,7 @@
 import {useEffect} from 'react';
 import {useNavigate} from 'react-router';
 import useAuth from '@/features/auth';
+import {isOnboardingWardCreatePreviewAllowed} from '@/shared/config/feature-flags';
 import ROUTE from '@/shared/constant/path';
 import Card from '@/shared/ui/Card';
 import {useOnboardingWardWizard} from './model';
@@ -51,6 +52,8 @@ function OnboardingWardCreatePage() {
     const isSuccess = submissionStatus === 'success';
 
     useEffect(() => {
+        if (isOnboardingWardCreatePreviewAllowed()) return;
+
         if (accountMe && accountMe.status !== 'WARD_SELECT_PENDING') {
             navigate(ROUTE.REGISTER);
         }

--- a/apps/app/src/shared/config/__tests__/feature-flags.test.ts
+++ b/apps/app/src/shared/config/__tests__/feature-flags.test.ts
@@ -1,0 +1,58 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {isNonProductionAppDomain, isOnboardingWardCreatePreviewAllowed} from '../feature-flags';
+
+describe('isNonProductionAppDomain', () => {
+    it('treats production app host as production', () => {
+        expect(isNonProductionAppDomain('app.dutying.net')).toBe(false);
+    });
+
+    it('treats dev and preview hosts as non-production', () => {
+        expect(isNonProductionAppDomain('dev.dutying.net')).toBe(true);
+        expect(isNonProductionAppDomain('local.app.dutying.net')).toBe(true);
+        expect(isNonProductionAppDomain('dutying-app-git-feat.vercel.app')).toBe(true);
+        expect(isNonProductionAppDomain('localhost')).toBe(true);
+    });
+});
+
+describe('isOnboardingWardCreatePreviewAllowed', () => {
+    beforeEach(() => {
+        vi.stubEnv('VITE_ALLOW_ONBOARDING_PREVIEW', '');
+        vi.stubGlobal('window', {location: {hostname: 'app.dutying.net'}});
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+    });
+
+    it('blocks preview on production app domain', () => {
+        expect(isOnboardingWardCreatePreviewAllowed()).toBe(false);
+    });
+
+    it('allows preview on dev app domain', () => {
+        vi.stubGlobal('window', {location: {hostname: 'dev.dutying.net'}});
+
+        expect(isOnboardingWardCreatePreviewAllowed()).toBe(true);
+    });
+
+    it('allows preview on vercel preview hostnames', () => {
+        vi.stubGlobal('window', {
+            location: {hostname: 'dutying-app-git-feat-foo-gom3.vercel.app'},
+        });
+
+        expect(isOnboardingWardCreatePreviewAllowed()).toBe(true);
+    });
+
+    it('respects VITE_ALLOW_ONBOARDING_PREVIEW=false override', () => {
+        vi.stubGlobal('window', {location: {hostname: 'dev.dutying.net'}});
+        vi.stubEnv('VITE_ALLOW_ONBOARDING_PREVIEW', 'false');
+
+        expect(isOnboardingWardCreatePreviewAllowed()).toBe(false);
+    });
+
+    it('respects VITE_ALLOW_ONBOARDING_PREVIEW=true override on production domain', () => {
+        vi.stubEnv('VITE_ALLOW_ONBOARDING_PREVIEW', 'true');
+
+        expect(isOnboardingWardCreatePreviewAllowed()).toBe(true);
+    });
+});

--- a/apps/app/src/shared/config/feature-flags.ts
+++ b/apps/app/src/shared/config/feature-flags.ts
@@ -38,5 +38,9 @@ export function isOnboardingWardCreatePreviewAllowed(): boolean {
     if (override === 'true') return true;
     if (override === 'false') return false;
 
-    return import.meta.env.DEV || isNonProductionAppDomain();
+    const hostname = getAppHostname();
+
+    if (hostname && PRODUCTION_APP_HOSTS.has(hostname)) return false;
+
+    return import.meta.env.DEV || isNonProductionAppDomain(hostname ?? '');
 }

--- a/apps/app/src/shared/config/feature-flags.ts
+++ b/apps/app/src/shared/config/feature-flags.ts
@@ -1,0 +1,42 @@
+/** 프로덕션 앱 도메인 — 여기서는 LINKED 계정 온보딩 미리보기 불가 */
+const PRODUCTION_APP_HOSTS = new Set(['app.dutying.net']);
+
+function getAppHostname(): string | null {
+    if (typeof window === 'undefined') return null;
+
+    return window.location.hostname;
+}
+
+/**
+ * 접속 중인 앱 도메인이 dev/staging/로컬/프리뷰인지 판별한다.
+ * Vercel env 없이 `window.location.hostname`만 사용한다.
+ */
+export function isNonProductionAppDomain(hostname: string = getAppHostname() ?? ''): boolean {
+    if (!hostname) return false;
+    if (PRODUCTION_APP_HOSTS.has(hostname)) return false;
+
+    if (hostname === 'localhost') return true;
+    if (hostname.endsWith('.vercel.app')) return true;
+    if (hostname.endsWith('.local')) return true;
+    if (hostname.startsWith('local.')) return true;
+    if (hostname === 'dev.dutying.net') return true;
+    if (hostname.startsWith('staging.')) return true;
+
+    return false;
+}
+
+/**
+ * 온보딩 병동 생성 UI를 WARD_SELECT_PENDING이 아닌 계정(LINKED 등)에서도 열 수 있게 한다.
+ *
+ * - 로컬 dev server: `import.meta.env.DEV`
+ * - 그 외: **접속 도메인**이 프로덕션(`app.dutying.net`)이 아니면 허용
+ * - 명시 override: `VITE_ALLOW_ONBOARDING_PREVIEW=true|false`
+ */
+export function isOnboardingWardCreatePreviewAllowed(): boolean {
+    const override = import.meta.env.VITE_ALLOW_ONBOARDING_PREVIEW;
+
+    if (override === 'true') return true;
+    if (override === 'false') return false;
+
+    return import.meta.env.DEV || isNonProductionAppDomain();
+}

--- a/apps/app/src/vite-env.d.ts
+++ b/apps/app/src/vite-env.d.ts
@@ -15,6 +15,8 @@ interface ImportMetaEnv {
     readonly VITE_GA_TRACKING_ID?: string;
     readonly VITE_PIXEL_ID?: string;
     readonly VITE_AI_SCHEDULE_PROVIDER?: string;
+    /** LINKED 계정 온보딩 미리보기 강제 on/off (미설정 시 접속 도메인으로 판별) */
+    readonly VITE_ALLOW_ONBOARDING_PREVIEW?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- `app.dutying.net`이 아닌 도메인(dev·로컬·Vercel 프리뷰 등)에서는 `LINKED` 계정도 `/onboarding/ward-create` UI를 볼 수 있게 한다.
- `isOnboardingWardCreatePreviewAllowed()`로 도메인 판별을 중앙화하고, 필요 시 `VITE_ALLOW_ONBOARDING_PREVIEW`로 강제 on/off 가능.

## Test plan
- [ ] `localhost` / `npm run dev`에서 LINKED 계정으로 `/onboarding/ward-create` 접속 → UI 유지
- [ ] `app.dutying.net`에서 동일 계정 → `/register` → `/make` 리다이렉트
- [ ] `*.vercel.app` 프리뷰 URL에서 UI 확인

Made with [Cursor](https://cursor.com)