### PR TITLE
hotfix: update dutying.ai domains on develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ pnpm run changeset:version
 
 ## 링크
 
-- 랜딩 화면: [https://dutying.net](https://dutying.net)
-- 웹 앱: [https://app.dutying.net](https://app.dutying.net)
-- 가이드 문서 사이트: [https://docs.dutying.net](https://docs.dutying.net)
+- 랜딩 화면: [https://dutying.ai](https://dutying.ai)
+- 웹 앱: [https://app.dutying.ai](https://app.dutying.ai)
+- 가이드 문서 사이트: [https://docs.dutying.ai](https://docs.dutying.ai)
 - 모바일 앱 저장소: [gom-3/dutying-mobile](https://github.com/gom-3/dutying-mobile)
 - 이용 약관: [Notion](https://gom3.notion.site/5ed51c04dd5d475c868367ed05a7d903?pvs=4)
 - 라이선스: [Apache License 2.0](LICENSE)

--- a/apps/app/src/features/auth/model/__tests__/login-redirect.test.ts
+++ b/apps/app/src/features/auth/model/__tests__/login-redirect.test.ts
@@ -32,7 +32,7 @@ describe('getLoginRedirectDecision', () => {
     it('falls back to the default app route when nextPageUrl is missing', () => {
         vi.stubGlobal('window', {
             location: {
-                origin: 'https://app.dutying.net',
+                origin: 'https://app.dutying.ai',
             },
             history: {
                 back: vi.fn(),
@@ -48,14 +48,14 @@ describe('getLoginRedirectDecision', () => {
     it('keeps allowed app-domain subdomain redirects as in-app replace targets', () => {
         vi.stubGlobal('window', {
             location: {
-                origin: 'https://app.dutying.net',
+                origin: 'https://app.dutying.ai',
             },
             history: {
                 back: vi.fn(),
             },
         });
 
-        expect(getLoginRedirectDecision('https://app.dutying.net/request?month=3#calendar')).toEqual({
+        expect(getLoginRedirectDecision('https://app.dutying.ai/request?month=3#calendar')).toEqual({
             type: 'replace',
             href: '/request?month=3#calendar',
         });
@@ -64,14 +64,14 @@ describe('getLoginRedirectDecision', () => {
     it('falls back when nextPageUrl points to the landing domain after subdomain split', () => {
         vi.stubGlobal('window', {
             location: {
-                origin: 'https://app.dutying.net',
+                origin: 'https://app.dutying.ai',
             },
             history: {
                 back: vi.fn(),
             },
         });
 
-        expect(getLoginRedirectDecision('https://dutying.net/request?month=3')).toEqual({
+        expect(getLoginRedirectDecision('https://dutying.ai/request?month=3')).toEqual({
             type: 'replace',
             href: ROUTE.HOME,
         });

--- a/apps/app/src/pages/login/__tests__/index.test.tsx
+++ b/apps/app/src/pages/login/__tests__/index.test.tsx
@@ -64,8 +64,8 @@ describe('LoginPage', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.net');
-        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.net');
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.ai');
+        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.ai');
     });
 
     it('renders sign-in as the default admin login page with a signup entry', () => {
@@ -87,11 +87,11 @@ describe('LoginPage', () => {
         expect(screen.getByRole('link', {name: '회원가입'})).toHaveAttribute('href', ROUTE.SIGN_UP);
         expect(screen.getByRole('link', {name: '카카오로 계속하기'})).toHaveAttribute(
             'href',
-            'https://api.dutying.net/oauth2/authorization/admin/kakao?nextPageUrl=https%3A%2F%2Fapp.dutying.net%2Fhome',
+            'https://api.dutying.ai/oauth2/authorization/admin/kakao?nextPageUrl=https%3A%2F%2Fapp.dutying.ai%2Fhome',
         );
         expect(screen.getByRole('link', {name: 'Apple로 계속하기'})).toHaveAttribute(
             'href',
-            'https://api.dutying.net/oauth2/authorization/admin/apple?nextPageUrl=https%3A%2F%2Fapp.dutying.net%2Fhome',
+            'https://api.dutying.ai/oauth2/authorization/admin/apple?nextPageUrl=https%3A%2F%2Fapp.dutying.ai%2Fhome',
         );
     });
 
@@ -167,7 +167,7 @@ describe('LoginPage', () => {
         expect(screen.getByRole('link', {name: '로그인'})).toHaveAttribute('href', ROUTE.SIGN_IN);
         expect(screen.getByRole('link', {name: '카카오로 시작하기'})).toHaveAttribute(
             'href',
-            'https://api.dutying.net/oauth2/authorization/admin/kakao?nextPageUrl=https%3A%2F%2Fapp.dutying.net%2Fregister%3FsocialSignup%3D1',
+            'https://api.dutying.ai/oauth2/authorization/admin/kakao?nextPageUrl=https%3A%2F%2Fapp.dutying.ai%2Fregister%3FsocialSignup%3D1',
         );
     });
 

--- a/apps/app/src/pages/login/__tests__/redirect-page.test.tsx
+++ b/apps/app/src/pages/login/__tests__/redirect-page.test.tsx
@@ -52,7 +52,7 @@ describe('RedirectPage', () => {
             },
         } as never);
 
-        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.net');
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.ai');
         window.history.replaceState({}, '', '/oauth2/redirect');
     });
 
@@ -74,7 +74,7 @@ describe('RedirectPage', () => {
         window.history.replaceState(
             {},
             '',
-            `/oauth2/redirect?accessToken=${adminToken}&nextPageUrl=https%3A%2F%2Fdutying.net%2Frequest%3Fmonth%3D3`,
+            `/oauth2/redirect?accessToken=${adminToken}&nextPageUrl=https%3A%2F%2Fdutying.ai%2Frequest%3Fmonth%3D3`,
         );
 
         render(<RedirectPage />);
@@ -90,7 +90,7 @@ describe('RedirectPage', () => {
         window.history.replaceState(
             {},
             '',
-            `/oauth2/redirect?accessToken=${adminToken}&nextPageUrl=https%3A%2F%2Fapp.dutying.net%2Frequest%3Fmonth%3D3%23calendar`,
+            `/oauth2/redirect?accessToken=${adminToken}&nextPageUrl=https%3A%2F%2Fapp.dutying.ai%2Frequest%3Fmonth%3D3%23calendar`,
         );
 
         render(<RedirectPage />);
@@ -220,7 +220,7 @@ describe('RedirectPage', () => {
     });
 
     it('uses the refresh cookie flow when the callback only includes an app-domain nextPageUrl', async () => {
-        window.history.replaceState({}, '', '/oauth2/redirect?nextPageUrl=https%3A%2F%2Fapp.dutying.net%2F');
+        window.history.replaceState({}, '', '/oauth2/redirect?nextPageUrl=https%3A%2F%2Fapp.dutying.ai%2F');
 
         const replace = mockLocationReplace();
 

--- a/apps/app/src/shared/api/__tests__/client.test.ts
+++ b/apps/app/src/shared/api/__tests__/client.test.ts
@@ -16,6 +16,6 @@ describe('api client unauthorized redirect policy', () => {
 
     it('redirects protected api failures to the refresh route', () => {
         expect(shouldRedirectToRefreshOnUnauthorized('/accounts/me', ROUTE.MAKE)).toBe(true);
-        expect(shouldRedirectToRefreshOnUnauthorized('https://api.dutying.net/wards/1/nurses', ROUTE.MEMBER)).toBe(true);
+        expect(shouldRedirectToRefreshOnUnauthorized('https://api.dutying.ai/wards/1/nurses', ROUTE.MEMBER)).toBe(true);
     });
 });

--- a/apps/app/src/shared/config/__tests__/feature-flags.test.ts
+++ b/apps/app/src/shared/config/__tests__/feature-flags.test.ts
@@ -3,10 +3,12 @@ import {isNonProductionAppDomain, isOnboardingWardCreatePreviewAllowed, isWardCh
 
 describe('isNonProductionAppDomain', () => {
     it('treats production app host as production', () => {
+        expect(isNonProductionAppDomain('app.dutying.ai')).toBe(false);
         expect(isNonProductionAppDomain('app.dutying.net')).toBe(false);
     });
 
     it('treats dev and preview hosts as non-production', () => {
+        expect(isNonProductionAppDomain('dev.dutying.ai')).toBe(true);
         expect(isNonProductionAppDomain('dev.dutying.net')).toBe(true);
         expect(isNonProductionAppDomain('local.app.dutying.net')).toBe(true);
         expect(isNonProductionAppDomain('dutying-app-git-feat.vercel.app')).toBe(true);
@@ -17,7 +19,7 @@ describe('isNonProductionAppDomain', () => {
 describe('isOnboardingWardCreatePreviewAllowed', () => {
     beforeEach(() => {
         vi.stubEnv('VITE_ALLOW_ONBOARDING_PREVIEW', '');
-        vi.stubGlobal('window', {location: {hostname: 'app.dutying.net'}});
+        vi.stubGlobal('window', {location: {hostname: 'app.dutying.ai'}});
     });
 
     afterEach(() => {
@@ -30,7 +32,7 @@ describe('isOnboardingWardCreatePreviewAllowed', () => {
     });
 
     it('allows preview on dev app domain', () => {
-        vi.stubGlobal('window', {location: {hostname: 'dev.dutying.net'}});
+        vi.stubGlobal('window', {location: {hostname: 'dev.dutying.ai'}});
 
         expect(isOnboardingWardCreatePreviewAllowed()).toBe(true);
     });
@@ -44,7 +46,7 @@ describe('isOnboardingWardCreatePreviewAllowed', () => {
     });
 
     it('respects VITE_ALLOW_ONBOARDING_PREVIEW=false override', () => {
-        vi.stubGlobal('window', {location: {hostname: 'dev.dutying.net'}});
+        vi.stubGlobal('window', {location: {hostname: 'dev.dutying.ai'}});
         vi.stubEnv('VITE_ALLOW_ONBOARDING_PREVIEW', 'false');
 
         expect(isOnboardingWardCreatePreviewAllowed()).toBe(false);
@@ -68,19 +70,19 @@ describe('isWardChatEnabled', () => {
     });
 
     it('disables ward chat against production API while it lacks chat routes', () => {
-        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.net');
+        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.ai');
 
         expect(isWardChatEnabled()).toBe(false);
     });
 
     it('allows ward chat against dev API', () => {
-        vi.stubEnv('VITE_SERVER_URL', 'https://dev.api.dutying.net');
+        vi.stubEnv('VITE_SERVER_URL', 'https://dev.api.dutying.ai');
 
         expect(isWardChatEnabled()).toBe(true);
     });
 
     it('respects explicit override', () => {
-        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.net');
+        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.ai');
         vi.stubEnv('VITE_ENABLE_WARD_CHAT', 'true');
 
         expect(isWardChatEnabled()).toBe(true);

--- a/apps/app/src/shared/config/__tests__/runtime.test.ts
+++ b/apps/app/src/shared/config/__tests__/runtime.test.ts
@@ -16,17 +16,17 @@ describe('resolveSafeRedirectTarget', () => {
     it('accepts same-origin absolute redirect and converts it to app-relative path', () => {
         vi.stubGlobal('window', {
             location: {
-                origin: 'https://app.dutying.net',
+                origin: 'https://app.dutying.ai',
             },
         });
 
-        expect(resolveSafeRedirectTarget('https://app.dutying.net/request?month=3#header')).toBe('/request?month=3#header');
+        expect(resolveSafeRedirectTarget('https://app.dutying.ai/request?month=3#header')).toBe('/request?month=3#header');
     });
 
     it('rejects cross-origin redirects', () => {
         vi.stubGlobal('window', {
             location: {
-                origin: 'https://app.dutying.net',
+                origin: 'https://app.dutying.ai',
             },
         });
 
@@ -34,14 +34,14 @@ describe('resolveSafeRedirectTarget', () => {
     });
 
     it('accepts redirects that match the configured public app origin in local development', () => {
-        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.net');
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.ai');
         vi.stubGlobal('window', {
             location: {
                 origin: 'https://local.app.dutying.net:3000',
             },
         });
 
-        expect(resolveSafeRedirectTarget('https://app.dutying.net/login?next=%2Fmake#cta')).toBe('/login?next=%2Fmake#cta');
+        expect(resolveSafeRedirectTarget('https://app.dutying.ai/login?next=%2Fmake#cta')).toBe('/login?next=%2Fmake#cta');
     });
 
     it('rejects protocol-relative redirect targets', () => {
@@ -51,32 +51,32 @@ describe('resolveSafeRedirectTarget', () => {
     it('rejects same-origin redirects whose normalized path becomes protocol-relative', () => {
         vi.stubGlobal('window', {
             location: {
-                origin: 'https://app.dutying.net',
+                origin: 'https://app.dutying.ai',
             },
         });
 
-        expect(resolveSafeRedirectTarget('https://app.dutying.net//evil.example')).toBe(ROUTE.HOME);
-        expect(resolveSafeRedirectTarget('https://app.dutying.net/\\evil.example')).toBe(ROUTE.HOME);
+        expect(resolveSafeRedirectTarget('https://app.dutying.ai//evil.example')).toBe(ROUTE.HOME);
+        expect(resolveSafeRedirectTarget('https://app.dutying.ai/\\evil.example')).toBe(ROUTE.HOME);
     });
 
     it('rejects landing-domain redirects after domain split', () => {
         vi.stubGlobal('window', {
             location: {
-                origin: 'https://app.dutying.net',
+                origin: 'https://app.dutying.ai',
             },
         });
 
-        expect(resolveSafeRedirectTarget('https://dutying.net/request')).toBe(ROUTE.HOME);
+        expect(resolveSafeRedirectTarget('https://dutying.ai/request')).toBe(ROUTE.HOME);
     });
 
     it('rejects docs-domain redirects after domain split', () => {
         vi.stubGlobal('window', {
             location: {
-                origin: 'https://app.dutying.net',
+                origin: 'https://app.dutying.ai',
             },
         });
 
-        expect(resolveSafeRedirectTarget('https://docs.dutying.net/request')).toBe(ROUTE.HOME);
+        expect(resolveSafeRedirectTarget('https://docs.dutying.ai/request')).toBe(ROUTE.HOME);
     });
 
     it('rejects slash-backslash redirect targets', () => {
@@ -86,32 +86,32 @@ describe('resolveSafeRedirectTarget', () => {
 
 describe('buildAppUrl', () => {
     it('uses the configured public app url and strips trailing slashes', () => {
-        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://staging.app.dutying.net///');
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://staging.app.dutying.ai///');
 
-        expect(buildAppUrl('/member')).toBe('https://staging.app.dutying.net/member');
+        expect(buildAppUrl('/member')).toBe('https://staging.app.dutying.ai/member');
     });
 });
 
 describe('buildAuthAuthorizeUrl', () => {
     it('sanitizes invalid nextPath before building auth url', () => {
-        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.net');
-        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.net');
+        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.ai');
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.ai');
 
         const url = new URL(buildAuthAuthorizeUrl('kakao', 'https://evil.example/phish'));
 
-        expect(url.origin).toBe('https://api.dutying.net');
+        expect(url.origin).toBe('https://api.dutying.ai');
         expect(url.pathname).toBe('/oauth2/authorization/admin/kakao');
-        expect(url.searchParams.get('nextPageUrl')).toBe('https://app.dutying.net/home');
+        expect(url.searchParams.get('nextPageUrl')).toBe('https://app.dutying.ai/home');
     });
 
     it('uses the default server origin when VITE_SERVER_URL is blank', () => {
         vi.stubEnv('VITE_SERVER_URL', '   ');
-        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.net');
+        vi.stubEnv('VITE_APP_PUBLIC_URL', 'https://app.dutying.ai');
 
         const url = new URL(buildAuthAuthorizeUrl('apple', ROUTE.REQUEST));
 
-        expect(url.origin).toBe('https://api.dutying.net');
+        expect(url.origin).toBe('https://api.dutying.ai');
         expect(url.pathname).toBe('/oauth2/authorization/admin/apple');
-        expect(url.searchParams.get('nextPageUrl')).toBe('https://app.dutying.net/request');
+        expect(url.searchParams.get('nextPageUrl')).toBe('https://app.dutying.ai/request');
     });
 });

--- a/apps/app/src/shared/config/feature-flags.ts
+++ b/apps/app/src/shared/config/feature-flags.ts
@@ -1,8 +1,8 @@
 import {RUNTIME_CONFIG} from './runtime';
 
 /** 프로덕션 앱 도메인 — 여기서는 LINKED 계정 온보딩 미리보기 불가 */
-const PRODUCTION_APP_HOSTS = new Set(['app.dutying.net']);
-const PRODUCTION_API_HOSTS_WITHOUT_WARD_CHAT = new Set(['api.dutying.net']);
+const PRODUCTION_APP_HOSTS = new Set(['app.dutying.ai', 'app.dutying.net']);
+const PRODUCTION_API_HOSTS_WITHOUT_WARD_CHAT = new Set(['api.dutying.ai', 'api.dutying.net']);
 
 function getAppHostname(): string | null {
     if (typeof window === 'undefined') return null;
@@ -27,7 +27,7 @@ export function isNonProductionAppDomain(hostname: string = getAppHostname() ?? 
 
     if (hostname.startsWith('local.')) return true;
 
-    if (hostname === 'dev.dutying.net') return true;
+    if (hostname === 'dev.dutying.ai' || hostname === 'dev.dutying.net') return true;
 
     if (hostname.startsWith('staging.')) return true;
 
@@ -38,7 +38,7 @@ export function isNonProductionAppDomain(hostname: string = getAppHostname() ?? 
  * 온보딩 병동 생성 UI를 WARD_SELECT_PENDING이 아닌 계정(LINKED 등)에서도 열 수 있게 한다.
  *
  * - 로컬 dev server: `import.meta.env.DEV`
- * - 그 외: **접속 도메인**이 프로덕션(`app.dutying.net`)이 아니면 허용
+ * - 그 외: **접속 도메인**이 프로덕션(`app.dutying.ai`, `app.dutying.net`)이 아니면 허용
  * - 명시 override: `VITE_ALLOW_ONBOARDING_PREVIEW=true|false`
  */
 export function isOnboardingWardCreatePreviewAllowed(): boolean {

--- a/apps/app/src/shared/config/runtime.ts
+++ b/apps/app/src/shared/config/runtime.ts
@@ -16,10 +16,10 @@ const getRuntimeUrl = (envValue: string | undefined, fallback: string) => {
     return trimTrailingSlash(normalized ?? fallback);
 };
 const INTERNAL_PATH_PATTERN = /^\/(?![\\/])/;
-export const DEFAULT_SERVER_URL = 'https://api.dutying.net';
+export const DEFAULT_SERVER_URL = 'https://api.dutying.ai';
 
 export const RUNTIME_CONFIG = {
-    publicAppUrl: () => getRuntimeUrl(import.meta.env.VITE_APP_PUBLIC_URL, getWindowOrigin() ?? 'https://app.dutying.net'),
+    publicAppUrl: () => getRuntimeUrl(import.meta.env.VITE_APP_PUBLIC_URL, getWindowOrigin() ?? 'https://app.dutying.ai'),
     serverUrl: () => getRuntimeUrl(import.meta.env.VITE_SERVER_URL, DEFAULT_SERVER_URL),
     profileImageBaseUrl: () =>
         getRuntimeUrl(import.meta.env.VITE_PUBLIC_S3_BASE_URL, 'https://dutying-prod.s3.ap-northeast-2.amazonaws.com'),

--- a/apps/app/src/widgets/ward-chat/__tests__/index.test.tsx
+++ b/apps/app/src/widgets/ward-chat/__tests__/index.test.tsx
@@ -81,7 +81,7 @@ describe('WardChatWidget', () => {
         authStateMock.isDemoExpired = false;
         authStateMock.wardId = 1;
         vi.stubEnv('VITE_ENABLE_WARD_CHAT', '');
-        vi.stubEnv('VITE_SERVER_URL', 'https://dev.api.dutying.net');
+        vi.stubEnv('VITE_SERVER_URL', 'https://dev.api.dutying.ai');
         vi.stubGlobal(
             'fetch',
             vi.fn(() => pendingFetch()),
@@ -182,7 +182,7 @@ describe('WardChatWidget', () => {
             expect(document.querySelector('img[src="https://cdn.example.com/profile/other-nurse.png"]')).toBeInTheDocument(),
         );
         expect(fetchMock).toHaveBeenCalledWith(
-            'https://dev.api.dutying.net/events/stream',
+            'https://dev.api.dutying.ai/events/stream',
             expect.objectContaining({
                 headers: expect.objectContaining({
                     Accept: 'text/event-stream',
@@ -438,7 +438,7 @@ describe('WardChatWidget', () => {
     });
 
     it('does not call ward chat APIs on production API while the routes are unavailable', () => {
-        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.net');
+        vi.stubEnv('VITE_SERVER_URL', 'https://api.dutying.ai');
 
         renderWithQueryClient(<WardChatWidget />);
 

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -47,8 +47,8 @@ const dependencies = {
     zustand: 'zustand',
 };
 const workspaceRoot = fileURLToPath(new URL('../..', import.meta.url));
-const defaultAppSiteUrl = 'https://app.dutying.net';
-const defaultPreviewAppSiteUrl = 'https://dev.dutying.net';
+const defaultAppSiteUrl = 'https://app.dutying.ai';
+const defaultPreviewAppSiteUrl = 'https://dev.dutying.ai';
 const stripTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 const withHttpsProtocol = (value: string) => (/^https?:\/\//.test(value) ? value : `https://${value}`);
 const getConfiguredAppSiteUrl = (env: Record<string, string>) => {

--- a/apps/docs/.vitepress/site.mts
+++ b/apps/docs/.vitepress/site.mts
@@ -2,9 +2,9 @@ import fs from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import path from 'node:path';
 
-const DEFAULT_MARKETING_SITE_URL = 'https://dutying.net';
-const DEFAULT_APP_SITE_URL = 'https://app.dutying.net';
-const DEFAULT_DOCS_SITE_URL = 'https://docs.dutying.net';
+const DEFAULT_MARKETING_SITE_URL = 'https://dutying.ai';
+const DEFAULT_APP_SITE_URL = 'https://app.dutying.ai';
+const DEFAULT_DOCS_SITE_URL = 'https://docs.dutying.ai';
 
 const stripTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 const workspaceRoot = fileURLToPath(new URL('../../..', import.meta.url));

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -4,7 +4,7 @@ import {loadRootEnv} from '../../packages/config/load-root-env.mjs';
 const env = loadRootEnv(process.cwd());
 
 export default defineConfig({
-    site: env.PUBLIC_MARKETING_SITE_URL ?? 'https://dutying.net',
+    site: env.PUBLIC_MARKETING_SITE_URL ?? 'https://dutying.ai',
     build: {
         format: 'directory',
     },

--- a/apps/landing/src/config/__tests__/site.test.ts
+++ b/apps/landing/src/config/__tests__/site.test.ts
@@ -5,36 +5,36 @@ describe('createSiteConfig', () => {
     it('falls back to the production dutying domains', () => {
         const config = createSiteConfig({});
 
-        expect(config.marketingOrigin).toBe('https://dutying.net');
-        expect(config.appOrigin).toBe('https://app.dutying.net');
-        expect(config.docsOrigin).toBe('https://docs.dutying.net');
+        expect(config.marketingOrigin).toBe('https://dutying.ai');
+        expect(config.appOrigin).toBe('https://app.dutying.ai');
+        expect(config.docsOrigin).toBe('https://docs.dutying.ai');
         expect(config.legal.terms).toBe('https://gom3.notion.site/5ed51c04dd5d475c868367ed05a7d903?pvs=4');
         expect(config.legal.privacyPolicy).toBe('https://www.notion.so/35c98c0fae25805cb6d5e2ce5f591f42?source=copy_link');
         expect(config.appLinks).toEqual({
-            home: 'https://app.dutying.net',
-            login: 'https://app.dutying.net/login',
-            signup: 'https://app.dutying.net/signup',
-            makeEntry: 'https://app.dutying.net/login?next=%2Fmake',
-            make: 'https://app.dutying.net/make',
-            register: 'https://app.dutying.net/register',
+            home: 'https://app.dutying.ai',
+            login: 'https://app.dutying.ai/login',
+            signup: 'https://app.dutying.ai/signup',
+            makeEntry: 'https://app.dutying.ai/login?next=%2Fmake',
+            make: 'https://app.dutying.ai/make',
+            register: 'https://app.dutying.ai/register',
         });
     });
 
     it('trims trailing slashes from overridden origins before composing links', () => {
         const config = createSiteConfig({
-            PUBLIC_MARKETING_SITE_URL: 'https://preview.dutying.net///',
-            PUBLIC_APP_SITE_URL: 'https://preview.app.dutying.net//',
-            PUBLIC_DOCS_SITE_URL: 'https://preview.docs.dutying.net//',
+            PUBLIC_MARKETING_SITE_URL: 'https://preview.dutying.ai///',
+            PUBLIC_APP_SITE_URL: 'https://preview.app.dutying.ai//',
+            PUBLIC_DOCS_SITE_URL: 'https://preview.docs.dutying.ai//',
             PUBLIC_TERMS_URL: 'https://example.com/terms',
             PUBLIC_PRIVACY_POLICY_URL: 'https://example.com/privacy',
         });
 
-        expect(config.marketingOrigin).toBe('https://preview.dutying.net');
-        expect(config.docsLinks.home).toBe('https://preview.docs.dutying.net');
+        expect(config.marketingOrigin).toBe('https://preview.dutying.ai');
+        expect(config.docsLinks.home).toBe('https://preview.docs.dutying.ai');
         expect(config.legal.terms).toBe('https://example.com/terms');
         expect(config.legal.privacyPolicy).toBe('https://example.com/privacy');
-        expect(config.appLinks.login).toBe('https://preview.app.dutying.net/login');
-        expect(config.appLinks.makeEntry).toBe('https://preview.app.dutying.net/login?next=%2Fmake');
+        expect(config.appLinks.login).toBe('https://preview.app.dutying.ai/login');
+        expect(config.appLinks.makeEntry).toBe('https://preview.app.dutying.ai/login?next=%2Fmake');
     });
 
     it('falls back safely when env overrides are blank strings', () => {
@@ -43,9 +43,9 @@ describe('createSiteConfig', () => {
             PUBLIC_APP_SITE_URL: '',
         });
 
-        expect(config.marketingOrigin).toBe('https://dutying.net');
-        expect(config.appOrigin).toBe('https://app.dutying.net');
-        expect(config.appLinks.login).toBe('https://app.dutying.net/login');
+        expect(config.marketingOrigin).toBe('https://dutying.ai');
+        expect(config.appOrigin).toBe('https://app.dutying.ai');
+        expect(config.appLinks.login).toBe('https://app.dutying.ai/login');
     });
 });
 
@@ -53,13 +53,13 @@ describe('createLandingPrimaryCtas', () => {
     it('keeps the web CTA entrypoints pinned to the app login and make routes', () => {
         const ctas = createLandingPrimaryCtas(
             createSiteConfig({
-                PUBLIC_APP_SITE_URL: 'https://staging.app.dutying.net/',
+                PUBLIC_APP_SITE_URL: 'https://staging.app.dutying.ai/',
             }),
         );
 
         expect(ctas).toEqual([
-            {label: '근무표 작성 체험하기', href: 'https://staging.app.dutying.net/login?next=%2Fmake'},
-            {label: '근무표 만들기', href: 'https://staging.app.dutying.net/make'},
+            {label: '근무표 작성 체험하기', href: 'https://staging.app.dutying.ai/login?next=%2Fmake'},
+            {label: '근무표 만들기', href: 'https://staging.app.dutying.ai/make'},
         ]);
     });
 });

--- a/apps/landing/src/config/site.ts
+++ b/apps/landing/src/config/site.ts
@@ -26,9 +26,9 @@ const readSiteEnv = (): SiteEnv => ({
 });
 
 export const createSiteConfig = (env: SiteEnv = readSiteEnv()) => {
-    const marketingOrigin = getRuntimeOrigin(env.PUBLIC_MARKETING_SITE_URL, 'https://dutying.net');
-    const appOrigin = getRuntimeOrigin(env.PUBLIC_APP_SITE_URL, 'https://app.dutying.net');
-    const docsOrigin = getRuntimeOrigin(env.PUBLIC_DOCS_SITE_URL, 'https://docs.dutying.net');
+    const marketingOrigin = getRuntimeOrigin(env.PUBLIC_MARKETING_SITE_URL, 'https://dutying.ai');
+    const appOrigin = getRuntimeOrigin(env.PUBLIC_APP_SITE_URL, 'https://app.dutying.ai');
+    const docsOrigin = getRuntimeOrigin(env.PUBLIC_DOCS_SITE_URL, 'https://docs.dutying.ai');
     const termsUrl = env.PUBLIC_TERMS_URL ?? 'https://gom3.notion.site/5ed51c04dd5d475c868367ed05a7d903?pvs=4';
     const privacyPolicyUrl = env.PUBLIC_PRIVACY_POLICY_URL ?? 'https://www.notion.so/35c98c0fae25805cb6d5e2ce5f591f42?source=copy_link';
 

--- a/docs/architecture/desktop-tauri-readiness.md
+++ b/docs/architecture/desktop-tauri-readiness.md
@@ -17,7 +17,7 @@
 ### 1. 인증과 redirect
 
 - 로그인 시작점이 `${VITE_SERVER_URL}/oauth2/authorization/*?nextPageUrl=${appOrigin}/make` 형식이라, 현재는 브라우저 origin이 곧 복귀 주소라는 가정이 있다.
-- `RedirectPage`는 querystring의 `accessToken`, `nextPageUrl`을 바로 읽는다. Tauri에서는 `https://app.dutying.net`, `tauri://localhost`, custom scheme, loopback URL 중 무엇을 복귀 주소로 쓸지 먼저 정해야 한다.
+- `RedirectPage`는 querystring의 `accessToken`, `nextPageUrl`을 바로 읽는다. Tauri에서는 `https://app.dutying.ai`, `tauri://localhost`, custom scheme, loopback URL 중 무엇을 복귀 주소로 쓸지 먼저 정해야 한다.
 - refresh는 `withCredentials: true` 쿠키 기반이며 401 발생 시 `/refresh?next=...`로 강제 이동한다. desktop에서 webview cookie jar가 서버의 `SameSite`, `Secure`, domain 정책과 호환되는지 점검이 필요하다.
 - 이번 변경으로 로그인 시작 URL은 `VITE_APP_PUBLIC_URL` 우선, 브라우저 origin fallback 방식으로 정리했다. desktop에서는 이 값을 명시적으로 주입하는 쪽이 안전하다.
 
@@ -33,7 +33,7 @@
 
 ### 3. 도메인/환경 변수 하드코딩
 
-- 앱 내부에 `app.dutying.net`, Notion 문서 URL, S3 bucket base URL이 직접 박혀 있었다.
+- 앱 내부에 `app.dutying.ai`, Notion 문서 URL, S3 bucket base URL이 직접 박혀 있었다.
 - 이 값들은 desktop 전용 배포 채널, staging, custom scheme 실험 시 매번 코드 수정 포인트가 된다.
 - `VITE_APP_PUBLIC_URL`, `VITE_PUBLIC_S3_BASE_URL`, 문서 URL env를 두고 런타임 구성으로 노출하는 편이 안전하다.
 

--- a/docs/auth-security-backend-requirements.md
+++ b/docs/auth-security-backend-requirements.md
@@ -11,10 +11,10 @@
 - OAuth `state` 값으로 CSRF 방지와 `nextPageUrl` 무결성 검증
 - `nextPageUrl`은 서버에서도 app origin allow-list 검증
 - OAuth 콜백/`nextPageUrl`은 환경별 프론트 도메인을 유지
-  - production: `https://app.dutying.net/oauth2/redirect`, `nextPageUrl=https://app.dutying.net/...`
-  - dev: `https://dev.dutying.net/oauth2/redirect`, `nextPageUrl=https://dev.dutying.net/...`
+  - production: `https://app.dutying.ai/oauth2/redirect`, `nextPageUrl=https://app.dutying.ai/...`
+  - dev: `https://dev.dutying.ai/oauth2/redirect`, `nextPageUrl=https://dev.dutying.ai/...`
   - local 필요 시: `https://local.app.dutying.net:3000/oauth2/redirect`
-  - dev 로그인 요청이 production `app.dutying.net`으로 돌아가면 안 됩니다.
+  - dev 로그인 요청이 production `app.dutying.ai`으로 돌아가면 안 됩니다.
 
 ## 2. Refresh/Logout 토큰 정책
 
@@ -42,8 +42,8 @@
 ## 5. 운영 보안 헤더/CORS
 
 - API CORS origin allow-list를 환경별 필요한 프론트 도메인으로 제한
-  - production: `https://app.dutying.net`
-  - dev: `https://dev.dutying.net`
+  - production: `https://app.dutying.ai`
+  - dev: `https://dev.dutying.ai`
   - local 필요 시: `https://local.app.dutying.net:3000`
 - credential 요청 허용 시 wildcard origin 금지
 - CSP는 프론트 SDK 목록을 확정한 뒤 배포 환경에서 적용

--- a/docs/landing-app-split.md
+++ b/docs/landing-app-split.md
@@ -2,19 +2,19 @@
 
 ## Decision
 
-- `apps/landing` is a dedicated Astro app for `dutying.net`.
-- `apps/app` remains the product app that will be served from `app.dutying.net`.
+- `apps/landing` is a dedicated Astro app for `dutying.ai`.
+- `apps/app` remains the product app that will be served from `app.dutying.ai`.
 - This ticket establishes the split-ready baseline, not the final landing content or the full authentication migration.
 
 ## Responsibility Boundary
 
-### `dutying.net` landing
+### `dutying.ai` landing
 
 - product positioning, marketing copy, SEO, OG metadata
 - feature overview and trust-building content
 - CTA links that send users into the product app
 
-### `app.dutying.net` app
+### `app.dutying.ai` app
 
 - login and OAuth callback flow
 - authenticated product routes
@@ -22,9 +22,9 @@
 
 ## Landing Entry Flow
 
-- Primary CTA: `https://app.dutying.net/login`
-- Secondary CTA: `https://app.dutying.net/make`
-- Additional path: `https://app.dutying.net/register`
+- Primary CTA: `https://app.dutying.ai/login`
+- Secondary CTA: `https://app.dutying.ai/make`
+- Additional path: `https://app.dutying.ai/register`
 
 These URLs are exposed in `apps/landing/src/config/site.ts` and can be overridden with:
 
@@ -45,7 +45,7 @@ The app itself uses matching Vite env keys:
 ### 1. Root route responsibility is still mixed
 
 - `apps/app/src/app/Router.tsx` still serves `LandingPage` on `/`.
-- Once `app.dutying.net` becomes the product-only domain, `/` should stop acting as the public marketing landing.
+- Once `app.dutying.ai` becomes the product-only domain, `/` should stop acting as the public marketing landing.
 - Follow-up options:
     - redirect `/` to `/login` or `/make`
     - or keep `/` as a signed-in gateway page explicitly designed for the app domain
@@ -56,7 +56,7 @@ The app itself uses matching Vite env keys:
 - `apps/app/public/robots.txt`
 - `apps/app/public/sitemap.xml`
 
-These are now updated toward `app.dutying.net`, but the real deployment sitemap strategy still needs a final decision once both domains ship.
+These are now updated toward `app.dutying.ai`, but the real deployment sitemap strategy still needs a final decision once both domains ship.
 
 ### 3. OAuth redirect should stay app-domain only
 
@@ -66,12 +66,12 @@ These are now updated toward `app.dutying.net`, but the real deployment sitemap 
 - `apps/app/src/shared/api/client.ts`
 - `apps/app/src/pages/refresh/index.tsx`
 
-The app should build OAuth entry URLs from an explicit app-site setting and normalize callback targets back into app-relative paths. That keeps login, refresh, and callback flows inside `app.dutying.net` even after domain separation.
+The app should build OAuth entry URLs from an explicit app-site setting and normalize callback targets back into app-relative paths. That keeps login, refresh, and callback flows inside `app.dutying.ai` even after domain separation.
 
 Checkpoints:
 
-- backend OAuth allow-list must include `https://app.dutying.net/oauth2/redirect`
-- refresh redirect flow must never bounce users back to `dutying.net`
+- backend OAuth allow-list must include `https://app.dutying.ai/oauth2/redirect`
+- refresh redirect flow must never bounce users back to `dutying.ai`
 - post-login default route should remain product-focused
 
 ### 4. Auth state is not purely cookie-based


### PR DESCRIPTION
## Summary
- Switch web, landing, docs, robots/sitemap-related defaults, and OAuth URL tests to `dutying.ai` domains.
- Keep `.net` recognized as production during the migration window where needed.
- Update current domain architecture docs and README links.

## Tests
- `pnpm --dir ./apps/app test:run src/shared/config/__tests__/runtime.test.ts src/shared/config/__tests__/feature-flags.test.ts src/pages/login/__tests__/index.test.tsx src/pages/login/__tests__/redirect-page.test.tsx src/features/auth/model/__tests__/login-redirect.test.ts src/shared/api/__tests__/client.test.ts src/widgets/ward-chat/__tests__/index.test.tsx`
- `pnpm exec vitest run apps/landing/src/config/__tests__/site.test.ts`

## Risks / Notes
- First test run was delayed by dependency installation timeout; rerun passed after install completed.
- FE rollout still depends on Route 53, TLS, and OAuth provider console updates being in place.