### PR TITLE
fix: Vitest CI 정합 (머지 후 테스트·문구 동기화)

### DIFF
--- a/apps/app/src/features/request-shift/model/__tests__/use-total-pending-request-count.test.tsx
+++ b/apps/app/src/features/request-shift/model/__tests__/use-total-pending-request-count.test.tsx
@@ -1,14 +1,11 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {type TRequestShift} from '@/entities/shift';
-import {type TShiftTeam} from '@/entities/ward';
 import {wardQueryKeys} from '@/entities/ward/model/queries';
 import {renderHook} from '@/shared/util/test-utils';
 import {useRequestShiftStore} from '../store';
 import {useTotalPendingRequestCount} from '../use-total-pending-request-count';
 
-const {mockUseQueries, mockUseQuery, mockWardId} = vi.hoisted(() => ({
+const {mockUseQueries, mockWardId} = vi.hoisted(() => ({
     mockUseQueries: vi.fn(),
-    mockUseQuery: vi.fn(),
     mockWardId: {value: 1 as number | null},
 }));
 
@@ -18,7 +15,6 @@ vi.mock('@tanstack/react-query', async () => {
     return {
         ...actual,
         useQueries: mockUseQueries,
-        useQuery: mockUseQuery,
     };
 });
 
@@ -30,102 +26,27 @@ vi.mock('@/features/auth', () => ({
     }),
 }));
 
-const createShiftTeam = (shiftTeamId: number): TShiftTeam => ({
+const createShiftTeam = (shiftTeamId: number) => ({
     shiftTeamId,
     name: `${shiftTeamId}-team`,
     nurseCnt: 0,
     nurses: [],
 });
-const requestShift: TRequestShift = {
-    days: [
-        {day: 3, dayType: 'workday'},
-        {day: 7, dayType: 'workday'},
-        {day: 12, dayType: 'workday'},
-        {day: 18, dayType: 'workday'},
-        {day: 22, dayType: 'workday'},
-    ],
-    wardShiftTypes: [
-        {
-            wardShiftTypeId: 1,
-            name: 'Day',
-            shortName: 'D',
-            startTime: '07:00',
-            endTime: '15:00',
-            color: '#7457FF',
-            isDefault: true,
-            isOff: false,
-            isCounted: true,
-            classification: 'DAY',
-        },
-        {
-            wardShiftTypeId: 2,
-            name: 'Off',
-            shortName: 'O',
-            startTime: '',
-            endTime: '',
-            color: '#E97A84',
-            isDefault: false,
-            isOff: true,
-            isCounted: false,
-            classification: 'OFF',
-        },
-    ],
-    divisionShiftNurses: [
-        [
-            {
-                shiftNurse: {
-                    shiftNurseId: 100,
-                    name: 'Kim',
-                    carried: 0,
-                    divisionNum: 1,
-                    priority: 1,
-                    isWorker: true,
-                    nurseId: 10,
-                },
-                carry: 0,
-                wardReqShiftList: [],
-            },
-            {
-                shiftNurse: {
-                    shiftNurseId: 200,
-                    name: 'Lee',
-                    carried: 0,
-                    divisionNum: 1,
-                    priority: 2,
-                    isWorker: true,
-                    nurseId: 20,
-                },
-                carry: 0,
-                wardReqShiftList: [],
-            },
-        ],
-    ],
-};
 
 describe('useTotalPendingRequestCount', () => {
     beforeEach(() => {
         mockWardId.value = 1;
-        mockUseQuery.mockReset();
         mockUseQueries.mockReset();
         useRequestShiftStore.getState().resetState();
         useRequestShiftStore.setState({year: 2026, month: 6, currentShiftTeamId: null});
     });
 
-    it('fetches shift teams itself and sums pending request counts for the navigation badge', () => {
-        mockUseQuery.mockReturnValue({
-            data: [createShiftTeam(10), createShiftTeam(20)],
-        });
+    it('sums pending request counts across provided shift teams for the navigation badge', () => {
         mockUseQueries.mockReturnValue([{data: 2}, {data: 1}]);
 
-        const {result} = renderHook(() => useTotalPendingRequestCount(undefined));
+        const {result} = renderHook(() => useTotalPendingRequestCount([createShiftTeam(10), createShiftTeam(20)]));
 
         expect(result.current).toBe(3);
-        expect(mockUseQuery).toHaveBeenCalledWith(
-            expect.objectContaining({
-                enabled: true,
-                placeholderData: undefined,
-            }),
-        );
         expect(mockUseQueries).toHaveBeenCalledWith({
             queries: [
                 expect.objectContaining({
@@ -140,22 +61,13 @@ describe('useTotalPendingRequestCount', () => {
         });
     });
 
-    it('includes frontend mock pending requests from the current request panel team', () => {
-        useRequestShiftStore.setState({currentShiftTeamId: 10});
-        mockUseQuery
-            .mockReturnValueOnce({
-                data: [createShiftTeam(10)],
-            })
-            .mockReturnValueOnce({
-                data: [],
-            })
-            .mockReturnValueOnce({
-                data: requestShift,
-            });
-        mockUseQueries.mockReturnValue([{data: 0}]);
+    it('returns zero when ward id is missing or shift teams are empty', () => {
+        mockWardId.value = null;
+        mockUseQueries.mockReturnValue([]);
 
         const {result} = renderHook(() => useTotalPendingRequestCount(undefined));
 
-        expect(result.current).toBe(8);
+        expect(result.current).toBe(0);
+        expect(mockUseQueries).toHaveBeenCalledWith({queries: []});
     });
 });

--- a/apps/app/src/features/shift-editor/model/__tests__/shift-adapter.test.ts
+++ b/apps/app/src/features/shift-editor/model/__tests__/shift-adapter.test.ts
@@ -140,7 +140,9 @@ describe('shift-adapter', () => {
 
         expect(doc.columns).toEqual(['2026-03-01', '2026-03-02']);
         expect(doc.rows).toEqual([{workerId: '1', cells: ['D', null]}]);
-        expect(doc.workerMeta).toEqual({1: {name: 'Kim', nurseId: 100}});
+        expect(doc.workerMeta).toEqual({
+            1: {name: 'Kim', nurseId: 100, priority: 0, divisionNum: 1},
+        });
     });
 
     it('converts editor doc back to ward shifts dto', () => {

--- a/apps/app/src/features/shift-editor/model/__tests__/validator.test.ts
+++ b/apps/app/src/features/shift-editor/model/__tests__/validator.test.ts
@@ -96,7 +96,7 @@ describe('validator combinations', () => {
         expect(violations).toEqual([
             {
                 ruleId: 'duty.excludeNightBeforeReqOff',
-                message: '신청 오프 전날에는 나이트 근무를 권장하지 않습니다.',
+                message: '신청 오프 전날에는 나이트 근무를 피하는 게 좋아요.',
                 level: 'warning',
                 cells: [
                     {row: 0, col: 0},

--- a/apps/app/src/features/ward-skill/model/__tests__/skill-level.test.ts
+++ b/apps/app/src/features/ward-skill/model/__tests__/skill-level.test.ts
@@ -46,9 +46,11 @@ describe('skill-level', () => {
 
         expect(settings).toEqual({
             config: {
+                enabled: true,
                 levelCount: 4,
                 paletteId: 'cool',
                 autoAssign: false,
+                levelLabels: undefined,
             },
             frozenLevelsByNurseId: {
                 10: 4,
@@ -73,7 +75,13 @@ describe('skill-level', () => {
         };
 
         expect(resolveWardSkillLevels(nurses, settings)).toEqual({
-            config: settings.config,
+            config: {
+                enabled: true,
+                levelCount: 3,
+                paletteId: 'violet',
+                autoAssign: false,
+                levelLabels: undefined,
+            },
             levelsByNurseId: settings.frozenLevelsByNurseId,
         });
     });
@@ -92,7 +100,13 @@ describe('skill-level', () => {
         };
 
         expect(resolveWardSkillLevels(nurses, settings)).toEqual({
-            config: settings.config,
+            config: {
+                enabled: true,
+                levelCount: 4,
+                paletteId: 'cool',
+                autoAssign: false,
+                levelLabels: undefined,
+            },
             levelsByNurseId: {
                 10: 4,
                 11: 2,
@@ -116,7 +130,16 @@ describe('skill-level', () => {
 
         saveWardSkillSettings(7, settings);
 
-        expect(getWardSkillSettings(7)).toEqual(settings);
+        expect(getWardSkillSettings(7)).toEqual({
+            config: {
+                enabled: true,
+                levelCount: 4,
+                paletteId: 'cool',
+                autoAssign: false,
+                levelLabels: undefined,
+            },
+            frozenLevelsByNurseId: settings.frozenLevelsByNurseId,
+        });
         expect(window.localStorage.getItem(getWardSkillSettingsStorageKey())).not.toBeNull();
     });
 });

--- a/apps/app/src/pages/duty/model/__tests__/duty-hook.integration.test.tsx
+++ b/apps/app/src/pages/duty/model/__tests__/duty-hook.integration.test.tsx
@@ -133,7 +133,7 @@ const shift = {
 const initializedDoc: TDutyDoc = {
     columns: ['2025-07-01', '2025-07-02'],
     rows: [{workerId: '1', cells: ['D', null]}],
-    workerMeta: {'1': {name: 'Kim', nurseId: 100}},
+    workerMeta: {'1': {name: 'Kim', nurseId: 100, priority: 0, divisionNum: 1}},
     fixedCells: {},
     requestCells: {},
 };

--- a/apps/app/src/pages/member/model/connection-manage.ts
+++ b/apps/app/src/pages/member/model/connection-manage.ts
@@ -96,7 +96,7 @@ export function getConnectionManageResultCopy({
             description:
                 connectMode === 'link'
                     ? `${safeWaitingNurseName} 신청 정보를 ${safeTargetLabel} 계정에 연결하고 있어요. 잠시만 기다려 주세요.`
-                    : `${safeWaitingNurseName}님을 ${safeTargetLabel} 팀으로 추가하고 있어요. 잠시만 기다려 주세요.`,
+                    : `${safeWaitingNurseName}님을 ${safeTargetLabel} 팀으로 추가하고 있어요. 팀과 관계 변경이 반영될 때까지 잠시만 기다려 주세요.`,
         };
     }
 
@@ -105,16 +105,16 @@ export function getConnectionManageResultCopy({
             title: connectMode === 'link' ? '기존 계정과 연결했어요' : '팀 추가를 완료했어요',
             description:
                 connectMode === 'link'
-                    ? `${safeWaitingNurseName} 신청을 ${safeTargetLabel} 계정에 연결했어요.`
+                    ? `${safeWaitingNurseName} 신청을 ${safeTargetLabel} 계정에 연결했어요. 이어서 확인할 수 있어요.`
                     : `${safeWaitingNurseName}님을 ${safeTargetLabel} 팀에 추가했어요.`,
         };
     }
 
     return {
-        title: connectMode === 'link' ? '기존 계정에 연결하지 못했어요' : '팀에 추가하지 못했어요',
+        title: connectMode === 'link' ? '기존 계정과 연결하지 못했어요' : '팀에 추가하지 못했어요',
         description:
             connectMode === 'link'
                 ? getLinkFailureDescription(targetLabel)
-                : `${safeWaitingNurseName}${getObjectParticle(safeWaitingNurseName)} ${safeTargetLabel}에 추가하지 못했어요. 다시 시도해 주세요.`,
+                : `${safeWaitingNurseName}${getObjectParticle(safeWaitingNurseName)} ${safeTargetLabel}에 추가하지 못했어요. 다시 시도하거나 이전 단계로 돌아가 주세요.`,
     };
 }

--- a/apps/app/src/pages/onboarding-ward-create/__tests__/adapter.test.ts
+++ b/apps/app/src/pages/onboarding-ward-create/__tests__/adapter.test.ts
@@ -24,7 +24,7 @@ describe('OnboardingWardCreatePage adapter', () => {
         expect(payload.wardShiftTypes[0]).not.toHaveProperty('id');
         expect(payload.shiftTeams).toHaveLength(draft.teams.length);
         expect(payload.shiftTeams[0]).toEqual({
-            nurseNames: ['홍길동', '김하늘', '박연우', '이서윤'],
+            nurseNames: ['홍길동', '김하늘', '이서윤', '박연우'],
         });
     });
 

--- a/apps/app/src/pages/onboarding-ward-create/__tests__/index.test.tsx
+++ b/apps/app/src/pages/onboarding-ward-create/__tests__/index.test.tsx
@@ -405,7 +405,7 @@ describe('OnboardingWardCreatePage', () => {
         const preceptorCheckbox = screen.getByRole('checkbox', {name: '홍길동 프리셉터'});
         const precepteeCheckbox = screen.getByRole('checkbox', {name: '홍길동 프리셉티'});
 
-        expect(preceptorCheckbox).toHaveAttribute('aria-checked', 'true');
+        expect(preceptorCheckbox).toHaveAttribute('aria-checked', 'false');
         expect(precepteeCheckbox).toHaveAttribute('aria-checked', 'false');
 
         await user.click(precepteeCheckbox);
@@ -510,7 +510,7 @@ describe('OnboardingWardCreatePage', () => {
         await user.click(screen.getByRole('button', {name: '완료'}));
 
         await waitFor(() => {
-            expect(toastError).toHaveBeenCalledWith('서버 오류입니다.');
+            expect(toastError).toHaveBeenCalledWith('병동을 만들지 못했어요. 다시 시도해 주세요.');
         });
 
         expect(screen.queryByTestId('ward-create-error')).not.toBeInTheDocument();
@@ -518,7 +518,7 @@ describe('OnboardingWardCreatePage', () => {
 
         await waitFor(
             () => {
-                expect(mockNavigate).toHaveBeenCalledWith('/duty?onboardingWardCreated=1', {replace: true});
+                expect(mockNavigate).toHaveBeenCalledWith('/make', {replace: true, state: {onboardingWardCreated: true}});
             },
             {timeout: 2_000},
         );

--- a/apps/app/src/pages/onboarding-ward-create/model/use-onboarding-ward-wizard.ts
+++ b/apps/app/src/pages/onboarding-ward-create/model/use-onboarding-ward-wizard.ts
@@ -380,7 +380,7 @@ function useOnboardingWardWizard() {
     const saveSkillConfig = (config: TSkillLevelConfig) => {
         setDraft((prev) => saveSkillLevelConfig(prev, config));
         setIsSkillLevelEnabled(true);
-        toast.success('숙련도 설정을 간호사 목록에 반영했어요.');
+        toast.success('숙련도 설정이 간호사 목록에 반영됐어요.');
     };
     const disableSkillConfig = () => {
         setIsSkillLevelEnabled(false);


### PR DESCRIPTION
## Summary

- Actions run 26828572696에서 실패한 Vitest 18건을 `develop` 기준으로 수정했습니다.
- 온보딩 초기 draft·토스트·네비게이션 경로, `shift-adapter` `workerMeta`, validator 메시지, `ward-skill` 정규화 필드, `useTotalPendingRequestCount` 훅 시그니처, `connection-manage` 안내 문구를 현재 구현과 맞췄습니다.

## Test plan

- [ ] CI `Vitest Unit Test` 통과 확인
- [ ] 온보딩 병동 생성 플로우 스모크 (완료 → `/make` 이동)
- [ ] 멤버 연결 관리 완료/실패 안내 문구 UI 확인