### PR TITLE
[codex] Add admin password reset flow

### DIFF
--- a/apps/app/src/pages/login/__tests__/index.test.tsx
+++ b/apps/app/src/pages/login/__tests__/index.test.tsx
@@ -5,11 +5,14 @@ import ROUTE from '@/shared/constant/path';
 import {render, screen, userEvent} from '@/shared/util/test-utils';
 import LoginPage from '../index';
 
-const {mockHandleLogin, mockPasswordSignup, mockSendAdminEmailVerification} = vi.hoisted(() => ({
-    mockHandleLogin: vi.fn(),
-    mockPasswordSignup: vi.fn(),
-    mockSendAdminEmailVerification: vi.fn(),
-}));
+const {mockHandleLogin, mockPasswordSignup, mockSendAdminEmailVerification, mockRequestAdminPasswordReset, mockResetAdminPassword} =
+    vi.hoisted(() => ({
+        mockHandleLogin: vi.fn(),
+        mockPasswordSignup: vi.fn(),
+        mockSendAdminEmailVerification: vi.fn(),
+        mockRequestAdminPasswordReset: vi.fn(),
+        mockResetAdminPassword: vi.fn(),
+    }));
 
 vi.mock('react-responsive-carousel', () => ({
     Carousel: ({children}: {children: ReactNode}) => <div>{children}</div>,
@@ -29,6 +32,8 @@ vi.mock('@/shared/api', () => ({
         passwordLogin: vi.fn(),
         passwordSignup: mockPasswordSignup,
         sendAdminEmailVerification: mockSendAdminEmailVerification,
+        requestAdminPasswordReset: mockRequestAdminPasswordReset,
+        resetAdminPassword: mockResetAdminPassword,
     },
 }));
 
@@ -55,6 +60,7 @@ describe('LoginPage', () => {
         expect(screen.getByRole('heading', {name: '로그인'})).toBeInTheDocument();
         expect(screen.queryByLabelText('병원명 또는 기관명')).not.toBeInTheDocument();
         expect(screen.getByRole('link', {name: '회원가입'})).toHaveAttribute('href', ROUTE.SIGN_UP);
+        expect(screen.getByRole('link', {name: '비밀번호 찾기'})).toHaveAttribute('href', `${ROUTE.SIGN_IN}?mode=password-reset`);
         expect(screen.getByRole('link', {name: '카카오로 계속하기'})).toHaveAttribute(
             'href',
             'https://api.dutying.net/oauth2/authorization/admin/kakao?nextPageUrl=https%3A%2F%2Fapp.dutying.net%2Fmake',
@@ -115,5 +121,42 @@ describe('LoginPage', () => {
             password: 'password1234',
         });
         expect(mockHandleLogin).toHaveBeenCalledWith('admin-token', ROUTE.REGISTER);
+    });
+
+    it('requests a password reset code and submits a new password', async () => {
+        const user = userEvent.setup();
+
+        mockRequestAdminPasswordReset.mockResolvedValueOnce({email: 'admin@example.com', debugResetToken: 'reset-token'});
+        mockResetAdminPassword.mockResolvedValueOnce(undefined);
+
+        render(
+            <MemoryRouter initialEntries={[`${ROUTE.SIGN_IN}?mode=password-reset`]}>
+                <Routes>
+                    <Route path={ROUTE.SIGN_IN} element={<LoginPage />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByRole('heading', {name: '비밀번호 재설정'})).toBeInTheDocument();
+        expect(screen.queryByRole('link', {name: '카카오로 계속하기'})).not.toBeInTheDocument();
+
+        await user.type(screen.getByLabelText('이메일'), 'admin@example.com');
+        await user.click(screen.getByRole('button', {name: '메일 보내기'}));
+
+        const resetCodeInput = await screen.findByLabelText('재설정 코드');
+
+        expect(resetCodeInput).toHaveValue('reset-token');
+
+        await user.type(screen.getByLabelText('새 비밀번호'), 'new-password123');
+        await user.type(screen.getByLabelText('새 비밀번호 확인'), 'new-password123');
+        await user.click(screen.getByRole('button', {name: '비밀번호 변경'}));
+
+        expect(mockRequestAdminPasswordReset).toHaveBeenCalledWith({email: 'admin@example.com'});
+        expect(mockResetAdminPassword).toHaveBeenCalledWith({
+            email: 'admin@example.com',
+            resetToken: 'reset-token',
+            newPassword: 'new-password123',
+        });
+        expect(await screen.findByText('비밀번호가 변경됐어요. 새 비밀번호로 로그인해 주세요.')).toBeInTheDocument();
     });
 });

--- a/apps/app/src/pages/login/index.tsx
+++ b/apps/app/src/pages/login/index.tsx
@@ -14,11 +14,13 @@ import 'react-responsive-carousel/lib/styles/carousel.min.css';
 import './index.css';
 
 type TSignupErrors = Partial<Record<'name' | 'email' | 'password' | 'passwordConfirm', string>>;
+type TPasswordResetErrors = Partial<Record<'email' | 'resetToken' | 'newPassword' | 'newPasswordConfirm', string>>;
 
 const FIELD_CLASS =
     'h-11 w-full rounded-[12px] border border-transparent bg-gray-7 px-3.5 text-[15px] font-medium text-sub-1 outline-none transition-colors placeholder:text-gray-4 focus-visible:bg-main-light';
 const PASSWORD_MIN_LENGTH = 8;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PASSWORD_RESET_MODE = 'password-reset';
 const getInputClassName = (hasError: boolean) => cn(FIELD_CLASS, hasError && 'border-red bg-[#FFF7F8] focus-visible:bg-white');
 const PasswordVisibilityButton = ({visible, onClick}: {visible: boolean; onClick: () => void}) => (
     <button
@@ -48,6 +50,7 @@ function LoginPage() {
     const nextPath = sanitizeInternalPath(params.get('next'), ROUTE.MAKE);
     const isDemoSignupFlow = getIsDemoSignupLoginReason(search);
     const isSignupPage = pathname === ROUTE.SIGN_UP;
+    const isPasswordResetPage = !isSignupPage && params.get('mode') === PASSWORD_RESET_MODE;
     const canUseDevSignupBypass = import.meta.env.DEV && isSignupPage;
     const [loginEmail, setLoginEmail] = useState('');
     const [loginPassword, setLoginPassword] = useState('');
@@ -63,18 +66,36 @@ function LoginPage() {
     const [signupVerificationError, setSignupVerificationError] = useState<string | null>(null);
     const [signupVerificationCode, setSignupVerificationCode] = useState('');
     const [hasRequestedSignupVerification, setHasRequestedSignupVerification] = useState(false);
+    const [passwordResetEmail, setPasswordResetEmail] = useState('');
+    const [passwordResetToken, setPasswordResetToken] = useState('');
+    const [passwordResetNewPassword, setPasswordResetNewPassword] = useState('');
+    const [passwordResetNewPasswordConfirm, setPasswordResetNewPasswordConfirm] = useState('');
+    const [passwordResetErrors, setPasswordResetErrors] = useState<TPasswordResetErrors>({});
+    const [passwordResetMessage, setPasswordResetMessage] = useState<string | null>(null);
+    const [passwordResetError, setPasswordResetError] = useState<string | null>(null);
+    const [hasRequestedPasswordReset, setHasRequestedPasswordReset] = useState(false);
     const [isPasswordVisible, setIsPasswordVisible] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isSendingVerification, setIsSendingVerification] = useState(false);
+    const [isRequestingPasswordReset, setIsRequestingPasswordReset] = useState(false);
     const isSignupEmailValid = EMAIL_PATTERN.test(signupEmail.trim());
     const isSignupEmailVerified = Boolean(signupEmailVerificationToken);
+    const isPasswordResetEmailValid = EMAIL_PATTERN.test(passwordResetEmail.trim());
     const isLoginDisabled = !loginEmail.trim() || !loginPassword || isSubmitting;
     const isSignupBusy = isSubmitting || isSendingVerification;
     const isSignupDisabled = !signupName.trim() || !isSignupEmailVerified || !signupPassword || !signupPasswordConfirm || isSignupBusy;
+    const isPasswordResetBusy = isSubmitting || isRequestingPasswordReset;
+    const isPasswordResetSubmitDisabled =
+        !hasRequestedPasswordReset ||
+        !isPasswordResetEmailValid ||
+        !passwordResetToken.trim() ||
+        !passwordResetNewPassword ||
+        !passwordResetNewPasswordConfirm ||
+        isPasswordResetBusy;
     const socialAuthorizeNextPath = isSignupPage ? buildSocialSignupRegisterPath() : nextPath;
     const kakaoAuthorizeUrl = buildAuthAuthorizeUrl('kakao', socialAuthorizeNextPath);
     const appleAuthorizeUrl = buildAuthAuthorizeUrl('apple', socialAuthorizeNextPath);
-    const title = isSignupPage ? '\ud68c\uc6d0\uac00\uc785' : '\ub85c\uadf8\uc778';
+    const title = isSignupPage ? '회원가입' : isPasswordResetPage ? '비밀번호 재설정' : '로그인';
     const validateSignup = () => {
         const nextErrors: TSignupErrors = {};
 
@@ -110,6 +131,41 @@ function LoginPage() {
         setSignupVerificationCode(value);
         setSignupEmailVerificationToken(value.trim() ? value.trim() : null);
     };
+    const handlePasswordResetEmailChange = (value: string) => {
+        setPasswordResetEmail(value);
+        setPasswordResetToken('');
+        setPasswordResetNewPassword('');
+        setPasswordResetNewPasswordConfirm('');
+        setPasswordResetErrors({});
+        setPasswordResetMessage(null);
+        setPasswordResetError(null);
+        setHasRequestedPasswordReset(false);
+    };
+    const validatePasswordReset = () => {
+        const nextErrors: TPasswordResetErrors = {};
+
+        if (!EMAIL_PATTERN.test(passwordResetEmail.trim())) {
+            nextErrors.email = '올바른 이메일 주소를 입력해 주세요.';
+        }
+
+        if (!hasRequestedPasswordReset) {
+            nextErrors.resetToken = '먼저 재설정 메일을 요청해 주세요.';
+        } else if (!passwordResetToken.trim()) {
+            nextErrors.resetToken = '메일로 받은 재설정 코드를 입력해 주세요.';
+        }
+
+        if (passwordResetNewPassword.length < PASSWORD_MIN_LENGTH) {
+            nextErrors.newPassword = `비밀번호는 ${PASSWORD_MIN_LENGTH}자 이상 입력해 주세요.`;
+        }
+
+        if (passwordResetNewPassword !== passwordResetNewPasswordConfirm) {
+            nextErrors.newPasswordConfirm = '비밀번호가 서로 달라요.';
+        }
+
+        setPasswordResetErrors(nextErrors);
+
+        return Object.keys(nextErrors).length === 0;
+    };
     const handleSendSignupEmailVerification = async () => {
         setHasRequestedSignupVerification(true);
         setSignupVerificationMessage(null);
@@ -137,11 +193,46 @@ function LoginPage() {
                 return;
             }
 
-            setSignupVerificationMessage('인증 메일을 보냈어요. 메일함에서 인증을 완료해 주세요.');
+            setSignupVerificationMessage('인증 메일을 보냈어요. 메일함에서 인증번호를 확인해 주세요.');
         } catch (error) {
             setSignupVerificationError(error instanceof Error ? error.message : '인증 메일을 보내지 못했어요. 다시 시도해 주세요.');
         } finally {
             setIsSendingVerification(false);
+        }
+    };
+    const handleRequestPasswordReset = async () => {
+        setPasswordResetMessage(null);
+        setPasswordResetError(null);
+        setPasswordResetToken('');
+        setPasswordResetNewPassword('');
+        setPasswordResetNewPasswordConfirm('');
+
+        if (!isPasswordResetEmailValid) {
+            setPasswordResetErrors((errors) => ({...errors, email: '올바른 이메일 주소를 입력해 주세요.'}));
+
+            return;
+        }
+
+        setPasswordResetErrors({});
+        setIsRequestingPasswordReset(true);
+
+        try {
+            const response = await AuthAPI.requestAdminPasswordReset({email: passwordResetEmail.trim()});
+
+            setHasRequestedPasswordReset(true);
+
+            if (response.debugResetToken) {
+                setPasswordResetToken(response.debugResetToken);
+                setPasswordResetMessage('재설정 코드가 확인됐어요. 새 비밀번호를 입력해 주세요.');
+
+                return;
+            }
+
+            setPasswordResetMessage('재설정 메일을 보냈어요. 메일함에서 재설정 코드를 확인해 주세요.');
+        } catch (error) {
+            setPasswordResetError(error instanceof Error ? error.message : '재설정 메일을 보내지 못했어요. 다시 시도해 주세요.');
+        } finally {
+            setIsRequestingPasswordReset(false);
         }
     };
     const handlePasswordLogin = async (event: FormEvent<HTMLFormElement>) => {
@@ -194,6 +285,35 @@ function LoginPage() {
             setIsSubmitting(false);
         }
     };
+    const handlePasswordReset = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setPasswordResetError(null);
+        setPasswordResetMessage(null);
+
+        if (!validatePasswordReset()) {
+            return;
+        }
+
+        setIsSubmitting(true);
+
+        try {
+            await AuthAPI.resetAdminPassword({
+                email: passwordResetEmail.trim(),
+                resetToken: passwordResetToken.trim(),
+                newPassword: passwordResetNewPassword,
+            });
+
+            setLoginEmail(passwordResetEmail.trim());
+            setPasswordResetNewPassword('');
+            setPasswordResetNewPasswordConfirm('');
+            setPasswordResetMessage('비밀번호가 변경됐어요. 새 비밀번호로 로그인해 주세요.');
+        } catch (error) {
+            setPasswordResetError(error instanceof Error ? error.message : '비밀번호를 변경하지 못했어요. 다시 시도해 주세요.');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
     return (
         <div className="flex min-h-screen w-screen bg-white">
             <div className="hidden h-screen w-[calc(100vh/1080*1140)] min-w-0 shrink xl:block">
@@ -245,7 +365,140 @@ function LoginPage() {
                         <h1 className="font-apple text-[32px] font-semibold text-text-1">{title}</h1>
                     </div>
 
-                    {!isSignupPage ? (
+                    {isPasswordResetPage ? (
+                        <form onSubmit={handlePasswordReset} className="mx-auto mt-7 w-[334px] space-y-4">
+                            <div>
+                                <label htmlFor="password-reset-email" className="mb-1.5 block text-sm font-medium text-sub-2">
+                                    이메일
+                                </label>
+                                <div className="flex gap-2">
+                                    <div className="relative min-w-0 flex-1">
+                                        <Mail className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-4" />
+                                        <input
+                                            id="password-reset-email"
+                                            value={passwordResetEmail}
+                                            type="email"
+                                            className={cn(getInputClassName(Boolean(passwordResetErrors.email)), 'pl-9')}
+                                            placeholder="가입한 이메일"
+                                            autoComplete="email"
+                                            onChange={(event) => handlePasswordResetEmailChange(event.target.value)}
+                                            aria-invalid={Boolean(passwordResetErrors.email)}
+                                            aria-describedby={passwordResetErrors.email ? 'password-reset-email-error' : undefined}
+                                        />
+                                    </div>
+                                    <button
+                                        type="button"
+                                        disabled={!isPasswordResetEmailValid || isRequestingPasswordReset}
+                                        className="flex h-11 w-[104px] shrink-0 cursor-pointer items-center justify-center gap-1 rounded-[12px] bg-sub-1 px-2 text-sm font-semibold text-white transition-colors hover:bg-black disabled:cursor-not-allowed disabled:bg-gray-6 disabled:text-gray-3"
+                                        onClick={handleRequestPasswordReset}
+                                    >
+                                        {isRequestingPasswordReset ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                                        메일 보내기
+                                    </button>
+                                </div>
+                                <FieldError id="password-reset-email-error" message={passwordResetErrors.email} />
+                            </div>
+
+                            {hasRequestedPasswordReset ? (
+                                <>
+                                    <div>
+                                        <label htmlFor="password-reset-token" className="mb-1.5 block text-sm font-medium text-sub-2">
+                                            재설정 코드
+                                        </label>
+                                        <input
+                                            id="password-reset-token"
+                                            value={passwordResetToken}
+                                            type="text"
+                                            className={getInputClassName(Boolean(passwordResetErrors.resetToken))}
+                                            placeholder="메일로 받은 재설정 코드"
+                                            autoComplete="one-time-code"
+                                            onChange={(event) => setPasswordResetToken(event.target.value)}
+                                            aria-invalid={Boolean(passwordResetErrors.resetToken)}
+                                            aria-describedby={passwordResetErrors.resetToken ? 'password-reset-token-error' : undefined}
+                                        />
+                                        <FieldError id="password-reset-token-error" message={passwordResetErrors.resetToken} />
+                                    </div>
+
+                                    <div>
+                                        <label
+                                            htmlFor="password-reset-new-password"
+                                            className="mb-1.5 block text-sm font-medium text-sub-2"
+                                        >
+                                            새 비밀번호
+                                        </label>
+                                        <input
+                                            id="password-reset-new-password"
+                                            value={passwordResetNewPassword}
+                                            type="password"
+                                            className={getInputClassName(Boolean(passwordResetErrors.newPassword))}
+                                            placeholder="새 비밀번호를 입력해 주세요"
+                                            autoComplete="new-password"
+                                            onChange={(event) => setPasswordResetNewPassword(event.target.value)}
+                                            aria-invalid={Boolean(passwordResetErrors.newPassword)}
+                                            aria-describedby={
+                                                passwordResetErrors.newPassword ? 'password-reset-new-password-error' : undefined
+                                            }
+                                        />
+                                        <FieldError id="password-reset-new-password-error" message={passwordResetErrors.newPassword} />
+                                    </div>
+
+                                    <div>
+                                        <label
+                                            htmlFor="password-reset-new-password-confirm"
+                                            className="mb-1.5 block text-sm font-medium text-sub-2"
+                                        >
+                                            새 비밀번호 확인
+                                        </label>
+                                        <input
+                                            id="password-reset-new-password-confirm"
+                                            value={passwordResetNewPasswordConfirm}
+                                            type="password"
+                                            className={getInputClassName(Boolean(passwordResetErrors.newPasswordConfirm))}
+                                            placeholder="새 비밀번호를 다시 입력해 주세요"
+                                            autoComplete="new-password"
+                                            onChange={(event) => setPasswordResetNewPasswordConfirm(event.target.value)}
+                                            aria-invalid={Boolean(passwordResetErrors.newPasswordConfirm)}
+                                            aria-describedby={
+                                                passwordResetErrors.newPasswordConfirm
+                                                    ? 'password-reset-new-password-confirm-error'
+                                                    : undefined
+                                            }
+                                        />
+                                        <FieldError
+                                            id="password-reset-new-password-confirm-error"
+                                            message={passwordResetErrors.newPasswordConfirm}
+                                        />
+                                    </div>
+                                </>
+                            ) : null}
+
+                            {passwordResetMessage ? (
+                                <p role="status" className="rounded-[12px] bg-main-light px-3 py-2 text-sm text-main-1">
+                                    {passwordResetMessage}
+                                </p>
+                            ) : null}
+                            {passwordResetError ? (
+                                <p role="alert" className="rounded-[12px] bg-[#FFF7F8] px-3 py-2 text-sm text-red">
+                                    {passwordResetError}
+                                </p>
+                            ) : null}
+
+                            <button
+                                type="submit"
+                                disabled={isPasswordResetSubmitDisabled}
+                                className="mx-auto flex h-[44px] w-[334px] cursor-pointer items-center justify-center gap-2 rounded-[12px] border border-[1px] border-main-1 bg-main-1 px-[12px] text-sm font-semibold text-white transition-colors hover:bg-[#5832E7] disabled:cursor-not-allowed disabled:border-transparent disabled:bg-gray-6 disabled:text-gray-3"
+                            >
+                                {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                                비밀번호 변경
+                            </button>
+                            <p className="text-center text-sm text-gray-3">
+                                비밀번호가 기억났나요?{' '}
+                                <Link to={ROUTE.SIGN_IN} className="font-semibold text-main-1 underline underline-offset-[3px]">
+                                    로그인
+                                </Link>
+                            </p>
+                        </form>
+                    ) : !isSignupPage ? (
                         <form onSubmit={handlePasswordLogin} className="mx-auto mt-7 w-[334px] space-y-4">
                             <div>
                                 <label htmlFor="login-email" className="mb-1.5 block text-sm font-medium text-sub-2">
@@ -299,6 +552,14 @@ function LoginPage() {
                                 로그인
                             </button>
                             <p className="text-center text-sm text-gray-3">
+                                <Link
+                                    to={`${ROUTE.SIGN_IN}?mode=${PASSWORD_RESET_MODE}`}
+                                    className="font-semibold text-main-1 underline underline-offset-[3px]"
+                                >
+                                    비밀번호 찾기
+                                </Link>
+                            </p>
+                            <p className="text-center text-sm text-gray-3">
                                 아직 계정이 없나요?{' '}
                                 <Link to={ROUTE.SIGN_UP} className="font-semibold text-main-1 underline underline-offset-[3px]">
                                     회원가입
@@ -347,7 +608,13 @@ function LoginPage() {
                                         className="flex h-11 w-[76px] shrink-0 cursor-pointer items-center justify-center rounded-[12px] bg-sub-1 px-2 text-sm font-semibold text-white transition-colors hover:bg-black disabled:cursor-not-allowed disabled:bg-gray-6 disabled:text-gray-3"
                                         onClick={handleSendSignupEmailVerification}
                                     >
-                                        {isSendingVerification ? <Loader2 className="h-4 w-4 animate-spin" /> : isSignupEmailVerified ? '완료' : '인증'}
+                                        {isSendingVerification ? (
+                                            <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : isSignupEmailVerified ? (
+                                            '완료'
+                                        ) : (
+                                            '인증'
+                                        )}
                                     </button>
                                 </div>
                                 <FieldError id="signup-email-error" message={signupErrors.email} />
@@ -358,17 +625,15 @@ function LoginPage() {
                                             value={signupVerificationCode}
                                             type="text"
                                             className={getInputClassName(false)}
-                                            placeholder="?몄쬆踰덊샇瑜??낅젰??二쇱꽭??"
+                                            placeholder="인증번호를 입력해 주세요"
+                                            aria-label="이메일 인증번호"
+                                            autoComplete="one-time-code"
                                             onChange={(event) => handleSignupVerificationCodeChange(event.target.value)}
                                         />
                                     </div>
                                 ) : null}
                                 {signupVerificationMessage ? <p className="mt-1 text-xs text-main-1">{signupVerificationMessage}</p> : null}
-                                {signupVerificationError ? (
-                                    <p className="mt-1 text-xs text-red">
-                                        {signupVerificationError}
-                                    </p>
-                                ) : null}
+                                {signupVerificationError ? <p className="mt-1 text-xs text-red">{signupVerificationError}</p> : null}
                             </div>
 
                             <div>
@@ -430,34 +695,36 @@ function LoginPage() {
                         </form>
                     )}
 
-                    <div className="mx-auto mt-7 w-[334px] border-t border-gray-6 pt-6">
-                        <div className="grid grid-cols-1 gap-3">
-                            <a
-                                href={kakaoAuthorizeUrl}
-                                className="mx-auto flex h-[44px] w-[334px] cursor-pointer items-center justify-center rounded-[12px] border border-[1px] border-[#F2D600] bg-[#FEE500] px-[12px] text-sm font-semibold text-sub-1 shadow-banner"
-                            >
-                                <KakaoIcon className="mr-3 h-5 w-5" />
-                                {isSignupPage ? '카카오로 시작하기' : '카카오로 계속하기'}
-                            </a>
-                            {canUseDevSignupBypass ? (
-                                <button
-                                    type="button"
-                                    disabled={isSubmitting}
-                                    onClick={handleDevSignupBypass}
-                                    className="mx-auto flex h-[44px] w-[334px] cursor-pointer items-center justify-center rounded-[12px] border border-dashed border-gray-6 bg-white px-[12px] text-sm font-semibold text-gray-3 transition-colors hover:bg-gray-7 disabled:cursor-not-allowed disabled:text-gray-4"
+                    {!isPasswordResetPage ? (
+                        <div className="mx-auto mt-7 w-[334px] border-t border-gray-6 pt-6">
+                            <div className="grid grid-cols-1 gap-3">
+                                <a
+                                    href={kakaoAuthorizeUrl}
+                                    className="mx-auto flex h-[44px] w-[334px] cursor-pointer items-center justify-center rounded-[12px] border border-[1px] border-[#F2D600] bg-[#FEE500] px-[12px] text-sm font-semibold text-sub-1 shadow-banner"
                                 >
-                                    DEV: skip Kakao signup
-                                </button>
-                            ) : null}
-                            <a
-                                href={appleAuthorizeUrl}
-                                className="mx-auto flex h-[44px] w-[334px] cursor-pointer items-center justify-center rounded-[12px] border border-[1px] border-[#231F20] bg-[#231F20] px-[12px] text-sm font-semibold text-white shadow-banner"
-                            >
-                                <AppleIcon className="mr-3 h-5 w-5" />
-                                {isSignupPage ? 'Apple로 시작하기' : 'Apple로 계속하기'}
-                            </a>
+                                    <KakaoIcon className="mr-3 h-5 w-5" />
+                                    {isSignupPage ? '카카오로 시작하기' : '카카오로 계속하기'}
+                                </a>
+                                {canUseDevSignupBypass ? (
+                                    <button
+                                        type="button"
+                                        disabled={isSubmitting}
+                                        onClick={handleDevSignupBypass}
+                                        className="mx-auto flex h-[44px] w-[334px] cursor-pointer items-center justify-center rounded-[12px] border border-dashed border-gray-6 bg-white px-[12px] text-sm font-semibold text-gray-3 transition-colors hover:bg-gray-7 disabled:cursor-not-allowed disabled:text-gray-4"
+                                    >
+                                        DEV: skip Kakao signup
+                                    </button>
+                                ) : null}
+                                <a
+                                    href={appleAuthorizeUrl}
+                                    className="mx-auto flex h-[44px] w-[334px] cursor-pointer items-center justify-center rounded-[12px] border border-[1px] border-[#231F20] bg-[#231F20] px-[12px] text-sm font-semibold text-white shadow-banner"
+                                >
+                                    <AppleIcon className="mr-3 h-5 w-5" />
+                                    {isSignupPage ? 'Apple로 시작하기' : 'Apple로 계속하기'}
+                                </a>
+                            </div>
                         </div>
-                    </div>
+                    ) : null}
                 </div>
 
                 <div className="mt-auto flex flex-wrap justify-center gap-x-2 gap-y-1 pt-8 font-apple text-sm text-sub-3">

--- a/apps/app/src/shared/api/auth/__tests__/index.test.ts
+++ b/apps/app/src/shared/api/auth/__tests__/index.test.ts
@@ -49,6 +49,27 @@ describe('AuthAPI', () => {
         expect(mockPost).toHaveBeenCalledWith('/auth/admin/email-verifications', payload);
     });
 
+    it('uses the ward admin password reset request endpoint', async () => {
+        const payload = {email: 'admin@example.com'};
+        const response = {email: 'admin@example.com', debugResetToken: 'reset-token'};
+
+        mockPost.mockResolvedValue({data: response});
+
+        await expect(AuthAPI.requestAdminPasswordReset(payload)).resolves.toBe(response);
+
+        expect(mockPost).toHaveBeenCalledWith('/auth/admin/password-reset-requests', payload);
+    });
+
+    it('uses the ward admin password reset confirm endpoint', async () => {
+        const payload = {email: 'admin@example.com', resetToken: 'reset-token', newPassword: 'new-password123'};
+
+        mockPost.mockResolvedValue({data: undefined});
+
+        await expect(AuthAPI.resetAdminPassword(payload)).resolves.toBeUndefined();
+
+        expect(mockPost).toHaveBeenCalledWith('/auth/admin/password-reset', payload);
+    });
+
     it('uses the ward admin social profile endpoint', async () => {
         const payload = {provider: 'KAKAO' as const, idToken: 'id-token'};
         const response = {provider: 'KAKAO' as const, email: 'admin@example.com'};

--- a/apps/app/src/shared/api/auth/index.ts
+++ b/apps/app/src/shared/api/auth/index.ts
@@ -4,6 +4,9 @@ import {
     type TAdminEmailVerificationSendRequest,
     type TAdminEmailVerificationSendResponse,
     type TAdminPasswordLoginRequest,
+    type TAdminPasswordResetConfirmRequest,
+    type TAdminPasswordResetRequest,
+    type TAdminPasswordResetRequestResponse,
     type TAdminPasswordSignupRequest,
     type TAdminSocialProfileRequest,
     type TAdminSocialProfileResponse,
@@ -20,6 +23,10 @@ class AuthAPI implements IAuthAPI {
         (await axiosInstance.post<TAuthTokenResponse>('/auth/admin/password/signup', request)).data;
     sendAdminEmailVerification = async (request: TAdminEmailVerificationSendRequest) =>
         (await axiosInstance.post<TAdminEmailVerificationSendResponse>('/auth/admin/email-verifications', request)).data;
+    requestAdminPasswordReset = async (request: TAdminPasswordResetRequest) =>
+        (await axiosInstance.post<TAdminPasswordResetRequestResponse>('/auth/admin/password-reset-requests', request)).data;
+    resetAdminPassword = async (request: TAdminPasswordResetConfirmRequest) =>
+        (await axiosInstance.post<void>('/auth/admin/password-reset', request)).data;
     adminSocialProfile = async (request: TAdminSocialProfileRequest) =>
         (await axiosInstance.post<TAdminSocialProfileResponse>('/auth/admin/social/profile', request)).data;
     adminSocialSignup = async (request: TAdminSocialSignupRequest) =>

--- a/apps/app/src/shared/api/auth/type.ts
+++ b/apps/app/src/shared/api/auth/type.ts
@@ -31,6 +31,22 @@ export type TAdminEmailVerificationSendResponse = {
     debugVerificationToken?: string;
 };
 
+export type TAdminPasswordResetRequest = {
+    email: string;
+};
+
+export type TAdminPasswordResetRequestResponse = {
+    email: string;
+    expiresAt?: string;
+    debugResetToken?: string;
+};
+
+export type TAdminPasswordResetConfirmRequest = {
+    email: string;
+    resetToken: string;
+    newPassword: string;
+};
+
 export type TAdminSocialProvider = 'KAKAO' | 'APPLE';
 
 export type TAdminSocialProfileRequest = {
@@ -66,6 +82,8 @@ export interface IAuthAPI {
     passwordLogin: (request: TAdminPasswordLoginRequest) => Promise<TAuthTokenResponse>;
     passwordSignup: (request: TAdminPasswordSignupRequest) => Promise<TAuthTokenResponse>;
     sendAdminEmailVerification: (request: TAdminEmailVerificationSendRequest) => Promise<TAdminEmailVerificationSendResponse>;
+    requestAdminPasswordReset: (request: TAdminPasswordResetRequest) => Promise<TAdminPasswordResetRequestResponse>;
+    resetAdminPassword: (request: TAdminPasswordResetConfirmRequest) => Promise<void>;
     adminSocialProfile: (request: TAdminSocialProfileRequest) => Promise<TAdminSocialProfileResponse>;
     adminSocialSignup: (request: TAdminSocialSignupRequest) => Promise<TAuthTokenResponse>;
     logout: (accessToken: string | null) => Promise<void>;


### PR DESCRIPTION
## Summary
- Add admin password reset request/confirm API methods and types.
- Add `/login?mode=password-reset` flow with email request, reset code, and new password submission.
- Fix the broken signup verification code placeholder while preserving dev debug-token autofill.

## Tests
- `./node_modules/.bin/vitest run src/shared/api/auth/__tests__/index.test.ts src/pages/login/__tests__/index.test.tsx`
- `./node_modules/.bin/eslint src/pages/login/index.tsx src/pages/login/__tests__/index.test.tsx src/shared/api/auth/index.ts src/shared/api/auth/type.ts src/shared/api/auth/__tests__/index.test.ts`

## Risks / Notes
- Full `tsc -b` still fails on existing unrelated type errors outside this change set.
- Real email delivery depends on the server SMTP configuration PR.