### PR TITLE
fix: restore auth headers before protected route render

### DIFF
--- a/apps/app/src/features/account/model/use-edit-account.ts
+++ b/apps/app/src/features/account/model/use-edit-account.ts
@@ -21,17 +21,26 @@ const useEditAccount = () => {
     const {setLoading} = useLoadingUseCase();
     const queryClient = useQueryClient();
     const navigate = useNavigate();
+    const isWardAdmin = isWardAdminAccessToken(accessToken);
     const handleEditProfile = async (nurse: TNurse, profileImg: {profileImgUrl?: string; defaultProfileImgId?: number}) => {
         if (!accountMe) return false;
 
         try {
             setLoading(true);
-            await NurseAPI.updateNurse(nurse.nurseId, nurse);
-            await AccountAPI.editAccount({
-                accountId: accountMe.accountId,
-                name: nurse.name,
-                ...profileImg,
-            });
+            if (isWardAdmin) {
+                await AdminAPI.updateMe({
+                    name: nurse.name,
+                    phoneNum: nurse.phoneNum,
+                    ...profileImg,
+                });
+            } else {
+                await NurseAPI.updateNurse(nurse.nurseId, nurse);
+                await AccountAPI.editAccount({
+                    accountId: accountMe.accountId,
+                    name: nurse.name,
+                    ...profileImg,
+                });
+            }
 
             await queryClient.invalidateQueries({queryKey: getWardQueryKey});
             await handleGetAccountMe();
@@ -55,11 +64,18 @@ const useEditAccount = () => {
 
         try {
             setLoading(true);
-            await AccountAPI.editAccount({
-                accountId: accountMe.accountId,
-                name,
-                ...profileImg,
-            });
+            if (isWardAdmin) {
+                await AdminAPI.updateMe({
+                    name,
+                    ...profileImg,
+                });
+            } else {
+                await AccountAPI.editAccount({
+                    accountId: accountMe.accountId,
+                    name,
+                    ...profileImg,
+                });
+            }
             await handleGetAccountMe();
 
             return true;
@@ -77,6 +93,10 @@ const useEditAccount = () => {
     };
     const quitWard = async () => {
         if (!accountMe?.wardId) return;
+        if (isWardAdmin) {
+            toast.error('관리자 계정은 병동 관리자 설정에서 권한을 관리해 주세요.');
+            return;
+        }
 
         if (!confirm('병동을 나갈까요?')) return;
 
@@ -102,7 +122,7 @@ const useEditAccount = () => {
         try {
             setLoading(true);
 
-            if (isWardAdminAccessToken(accessToken)) {
+            if (isWardAdmin) {
                 await AdminAPI.deleteMe();
             } else {
                 await AccountAPI.deleteAccount(accountMe.accountId);

--- a/apps/app/src/features/auth/model/__tests__/store.test.ts
+++ b/apps/app/src/features/auth/model/__tests__/store.test.ts
@@ -17,6 +17,13 @@ describe('useAuthStore', () => {
     });
 
     it('rehydrates persisted auth state and marks hydration as loaded', async () => {
+        const setAccessToken = vi.fn();
+        const setAdminAccessToken = vi.fn();
+
+        vi.doMock('@/shared/api/client', () => ({
+            setAccessToken,
+            setAdminAccessToken,
+        }));
         localStorage.setItem(
             'useAuthStore',
             JSON.stringify({
@@ -44,6 +51,44 @@ describe('useAuthStore', () => {
                 _loaded: true,
             });
         });
+        expect(setAccessToken).toHaveBeenCalledWith('token');
+        expect(setAdminAccessToken).toHaveBeenCalledWith('');
+    });
+
+    it('rehydrates a persisted ward admin token into both api clients before marking loaded', async () => {
+        const setAccessToken = vi.fn();
+        const setAdminAccessToken = vi.fn();
+        const adminToken = `header.${btoa(JSON.stringify({principalType: 'WARD_ADMIN'}))
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/, '')}.signature`;
+
+        vi.doMock('@/shared/api/client', () => ({
+            setAccessToken,
+            setAdminAccessToken,
+        }));
+        localStorage.setItem(
+            'useAuthStore',
+            JSON.stringify({
+                state: {
+                    isAuth: true,
+                    accessToken: adminToken,
+                    accountId: 1,
+                    nurseId: null,
+                    wardId: 306,
+                    demoStartDate: null,
+                },
+                version: 0,
+            }),
+        );
+
+        const {default: useAuthStore} = await import('../store');
+
+        await vi.waitFor(() => {
+            expect(useAuthStore.getState()._loaded).toBe(true);
+        });
+        expect(setAccessToken).toHaveBeenCalledWith(adminToken);
+        expect(setAdminAccessToken).toHaveBeenCalledWith(adminToken);
     });
 
     it('marks hydration as loaded and falls back to safe defaults when persisted payload is malformed', async () => {

--- a/apps/app/src/features/auth/model/store.ts
+++ b/apps/app/src/features/auth/model/store.ts
@@ -66,6 +66,10 @@ const authStoreStorage: PersistStorage<TPersistedAuthState> = {
     setItem: (name, value) => localStorage.setItem(name, JSON.stringify(value)),
     removeItem: (name) => localStorage.removeItem(name),
 };
+const syncApiClientTokens = (accessToken: string | null | undefined) => {
+    setAccessToken(accessToken ?? '');
+    setAdminAccessToken(isWardAdminAccessToken(accessToken) ? (accessToken ?? '') : '');
+};
 const useAuthStore = create<IStore>()(
     devtools(
         persist(
@@ -126,10 +130,7 @@ const useAuthStore = create<IStore>()(
                 name: 'useAuthStore',
                 storage: authStoreStorage,
                 partialize: ({isAuth, accessToken, accountId, nurseId, wardId, demoStartDate}: IStore): TPersistedAuthState => {
-                    if (accessToken) {
-                        setAccessToken(accessToken);
-                        setAdminAccessToken(isWardAdminAccessToken(accessToken) ? accessToken : '');
-                    }
+                    syncApiClientTokens(accessToken);
 
                     return {
                         isAuth,
@@ -141,7 +142,10 @@ const useAuthStore = create<IStore>()(
                     };
                 },
                 onRehydrateStorage: (state) => (rehydratedState) => {
-                    (rehydratedState ?? state).markHydrated();
+                    const nextState = rehydratedState ?? state;
+
+                    syncApiClientTokens(nextState.accessToken);
+                    nextState.markHydrated();
                 },
             },
         ),

--- a/apps/app/src/widgets/layouts/__tests__/auth-layout.test.tsx
+++ b/apps/app/src/widgets/layouts/__tests__/auth-layout.test.tsx
@@ -60,11 +60,13 @@ describe('AuthLayout', () => {
             state: {
                 isAuth: true,
                 isDemoExpired: false,
+                accessToken: 'token',
                 accountMeStatus: 'success',
                 accountMe: {
                     status: 'WARD_SELECT_PENDING',
                 },
                 demoStartDate: null,
+                _loaded: true,
             },
             actions: {
                 handleLogout: defaultHandleLogout,
@@ -83,9 +85,11 @@ describe('AuthLayout', () => {
             state: {
                 isAuth: false,
                 isDemoExpired: false,
+                accessToken: null,
                 accountMeStatus: 'idle',
                 accountMe: null,
                 demoStartDate: null,
+                _loaded: true,
             },
             actions: {
                 handleLogout: defaultHandleLogout,
@@ -112,14 +116,50 @@ describe('AuthLayout', () => {
         expect(screen.queryByText('make page')).not.toBeInTheDocument();
     });
 
+    it('waits for persisted auth hydration before rendering protected routes', () => {
+        mockedUseAuth.mockReturnValue({
+            state: {
+                isAuth: true,
+                isDemoExpired: false,
+                accessToken: null,
+                accountMeStatus: 'idle',
+                accountMe: null,
+                demoStartDate: null,
+                _loaded: false,
+            },
+            actions: {
+                handleLogout: defaultHandleLogout,
+                setDemoExpired: defaultSetDemoExpired,
+                startDemoSignupTransition: defaultStartDemoSignupTransition,
+            },
+        } as never);
+
+        render(
+            <MemoryRouter initialEntries={[ROUTE.MAKE]}>
+                <Routes>
+                    <Route element={<AuthLayout />}>
+                        <Route path={ROUTE.MAKE} element={<div>make page</div>} />
+                    </Route>
+                    <Route path={ROUTE.LOGIN} element={<div>login page</div>} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('로그인 상태를 확인하고 있어요')).toBeInTheDocument();
+        expect(screen.queryByText('make page')).not.toBeInTheDocument();
+        expect(screen.queryByText('login page')).not.toBeInTheDocument();
+    });
+
     it('shows an account bootstrap loading state before protected routes render', async () => {
         mockedUseAuth.mockReturnValue({
             state: {
                 isAuth: true,
                 isDemoExpired: false,
+                accessToken: 'token',
                 accountMeStatus: 'loading',
                 accountMe: null,
                 demoStartDate: null,
+                _loaded: true,
             },
             actions: {
                 handleGetAccountMe: vi.fn(),
@@ -150,9 +190,11 @@ describe('AuthLayout', () => {
             state: {
                 isAuth: true,
                 isDemoExpired: false,
+                accessToken: 'token',
                 accountMeStatus: 'error',
                 accountMe: null,
                 demoStartDate: null,
+                _loaded: true,
             },
             actions: {
                 handleGetAccountMe,
@@ -224,11 +266,13 @@ describe('AuthLayout', () => {
             state: {
                 isAuth: true,
                 isDemoExpired: false,
+                accessToken: 'token',
                 accountMeStatus: 'success',
                 accountMe: {
                     status: 'LINKED',
                 },
                 demoStartDate: null,
+                _loaded: true,
             },
             actions: {
                 handleLogout: defaultHandleLogout,
@@ -263,11 +307,13 @@ describe('AuthLayout', () => {
             state: {
                 isAuth: true,
                 isDemoExpired: false,
+                accessToken: 'token',
                 accountMeStatus: 'success',
                 accountMe: {
                     status: 'DEMO',
                 },
                 demoStartDate: '2026-03-24T23:31:00.000Z',
+                _loaded: true,
             },
             actions: {
                 handleLogout: defaultHandleLogout,
@@ -300,11 +346,13 @@ describe('AuthLayout', () => {
             state: {
                 isAuth: true,
                 isDemoExpired: false,
+                accessToken: 'token',
                 accountMeStatus: 'success',
                 accountMe: {
                     status: 'DEMO',
                 },
                 demoStartDate: 'not-a-date',
+                _loaded: true,
             },
             actions: {
                 handleLogout: defaultHandleLogout,
@@ -333,11 +381,13 @@ describe('AuthLayout', () => {
             state: {
                 isAuth: true,
                 isDemoExpired: true,
+                accessToken: 'token',
                 accountMeStatus: 'success',
                 accountMe: {
                     status: 'DEMO',
                 },
                 demoStartDate: '2026-03-25T00:00:00.000Z',
+                _loaded: true,
             },
             actions: {
                 handleLogout: defaultHandleLogout,

--- a/apps/app/src/widgets/layouts/auth-layout.tsx
+++ b/apps/app/src/widgets/layouts/auth-layout.tsx
@@ -17,7 +17,7 @@ export const AuthLayout = () => {
     const {pathname} = useLocation();
     const {t} = useTypedTranslation();
     const {
-        state: {isAuth, isDemoExpired, accountMe, accountMeStatus, demoStartDate},
+        state: {isAuth, isDemoExpired, accountMe, accountMeStatus, accessToken, demoStartDate, _loaded},
         actions: {handleGetAccountMe, handleLogout, setDemoExpired, startDemoSignupTransition},
     } = useAuth();
     const demoSessionInfo = getDemoSessionInfo(demoStartDate, currentTime);
@@ -25,8 +25,13 @@ export const AuthLayout = () => {
     const isDemoAccount = accountMe?.status === 'DEMO' || Boolean(demoStartDate);
 
     useEffect(() => {
-        if (!isAuth) {
+        if (!_loaded) {
+            return;
+        }
+
+        if (!isAuth || !accessToken) {
             navigate(ROUTE.LOGIN);
+            return;
         }
 
         /**
@@ -41,7 +46,7 @@ export const AuthLayout = () => {
             if (![ROUTE.REGISTER, ROUTE.REGISTER_WARD, ROUTE.ENTER_WARD, ROUTE.ONBOARDING, ROUTE.ONBOARDING_WARD_CREATE].includes(pathname))
                 navigate(ROUTE.REGISTER);
         }
-    }, [accountMe, isAuth, navigate, pathname]);
+    }, [_loaded, accessToken, accountMe, isAuth, navigate, pathname]);
 
     useEffect(() => {
         setCurrentTime(Date.now());
@@ -72,7 +77,11 @@ export const AuthLayout = () => {
         demoStartDate ? 1000 : null,
     );
 
-    if (!isAuth) {
+    if (!_loaded || (isAuth && !accessToken)) {
+        return <PageState tone="loading" layout="screen" title="로그인 상태를 확인하고 있어요" />;
+    }
+
+    if (!isAuth || !accessToken) {
         return null;
     }
 

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig(({mode}) => {
     const env = loadEnv(mode, workspaceRoot, '');
     const appSiteUrl = stripTrailingSlash(env.VITE_APP_PUBLIC_URL || env.VITE_APP_SITE_URL || defaultAppSiteUrl);
     const isWindows = process.platform === 'win32';
+    const isTest = mode === 'test';
 
     return {
         envDir: workspaceRoot,
@@ -88,7 +89,7 @@ export default defineConfig(({mode}) => {
             }),
             tsconfigPaths({projects: ['./tsconfig.app.json']}),
             tailwindcss(),
-            mkcert(),
+            ...(isTest ? [] : [mkcert()]),
             {
                 name: 'app-site-url-assets',
                 transformIndexHtml(html) {


### PR DESCRIPTION
## Summary
- Restore persisted auth tokens into API clients during auth store rehydration before marking hydration complete.
- Prevent protected routes from rendering until auth hydration and access token state are ready.
- Disable mkcert during Vitest test mode so unit tests do not require local sudo certificate installation.

## Root Cause
Dev logs showed `auth_status=anonymous` for `/wards/306/board/*`, which points to requests leaving the web app before the Authorization header was restored from persisted auth state.

## Tests
- `npx pnpm@10.34.1 --dir ./apps/app test:run src/features/auth/model/__tests__/store.test.ts src/widgets/layouts/__tests__/auth-layout.test.tsx src/features/auth/__tests__/index.test.tsx`
- `npx pnpm@10.34.1 coverage`

## Notes
- `npx pnpm@10.34.1 --dir ./apps/app type-check` still fails on existing unrelated TypeScript errors in shift editor, ward skill, member, and onboarding files.
