### PR TITLE
fix: preserve ai draft cells from fixed shift step

### DIFF
--- a/apps/app/src/features/shift-editor/model/__tests__/shift-adapter.test.ts
+++ b/apps/app/src/features/shift-editor/model/__tests__/shift-adapter.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'vitest';
 import type {TShift} from '@/entities';
 import {
     buildWorkKeyMap,
+    docToFixedWardShiftsDTO,
     docToShift,
     docToSnapshotCellsDTO,
     docToWardShiftsDTO,
@@ -223,6 +224,22 @@ describe('shift-adapter', () => {
         ]);
     });
 
+    it('converts only fixed cells for the fixed-shifts step dto', () => {
+        const shift = createShift();
+        const doc = {
+            columns: ['2026-03-01', '2026-03-02'],
+            rows: [{workerId: '1', cells: ['O', 'D']}],
+            workerMeta: {1: {name: 'Kim'}},
+            fixedCells: {'1|2026-03-01': true as const},
+            requestCells: {'1|2026-03-02': true as const},
+        };
+
+        expect(docToFixedWardShiftsDTO(doc, shift)).toEqual([
+            {shiftNurseId: 1, date: '2026-03-01', wardShiftTypeId: 20},
+            {shiftNurseId: 1, date: '2026-03-02', wardShiftTypeId: null},
+        ]);
+    });
+
     it('builds rich snapshot cells for Spring schedule authoring', () => {
         const shift = createShift();
         const doc = {
@@ -320,10 +337,12 @@ describe('shift-adapter', () => {
 
     it('preserves the original shift type id when a stale editor cell no longer maps by short name', () => {
         const shift = createShift();
+
         shift.divisionShiftNurses[0]![0]!.wardShiftList = [20, 10];
         shift.wardShiftTypes = shift.wardShiftTypes.map((shiftType) =>
             shiftType.wardShiftTypeId === 20 ? {...shiftType, shortName: '-'} : shiftType,
         );
+
         const doc = {
             columns: ['2026-03-01', '2026-03-02'],
             rows: [{workerId: '1', cells: ['O', 'D']}],

--- a/apps/app/src/features/shift-editor/model/__tests__/use-shift-editor-commands.test.tsx
+++ b/apps/app/src/features/shift-editor/model/__tests__/use-shift-editor-commands.test.tsx
@@ -115,7 +115,10 @@ describe('useShiftEditorCommands', () => {
         const {result} = renderHook(() => useShiftEditorCommands());
         const doc: TDutyDoc = {
             ...createDoc(),
-            rows: [{...createDoc().rows[0]!, lastCells: [null, 'D']}, {...createDoc().rows[1]!, lastCells: ['E', null]}],
+            rows: [
+                {...createDoc().rows[0]!, lastCells: [null, 'D']},
+                {...createDoc().rows[1]!, lastCells: ['E', null]},
+            ],
         };
 
         act(() => {
@@ -131,11 +134,55 @@ describe('useShiftEditorCommands', () => {
         expect(state.history.past).toHaveLength(0);
     });
 
+    it('preserves hidden non-fixed draft cells when clearing in fixed mode', () => {
+        const {result} = renderHook(() => useShiftEditorCommands());
+
+        act(() => {
+            result.current.init(createDoc());
+            useShiftEditorStore.getState().setEditorMode('fixed');
+            useShiftEditorStore.getState().setSelection({type: 'range', from: {row: 0, col: 0}, to: {row: 1, col: 1}});
+            result.current.setSelectionValue(null);
+        });
+
+        const state = useShiftEditorStore.getState();
+
+        expect(state.doc.rows.map((row) => row.cells)).toEqual([
+            ['D', null, 'N'],
+            [null, 'E', null],
+        ]);
+        expect(state.doc.fixedCells).toEqual({});
+        expect(state.history.past).toHaveLength(0);
+    });
+
+    it('clears visible fixed cells when clearing in fixed mode', () => {
+        const {result} = renderHook(() => useShiftEditorCommands());
+        const doc: TDutyDoc = {
+            ...createDoc(),
+            fixedCells: {'2|2026-03-01': true},
+        };
+
+        act(() => {
+            result.current.init(doc);
+            useShiftEditorStore.getState().setEditorMode('fixed');
+            useShiftEditorStore.getState().setSelection({type: 'single', anchor: {row: 0, col: 0}});
+            result.current.setSelectionValue(null);
+        });
+
+        const state = useShiftEditorStore.getState();
+
+        expect(state.doc.rows[0]?.cells[0]).toBeNull();
+        expect(state.doc.fixedCells).toEqual({});
+        expect(state.history.past).toHaveLength(0);
+    });
+
     it('pastes previous-shift cells in fixed mode', () => {
         const {result} = renderHook(() => useShiftEditorCommands());
         const doc: TDutyDoc = {
             ...createDoc(),
-            rows: [{...createDoc().rows[0]!, lastCells: [null, 'D']}, {...createDoc().rows[1]!, lastCells: ['E', null]}],
+            rows: [
+                {...createDoc().rows[0]!, lastCells: [null, 'D']},
+                {...createDoc().rows[1]!, lastCells: ['E', null]},
+            ],
         };
         const payload: TClipboardPayload = {
             width: 2,

--- a/apps/app/src/features/shift-editor/model/shift-adapter.ts
+++ b/apps/app/src/features/shift-editor/model/shift-adapter.ts
@@ -239,6 +239,28 @@ export function docToWardShiftsDTO(doc: TDutyDoc, originalShift: TShift): TWardS
     return dto;
 }
 
+export function docToFixedWardShiftsDTO(doc: TDutyDoc, originalShift: TShift): TWardShiftsDTO {
+    const maps = buildWardShiftTypeMaps(originalShift);
+    const dto: TWardShiftsDTO = [];
+
+    for (const row of doc.rows) {
+        const shiftNurseId = Number(row.workerId);
+        const originalRow = findShiftRowByShiftNurseId(originalShift, shiftNurseId);
+
+        for (let colIdx = 0; colIdx < doc.columns.length; colIdx += 1) {
+            const date = doc.columns[colIdx]!;
+            const lockKey = `${row.workerId}|${date}`;
+            const fixed = doc.fixedCells[lockKey] === true;
+            const cell = fixed ? (row.cells[colIdx] ?? null) : null;
+            const wardShiftTypeId = fixed ? cellToWardShiftTypeIdPreservingOriginal(cell, originalRow?.wardShiftList[colIdx], maps) : null;
+
+            dto.push({shiftNurseId, date, wardShiftTypeId});
+        }
+    }
+
+    return dto;
+}
+
 export function docToSnapshotCellsDTO(doc: TDutyDoc, originalShift: TShift): TSnapshotCellDTO[] {
     const maps = buildWardShiftTypeMaps(originalShift);
     const dto: TSnapshotCellDTO[] = [];

--- a/apps/app/src/features/shift-editor/model/use-shift-editor-commands.ts
+++ b/apps/app/src/features/shift-editor/model/use-shift-editor-commands.ts
@@ -144,6 +144,10 @@ export function useShiftEditorCommands() {
                 continue;
             }
 
+            if (editorMode === 'fixed' && key !== null && !prevFixed && value === null) {
+                continue;
+            }
+
             const cellChanged = prev !== value;
             const nextFixed = key !== null && editorMode === 'fixed' ? value !== null : prevFixed;
             const fixedChanged = prevFixed !== nextFixed;
@@ -552,6 +556,19 @@ export function useShiftEditorCommands() {
                 if (source === 'user' && skippedByRequest > 0) {
                     notifyRequestLocked();
                 }
+
+                const kept: typeof filteredCells = [];
+
+                for (const cell of filteredCells) {
+                    const key = getDutyCellLockKey(doc, cell.row, cell.col);
+                    const prevFixed = key !== null && doc.fixedCells[key] === true;
+
+                    if (key !== null && !prevFixed && cell.next === null) continue;
+
+                    kept.push(cell);
+                }
+
+                filteredCells = kept;
             }
 
             const fixedDelta: Array<{key: string; prev: boolean; next: boolean}> = [];

--- a/apps/app/src/pages/make-shift/ui/steps/fixed-shifts.tsx
+++ b/apps/app/src/pages/make-shift/ui/steps/fixed-shifts.tsx
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast';
 import {BouncingDotsSlot} from '@/components/loading-ui/bouncing-dots';
 import {wardQueryOptions} from '@/entities/ward/model/queries';
 import useAuth from '@/features/auth';
-import {docToWardShiftsDTO, useShiftEditorStore} from '@/features/shift-editor';
+import {docToFixedWardShiftsDTO, useShiftEditorStore} from '@/features/shift-editor';
 import {type TViolation} from '@/features/shift-editor/model';
 import {useRestLeavePolicy} from '@/pages/ward-settings/model/rest-leave-policy';
 import WardAPI from '@/shared/api/ward';
@@ -85,7 +85,7 @@ export function FixedShifts() {
         toast.loading(t('page.makeShift.navigation.saving'), {id: progressToastId});
 
         try {
-            const dto = docToWardShiftsDTO(editorDoc, dutyQuery.data);
+            const dto = docToFixedWardShiftsDTO(editorDoc, dutyQuery.data);
 
             await WardAPI.updateShifts(wardId, dto);
             await queryClient.invalidateQueries({


### PR DESCRIPTION
<!-- title: [{ticket-id | -}] {title} -->

## Motivation

티켓 요약을 2~3줄로 작성해주세요.

- 티켓: [DUT-XXX](https://gom3.atlassian.net/browse/DUT-XXX)
- 배경:
- 목표:

<br>

## Key Changes

사용자 영향 기준으로 주요 변경사항을 작성해주세요.

- 예시: 사용자가 근무 스케줄을 저장할 때 실패 원인을 바로 확인할 수 있도록 에러 메시지 노출 방식을 변경했습니다.

<br>

## To Reviewers

- 특히 봐야 할 파일:
- 중점적으로 봐야 할 로직:
- 우려되는 지점 / 확인이 필요한 부분:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 고정 근무 편집 단계에서 변경 내용이 더 정확하게 반영되도록 개선했습니다.
  * 고정된 셀은 기존 근무 유형을 유지하고, 고정되지 않은 셀은 비어 있음으로 처리되도록 저장 방식이 바뀌었습니다.

* **버그 수정**
  * 고정 모드에서 고정되지 않은 셀을 지우거나 붙여넣을 때의 처리 오류를 수정했습니다.
  * 일부 셀 삭제/붙여넣기 동작이 히스토리와 실제 반영 결과에서 일치하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->